### PR TITLE
Fixes plugin not working properly in the stable Android Studio version (currently 4.0.1)

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -32,10 +32,6 @@
                     secondary="true"/>
     </extensions>
 
-    <projectListeners>
-        <listener class="spock.adb.SpockAdbViewer" topic="com.intellij.openapi.wm.ex.ToolWindowManagerListener" />
-    </projectListeners>
-
     <actions>
         <!-- Add your actions here -->
     </actions>


### PR DESCRIPTION
#b44a42 introduced ToolWindowManagerListener to update the developer options settings whenever the plugin becomes visible (this tried to keep the plugin updated since we don't have a callback for when that settings change).
Although the current stable Android Studio version is based on idea version 193, the ToolWindowManagerListener lacks the "toolWindowShown" method (available in Android Studio version 4.2).

This commit uses a deprecated method to achieve the same result. When AS is updated, the not deprecated method will be used.