### PR TITLE
Adds section with developer options.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /build/
 /.gradle/
 /gradle.properties
+/out/*

--- a/src/main/kotlin/spock/AdbDrawerViewer.kt
+++ b/src/main/kotlin/spock/AdbDrawerViewer.kt
@@ -1,4 +1,5 @@
 package spock
+
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowFactory
@@ -9,10 +10,18 @@ import spock.adb.SpockAdbViewer
 
 class AdbDrawerViewer : ToolWindowFactory {
 
+    private var spockAdbViewer: SpockAdbViewer? = null
+
     override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
-    val adbController:AdbController = AdbControllerImp(project, AndroidSdkUtils.getDebugBridge(project))
+        val adbController: AdbController = AdbControllerImp(project, AndroidSdkUtils.getDebugBridge(project))
         val contentManager = toolWindow.contentManager
-            val content = contentManager.factory.createContent(SpockAdbViewer(adbController,project), null, false)
-            contentManager.addContent(content)
+
+        if (spockAdbViewer == null) {
+            spockAdbViewer = SpockAdbViewer(project)
+            spockAdbViewer?.initPlugin(adbController)
+        }
+
+        val content = contentManager.factory.createContent(spockAdbViewer, null, false)
+        contentManager.addContent(content)
     }
 }

--- a/src/main/kotlin/spock/adb/AdbController.kt
+++ b/src/main/kotlin/spock/adb/AdbController.kt
@@ -16,5 +16,10 @@ interface AdbController {
     fun revokePermission(device: IDevice, permissionListItem: PermissionListItem, success:(message:String)->Unit, error:(message:String)->Unit)
     fun grantPermission(device: IDevice, permissionListItem: PermissionListItem, success:(message:String)->Unit, error:(message:String)->Unit)
     fun connectDeviceOverIp(ip:String, success:(message:String)->Unit, error:(message:String)->Unit)
-
+    fun enableDisableDontKeepActivities(device: IDevice,success:(message:String)->Unit,error:(message:String)->Unit)
+    fun enableDisableShowTaps(device: IDevice,success:(message:String)->Unit,error:(message:String)->Unit)
+    fun enableDisableShowLayoutBounds(device: IDevice,success:(message:String)->Unit,error:(message:String)->Unit)
+    fun setWindowAnimatorScale(scale: String, device: IDevice,success:(message:String)->Unit,error:(message:String)->Unit)
+    fun setTransitionAnimatorScale(scale: String, device: IDevice,success:(message:String)->Unit,error:(message:String)->Unit)
+    fun setAnimatorDurationScale(scale: String, device: IDevice,success:(message:String)->Unit,error:(message:String)->Unit)
 }

--- a/src/main/kotlin/spock/adb/AdbControllerImp.kt
+++ b/src/main/kotlin/spock/adb/AdbControllerImp.kt
@@ -1,14 +1,11 @@
 package spock.adb
 
 import com.android.ddmlib.AndroidDebugBridge
-import com.android.ddmlib.Client
 import com.android.ddmlib.IDevice
-import com.intellij.ide.util.PropertiesComponent
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.popup.PopupChooserBuilder
 import com.intellij.psi.PsiClass
 import com.intellij.ui.components.JBList
-import org.jetbrains.android.sdk.AndroidSdkUtils
 
 import spock.adb.command.*
 import spock.adb.premission.PermissionListItem
@@ -22,7 +19,6 @@ class AdbControllerImp(
 
     init {
         AndroidDebugBridge.addDeviceChangeListener(this)
-
     }
 
     private fun getApplicationID(device: IDevice) =
@@ -31,9 +27,8 @@ class AdbControllerImp(
     override fun refresh() {
         AndroidDebugBridge.removeDeviceChangeListener(this)
         AndroidDebugBridge.addDeviceChangeListener(this)
-
-
     }
+
     override fun connectedDevices(block: (devices: List<IDevice>) -> Unit, error: (message: String) -> Unit) {
         updateDeviceList = block
         updateDeviceList?.invoke(debugBridge?.devices?.toList() ?: listOf())
@@ -61,7 +56,6 @@ class AdbControllerImp(
         val list = JBList(activitiesClass.mapIndexed
         { index, className -> "$index-$className" })
         showClassPopup("Activities", list, activitiesClass.map { it?.psiClassByNameFromProjct(project) })
-
     }
 
     override fun currentActivity(
@@ -69,7 +63,6 @@ class AdbControllerImp(
         success: (message: String) -> Unit,
         error: (message: String) -> Unit
     ) {
-
         execute({
             val activity =
                 GetActivityCommand().execute(Any(), project, device) ?: throw Exception("No activities found")
@@ -77,7 +70,6 @@ class AdbControllerImp(
                 ?: throw Exception("class $activity  Not Found")
         }, error)
     }
-
 
     override fun currentFragment(
         device: IDevice,
@@ -118,7 +110,6 @@ class AdbControllerImp(
         }, error)
     }
 
-
     override fun clearAppData(device: IDevice, success: (message: String) -> Unit, error: (message: String) -> Unit) {
         execute({
             val applicationID = getApplicationID(device)
@@ -126,7 +117,6 @@ class AdbControllerImp(
             success("application $applicationID data cleared")
         }, error)
     }
-
 
     override fun getApplicationPermissions(
         device: IDevice,
@@ -173,7 +163,75 @@ class AdbControllerImp(
        execute({ConnectDeviceOverIPCommand().execute(ip,project)
            success("connected to $ip")
        },error)
+    }
 
+    override fun enableDisableDontKeepActivities(
+        device: IDevice,
+        success: (message: String) -> Unit,
+        error: (message: String) -> Unit
+    ) {
+        execute({
+            val result = EnableDisableDontKeepActivitiesCommand().execute(Any(), project, device)
+            success(result)
+        }, error)
+    }
+
+    override fun enableDisableShowTaps(
+        device: IDevice,
+        success: (message: String) -> Unit,
+        error: (message: String) -> Unit
+    ) {
+        execute({
+            val result = EnableDisableShowTapsCommand().execute(Any(), project, device)
+            success(result)
+        }, error)
+    }
+
+    override fun enableDisableShowLayoutBounds(
+        device: IDevice,
+        success: (message: String) -> Unit,
+        error: (message: String) -> Unit
+    ) {
+        execute({
+            val result = EnableDisableShowLayoutBoundsCommand().execute(Any(), project, device)
+            success(result)
+        }, error)
+    }
+
+    override fun setWindowAnimatorScale(
+        scale: String,
+        device: IDevice,
+        success: (message: String) -> Unit,
+        error: (message: String) -> Unit
+    ) {
+        execute({
+            val result = WindowAnimatorScaleCommand().execute(scale, project, device)
+            success(result)
+        }, error)
+    }
+
+    override fun setTransitionAnimatorScale(
+        scale: String,
+        device: IDevice,
+        success: (message: String) -> Unit,
+        error: (message: String) -> Unit
+    ) {
+        execute({
+            val result = TransitionAnimatorScaleCommand().execute(scale, project, device)
+            success(result)
+        }, error)
+    }
+
+    override fun setAnimatorDurationScale(
+        scale: String,
+        device: IDevice,
+        success: (message: String) -> Unit,
+        error: (message: String) -> Unit
+    ) {
+        execute({
+            val result = AnimatorDurationScaleCommand().execute(scale, project, device)
+            success(result)
+        }, error)
     }
 
     private fun execute(execute: () -> Unit, error: (message: String) -> Unit) {
@@ -197,15 +255,4 @@ class AdbControllerImp(
             this.createPopup().showCenteredInCurrentWindow(project)
         }
     }
-
-
-
-
 }
-
-
-
-
-
-
-

--- a/src/main/kotlin/spock/adb/IDeivceHellper.kt
+++ b/src/main/kotlin/spock/adb/IDeivceHellper.kt
@@ -1,6 +1,9 @@
 package spock.adb
 
 import com.android.ddmlib.IDevice
+import spock.adb.command.DontKeepActivitiesState
+import spock.adb.command.ShowLayoutBoundsState
+import spock.adb.command.ShowTapsState
 import java.util.concurrent.TimeUnit
 
 
@@ -32,3 +35,48 @@ fun IDevice.getDefaultActivityForApplication(packageName: String?):String {
 }
 fun IDevice.isMarshmallow() = this.version.apiLevel >= 23
 fun IDevice.isNougatOrAbove() = this.version.apiLevel >= 24
+
+
+fun IDevice.areDontKeepActivitiesEnabled(): DontKeepActivitiesState {
+    val outputReceiver = ShellOutputReceiver()
+    executeShellCommand("settings get global always_finish_activities", outputReceiver,15L, TimeUnit.SECONDS)
+
+    return DontKeepActivitiesState.getState(outputReceiver.toString())
+}
+
+fun IDevice.areShowTapsEnabled(): ShowTapsState {
+    val outputReceiver = ShellOutputReceiver()
+    executeShellCommand("settings get system show_touches", outputReceiver,15L, TimeUnit.SECONDS)
+
+    return ShowTapsState.getState(outputReceiver.toString())
+}
+
+fun IDevice.areShowLayoutBoundsEnabled(): ShowLayoutBoundsState {
+    val outputReceiver = ShellOutputReceiver()
+    executeShellCommand("getprop debug.layout", outputReceiver,15L, TimeUnit.SECONDS)
+
+    return ShowLayoutBoundsState.getState(outputReceiver.toString())
+}
+
+fun IDevice.refreshUi() {
+    val shellOutputReceiver = ShellOutputReceiver()
+    executeShellCommand("service call activity 1599295570", shellOutputReceiver,15L, TimeUnit.SECONDS)
+}
+
+fun IDevice.getWindowAnimatorScale(): String {
+    val shellOutputReceiver = ShellOutputReceiver()
+    executeShellCommand("settings get global window_animation_scale", shellOutputReceiver,15L, TimeUnit.SECONDS)
+    return shellOutputReceiver.toString()
+}
+
+fun IDevice.getTransitionAnimationScale(): String {
+    val shellOutputReceiver = ShellOutputReceiver()
+    executeShellCommand("settings get global transition_animation_scale", shellOutputReceiver,15L, TimeUnit.SECONDS)
+    return shellOutputReceiver.toString()
+}
+
+fun IDevice.getAnimatorDurationScale(): String {
+    val shellOutputReceiver = ShellOutputReceiver()
+    executeShellCommand("settings get global animator_duration_scale", shellOutputReceiver,15L, TimeUnit.SECONDS)
+    return shellOutputReceiver.toString()
+}

--- a/src/main/kotlin/spock/adb/SpockAdbViewer.form
+++ b/src/main/kotlin/spock/adb/SpockAdbViewer.form
@@ -2,14 +2,14 @@
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="spock.adb.SpockAdbViewer">
   <grid id="27dc6" layout-manager="GridBagLayout">
     <constraints>
-      <xy x="20" y="20" width="514" height="400"/>
+      <xy x="20" y="20" width="514" height="614"/>
     </constraints>
     <properties>
       <enabled value="true"/>
     </properties>
     <border type="none"/>
     <children>
-      <grid id="fe6b7" binding="rootPanel" layout-manager="GridLayoutManager" row-count="10" column-count="7" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="fe6b7" binding="rootPanel" layout-manager="GridLayoutManager" row-count="11" column-count="7" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="10" left="10" bottom="10" right="10"/>
         <constraints>
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
@@ -17,15 +17,15 @@
         </constraints>
         <properties>
           <focusable value="true"/>
-          <minimumSize width="500" height="320"/>
+          <minimumSize width="500" height="600"/>
           <opaque value="true"/>
-          <preferredSize width="500" height="320"/>
+          <preferredSize width="500" height="600"/>
         </properties>
         <border type="none"/>
         <children>
           <vspacer id="6253e">
             <constraints>
-              <grid row="9" column="5" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+              <grid row="10" column="5" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
             </constraints>
           </vspacer>
           <component id="43c37" class="javax.swing.JSeparator">
@@ -123,6 +123,129 @@
               <text value="Connect Device Using IP"/>
             </properties>
           </component>
+          <grid id="eaa03" layout-manager="GridLayoutManager" row-count="6" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+            <margin top="0" left="0" bottom="0" right="0"/>
+            <constraints>
+              <grid row="9" column="0" row-span="1" col-span="6" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <foreground color="-11447983"/>
+            </properties>
+            <border type="line" title="Developer Options">
+              <color color="-4473925"/>
+            </border>
+            <children>
+              <component id="ab081" class="javax.swing.JCheckBox" binding="enableDisableDontKeepActivities">
+                <constraints>
+                  <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="Dont Keep Activities"/>
+                </properties>
+              </component>
+              <hspacer id="770c7">
+                <constraints>
+                  <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                </constraints>
+              </hspacer>
+              <vspacer id="c4585">
+                <constraints>
+                  <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+                </constraints>
+              </vspacer>
+              <component id="b7f16" class="javax.swing.JCheckBox" binding="enableDisableShowTaps">
+                <constraints>
+                  <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="Show taps"/>
+                </properties>
+              </component>
+              <component id="1da73" class="javax.swing.JCheckBox" binding="enableDisableShowLayoutBounds">
+                <constraints>
+                  <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="Show layout bounds"/>
+                </properties>
+              </component>
+              <component id="6c279" class="javax.swing.JLabel">
+                <constraints>
+                  <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="Window Animation Scale"/>
+                </properties>
+              </component>
+              <component id="41d2f" class="javax.swing.JLabel">
+                <constraints>
+                  <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="Transition Animation Scale"/>
+                </properties>
+              </component>
+              <component id="36e39" class="javax.swing.JLabel">
+                <constraints>
+                  <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="Animation Duration Scale"/>
+                </properties>
+              </component>
+              <component id="6e629" class="javax.swing.JComboBox" binding="windowAnimatorScaleComboBox">
+                <constraints>
+                  <grid row="3" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="1" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <model>
+                    <item value="0.0"/>
+                    <item value="0.5"/>
+                    <item value="1.0"/>
+                    <item value="1.5"/>
+                    <item value="2.0"/>
+                    <item value="5.0"/>
+                    <item value="10.0"/>
+                  </model>
+                  <name value=""/>
+                </properties>
+              </component>
+              <component id="343a2" class="javax.swing.JComboBox" binding="transitionAnimatorScaleComboBox">
+                <constraints>
+                  <grid row="4" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <model>
+                    <item value="0.0"/>
+                    <item value="0.5"/>
+                    <item value="1.0"/>
+                    <item value="1.5"/>
+                    <item value="2.0"/>
+                    <item value="5.0"/>
+                    <item value="10.0"/>
+                  </model>
+                  <name value=""/>
+                </properties>
+              </component>
+              <component id="af9c5" class="javax.swing.JComboBox" binding="animatorDurationScaleComboBox">
+                <constraints>
+                  <grid row="5" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <model>
+                    <item value="0.0"/>
+                    <item value="0.5"/>
+                    <item value="1.0"/>
+                    <item value="1.5"/>
+                    <item value="2.0"/>
+                    <item value="5.0"/>
+                    <item value="10.0"/>
+                  </model>
+                  <name value=""/>
+                </properties>
+              </component>
+            </children>
+          </grid>
         </children>
       </grid>
       <hspacer id="419e8">

--- a/src/main/kotlin/spock/adb/SpockAdbViewer.kt
+++ b/src/main/kotlin/spock/adb/SpockAdbViewer.kt
@@ -9,11 +9,14 @@ import com.intellij.openapi.ui.SimpleToolWindowPanel
 import spock.adb.premission.PermissionDialog
 import javax.swing.*
 import com.intellij.openapi.ui.Messages
+import com.intellij.openapi.wm.ToolWindow
+import com.intellij.openapi.wm.ex.ToolWindowManagerListener
+import spock.adb.command.*
+import java.awt.event.ActionEvent
 
 class SpockAdbViewer(
-    private val adbController: AdbController,
     private val project: Project
-) : SimpleToolWindowPanel(true) {
+) : SimpleToolWindowPanel(true), ToolWindowManagerListener {
     private lateinit var panel1: JPanel
     private lateinit var rootPanel: JPanel
     private lateinit var devicesListComboBox: JComboBox<String>
@@ -28,16 +31,81 @@ class SpockAdbViewer(
     private lateinit var adbWifi: JButton
     private lateinit var wifiDebug: JButton
     private lateinit var devices: List<IDevice>
+    private lateinit var enableDisableDontKeepActivities: JCheckBox
+    private lateinit var enableDisableShowTaps: JCheckBox
+    private lateinit var enableDisableShowLayoutBounds: JCheckBox
+    private lateinit var windowAnimatorScaleComboBox: JComboBox<String>
+    private lateinit var transitionAnimatorScaleComboBox: JComboBox<String>
+    private lateinit var animatorDurationScaleComboBox: JComboBox<String>
     private var selectedIDevice: IDevice? = null
     private val notifier: NotificationGroup by lazy {
         NotificationGroup("Spock_ADB",
             NotificationDisplayType.BALLOON, true)
     }
 
+    private lateinit var adbController: AdbController
+
+    private val dontKeepActivitiesActionListener: (ActionEvent) -> Unit = {
+        selectedIDevice?.let { device ->
+            adbController.enableDisableDontKeepActivities(device, ::showSuccess, ::showError)
+        }
+    }
+
+    private val showTapsActionListener: (ActionEvent) -> Unit = {
+        selectedIDevice?.let { device ->
+            adbController.enableDisableShowTaps(device, ::showSuccess, ::showError)
+        }
+    }
+
+    private val showLayoutBoundsActionListener: (ActionEvent) -> Unit = {
+        selectedIDevice?.let { device ->
+            adbController.enableDisableShowLayoutBounds(device, ::showSuccess, ::showError)
+            device.refreshUi()
+        }
+    }
+
+    private val windowAnimatorScaleActionListener: (ActionEvent) -> Unit = {
+        selectedIDevice?.let { device ->
+            adbController.setWindowAnimatorScale(
+                windowAnimatorScaleComboBox.selectedItem as String,
+                device,
+                ::showSuccess,
+                ::showError
+            )
+        }
+    }
+
+    private val transitionAnimatorScaleActionListener: (ActionEvent) -> Unit = {
+        selectedIDevice?.let { device ->
+            adbController.setTransitionAnimatorScale(
+                transitionAnimatorScaleComboBox.selectedItem as String,
+                device,
+                ::showSuccess,
+                ::showError
+            )
+        }
+    }
+
+    private val animatorDurationScaleActionListener: (ActionEvent) -> Unit = {
+        selectedIDevice?.let { device ->
+            adbController.setAnimatorDurationScale(
+                animatorDurationScaleComboBox.selectedItem as String,
+                device,
+                ::showSuccess,
+                ::showError
+            )
+        }
+    }
 
     init {
         setContent(rootPanel)
+    }
+
+    fun initPlugin(adbController: AdbController) {
+        this.adbController = adbController
+
         updateDevicesList()
+
         wifiDebug.isEnabled = false
         wifiDebug.isVisible = false
         val deviceSelected = { x:Boolean->
@@ -103,12 +171,8 @@ class SpockAdbViewer(
                     dialog.isVisible = true
 
                 }, ::showError)
-
             }
-
         }
-
-
     }
 
     private fun updateDevicesList() {
@@ -123,6 +187,65 @@ class SpockAdbViewer(
         }, ::showError)
     }
 
+    private fun removeDeveloperOptionsListeners() {
+        enableDisableDontKeepActivities.actionListeners.forEach {
+            enableDisableDontKeepActivities.removeActionListener(it)
+        }
+
+        enableDisableShowTaps.actionListeners.forEach {
+            enableDisableShowTaps.removeActionListener(it)
+        }
+
+        enableDisableShowLayoutBounds.actionListeners.forEach {
+            enableDisableShowLayoutBounds.removeActionListener(it)
+        }
+
+        windowAnimatorScaleComboBox.actionListeners.forEach {
+            windowAnimatorScaleComboBox.removeActionListener(it)
+        }
+
+        transitionAnimatorScaleComboBox.actionListeners.forEach {
+            transitionAnimatorScaleComboBox.removeActionListener(it)
+        }
+
+        animatorDurationScaleComboBox.actionListeners.forEach {
+            animatorDurationScaleComboBox.removeActionListener(it)
+        }
+    }
+
+    private fun setDeveloperOptionsValues() {
+        enableDisableDontKeepActivities.isSelected =
+            selectedIDevice?.areDontKeepActivitiesEnabled() == DontKeepActivitiesState.ENABLED
+
+        enableDisableShowTaps.isSelected = selectedIDevice?.areShowTapsEnabled() == ShowTapsState.ENABLED
+
+        enableDisableShowLayoutBounds.isSelected =
+            selectedIDevice?.areShowLayoutBoundsEnabled() == ShowLayoutBoundsState.ENABLED
+
+        windowAnimatorScaleComboBox.selectedItem =
+            WindowAnimatorScaleCommand.getWindowAnimatorScaleIndex(selectedIDevice?.getWindowAnimatorScale())
+
+        transitionAnimatorScaleComboBox.selectedItem =
+            TransitionAnimatorScaleCommand.getTransitionAnimatorScaleIndex(selectedIDevice?.getTransitionAnimationScale())
+
+        animatorDurationScaleComboBox.selectedItem =
+            AnimatorDurationScaleCommand.getAnimatorDurationScaleIndex(selectedIDevice?.getAnimatorDurationScale())
+    }
+
+    private fun setDeveloperOptionsListeners() {
+        enableDisableDontKeepActivities.addActionListener(dontKeepActivitiesActionListener)
+
+        enableDisableShowTaps.addActionListener(showTapsActionListener)
+
+        enableDisableShowLayoutBounds.addActionListener(showLayoutBoundsActionListener)
+
+        windowAnimatorScaleComboBox.addActionListener(windowAnimatorScaleActionListener)
+
+        transitionAnimatorScaleComboBox.addActionListener(transitionAnimatorScaleActionListener)
+
+        animatorDurationScaleComboBox.addActionListener(animatorDurationScaleActionListener)
+    }
+
     private fun showError(message: String) {
         notifier.createNotification(
             "Spock ADB",
@@ -130,7 +253,6 @@ class SpockAdbViewer(
             NotificationType.ERROR,
             null
         ).notify(project)
-
     }
 
     private fun showSuccess(message: String) {
@@ -142,6 +264,14 @@ class SpockAdbViewer(
         ).notify(project)
     }
 
+    override fun toolWindowShown(id: String, toolWindow: ToolWindow) {
+        super.toolWindowShown(id, toolWindow)
+        (toolWindow.component.components.first() as? SpockAdbViewer)?.run {
+            removeDeveloperOptionsListeners()
+            setDeveloperOptionsValues()
+            setDeveloperOptionsListeners()
+        }
+    }
 }
 
 

--- a/src/main/kotlin/spock/adb/command/AnimatorDurationScaleCommand.kt
+++ b/src/main/kotlin/spock/adb/command/AnimatorDurationScaleCommand.kt
@@ -1,0 +1,25 @@
+package spock.adb.command
+
+import com.android.ddmlib.IDevice
+import com.intellij.openapi.project.Project
+import spock.adb.ShellOutputReceiver
+import java.util.concurrent.TimeUnit
+
+class AnimatorDurationScaleCommand : Command<String, String> {
+
+    companion object {
+        fun getAnimatorDurationScaleIndex(scale: String?): String = scale ?: "0.0"
+    }
+
+    override fun execute(p: String, project: Project, device: IDevice): String {
+        val shellOutputReceiver = ShellOutputReceiver()
+        device.executeShellCommand(
+            "settings put global animator_duration_scale $p",
+            shellOutputReceiver,
+            15L,
+            TimeUnit.SECONDS
+        )
+
+        return "Set Animator Duration Scale to $p"
+    }
+}

--- a/src/main/kotlin/spock/adb/command/EnableDisableDontKeepActivitiesCommand.kt
+++ b/src/main/kotlin/spock/adb/command/EnableDisableDontKeepActivitiesCommand.kt
@@ -1,0 +1,44 @@
+package spock.adb.command
+
+import com.android.ddmlib.IDevice
+import com.intellij.openapi.project.Project
+import spock.adb.ShellOutputReceiver
+import spock.adb.areDontKeepActivitiesEnabled
+import java.util.concurrent.TimeUnit
+
+class EnableDisableDontKeepActivitiesCommand : Command<Any, String> {
+
+    override fun execute(p: Any, project: Project, device: IDevice): String {
+
+        return when (device.areDontKeepActivitiesEnabled()) {
+            DontKeepActivitiesState.DISABLED -> {
+                setDontKeepActivitiesState(device, DontKeepActivitiesState.ENABLED)
+                "Enabled dont keep activities"
+            }
+            DontKeepActivitiesState.ENABLED -> {
+                setDontKeepActivitiesState(device, DontKeepActivitiesState.DISABLED)
+                "Disabled dont keep activities"
+            }
+        }
+    }
+
+    private fun setDontKeepActivitiesState(device: IDevice, state: DontKeepActivitiesState) {
+        val shellOutputReceiver = ShellOutputReceiver()
+        device.executeShellCommand(
+            "settings put global always_finish_activities ${state.state}",
+            shellOutputReceiver,
+            15L,
+            TimeUnit.SECONDS
+        )
+    }
+}
+
+enum class DontKeepActivitiesState(val state: String) {
+    ENABLED("1"),
+    DISABLED("0");
+
+    companion object {
+        private val map = values().associateBy(DontKeepActivitiesState::state)
+        fun getState(value: String) = map[value] ?: DISABLED
+    }
+}

--- a/src/main/kotlin/spock/adb/command/EnableDisableShowLayoutBoundsCommand.kt
+++ b/src/main/kotlin/spock/adb/command/EnableDisableShowLayoutBoundsCommand.kt
@@ -1,0 +1,43 @@
+package spock.adb.command
+
+import com.android.ddmlib.IDevice
+import com.intellij.openapi.project.Project
+import spock.adb.ShellOutputReceiver
+import spock.adb.areShowLayoutBoundsEnabled
+import java.util.concurrent.TimeUnit
+
+class EnableDisableShowLayoutBoundsCommand : Command<Any, String> {
+
+    override fun execute(p: Any, project: Project, device: IDevice): String {
+
+        return when (device.areShowLayoutBoundsEnabled()) {
+            ShowLayoutBoundsState.DISABLED -> {
+                setShowLayoutBoundsState(device, ShowLayoutBoundsState.ENABLED)
+                "Enabled layout bounds"
+            }
+            ShowLayoutBoundsState.ENABLED -> {
+                setShowLayoutBoundsState(device, ShowLayoutBoundsState.DISABLED)
+                "Disabled layout bounds"
+            }
+        }
+    }
+
+    private fun setShowLayoutBoundsState(device: IDevice, state: ShowLayoutBoundsState) {
+        val shellOutputReceiver = ShellOutputReceiver()
+        device.executeShellCommand(
+            "setprop debug.layout ${state.state}",
+            shellOutputReceiver,
+            15L,
+            TimeUnit.SECONDS
+        )
+    }
+}
+
+enum class ShowLayoutBoundsState(val state: String) {
+    ENABLED("true"),
+    DISABLED("false");
+
+    companion object {
+        fun getState(value: String) = if (value.toBoolean()) ENABLED else DISABLED
+    }
+}

--- a/src/main/kotlin/spock/adb/command/EnableDisableShowTapsCommand.kt
+++ b/src/main/kotlin/spock/adb/command/EnableDisableShowTapsCommand.kt
@@ -1,0 +1,44 @@
+package spock.adb.command
+
+import com.android.ddmlib.IDevice
+import com.intellij.openapi.project.Project
+import spock.adb.ShellOutputReceiver
+import spock.adb.areShowTapsEnabled
+import java.util.concurrent.TimeUnit
+
+class EnableDisableShowTapsCommand : Command<Any, String> {
+
+    override fun execute(p: Any, project: Project, device: IDevice): String {
+
+        return when (device.areShowTapsEnabled()) {
+            ShowTapsState.DISABLED -> {
+                setShowTapsState(device, ShowTapsState.ENABLED)
+                "Enabled show taps"
+            }
+            ShowTapsState.ENABLED -> {
+                setShowTapsState(device, ShowTapsState.DISABLED)
+                "Disabled show taps"
+            }
+        }
+    }
+
+    private fun setShowTapsState(device: IDevice, state: ShowTapsState) {
+        val shellOutputReceiver = ShellOutputReceiver()
+        device.executeShellCommand(
+            "settings put system show_touches ${state.state}",
+            shellOutputReceiver,
+            15L,
+            TimeUnit.SECONDS
+        )
+    }
+}
+
+enum class ShowTapsState(val state: String) {
+    ENABLED("1"),
+    DISABLED("0");
+
+    companion object {
+        private val map = values().associateBy(ShowTapsState::state)
+        fun getState(value: String) = map[value] ?: DISABLED
+    }
+}

--- a/src/main/kotlin/spock/adb/command/TransitionAnimatorScaleCommand.kt
+++ b/src/main/kotlin/spock/adb/command/TransitionAnimatorScaleCommand.kt
@@ -1,0 +1,25 @@
+package spock.adb.command
+
+import com.android.ddmlib.IDevice
+import com.intellij.openapi.project.Project
+import spock.adb.ShellOutputReceiver
+import java.util.concurrent.TimeUnit
+
+class TransitionAnimatorScaleCommand : Command<String, String> {
+
+    companion object {
+        fun getTransitionAnimatorScaleIndex(scale: String?): String = scale ?: "0.0"
+    }
+
+    override fun execute(p: String, project: Project, device: IDevice): String {
+        val shellOutputReceiver = ShellOutputReceiver()
+        device.executeShellCommand(
+            "settings put global transition_animation_scale $p",
+            shellOutputReceiver,
+            15L,
+            TimeUnit.SECONDS
+        )
+
+        return "Set Transition Animator Scale to $p"
+    }
+}

--- a/src/main/kotlin/spock/adb/command/WindowAnimatorScaleCommand.kt
+++ b/src/main/kotlin/spock/adb/command/WindowAnimatorScaleCommand.kt
@@ -1,0 +1,25 @@
+package spock.adb.command
+
+import com.android.ddmlib.IDevice
+import com.intellij.openapi.project.Project
+import spock.adb.ShellOutputReceiver
+import java.util.concurrent.TimeUnit
+
+class WindowAnimatorScaleCommand : Command<String, String> {
+
+    companion object {
+        fun getWindowAnimatorScaleIndex(scale: String?): String = scale ?: "0.0"
+    }
+
+    override fun execute(p: String, project: Project, device: IDevice): String {
+        val shellOutputReceiver = ShellOutputReceiver()
+        device.executeShellCommand(
+            "settings put global window_animation_scale $p",
+            shellOutputReceiver,
+            15L,
+            TimeUnit.SECONDS
+        )
+
+        return "Set Window Animator Scale to $p"
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -17,7 +17,7 @@
 
         -Restart or Reopen Application ]]>
     </description>
-    <idea-version since-build="181"/>
+    <idea-version since-build="193"/>
 
     <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html
          on how to target different products -->
@@ -28,11 +28,13 @@
     <depends>org.jetbrains.android</depends>
 
     <extensions defaultExtensionNs="com.intellij">
-        <!-- Add your extensions here -->
-            <!-- Add your extensions here -->
-        <toolWindow anchor="left" canCloseContents="false" id="Spock ADB"
-                    factoryClass="spock.AdbDrawerViewer" secondary="true" />
+        <toolWindow anchor="left" canCloseContents="false" id="Spock ADB" factoryClass="spock.AdbDrawerViewer"
+                    secondary="true"/>
     </extensions>
+
+    <projectListeners>
+        <listener class="spock.adb.SpockAdbViewer" topic="com.intellij.openapi.wm.ex.ToolWindowManagerListener" />
+    </projectListeners>
 
     <actions>
         <!-- Add your actions here -->


### PR DESCRIPTION
Now it's possible to:
Toggle "Show Taps" setting;
Toggle "Show Layout Bounds" setting;
Toggle "Don't Keep Activities" setting;
Change scale of:
Window Animation;
Transition Animation;
Animator Duration.

Closing/Opening the tool window queries the device for the current developer options and changes plugin UI accordingly. For example, if the user, while the plugin is visible, changes one of the settings, closing and opening the plugin, updates the plugin ui.

Code format:
Removed some unused imports and unnecessary empty lines