### PR TITLE
Changes activity stack display and allows nested fragments

### DIFF
--- a/src/main/kotlin/spock/adb/AdbControllerImp.kt
+++ b/src/main/kotlin/spock/adb/AdbControllerImp.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.ui.popup.PopupChooserBuilder
 import com.intellij.psi.PsiClass
 import com.intellij.ui.components.JBList
 import spock.adb.command.*
+import spock.adb.models.ActivityData
 import spock.adb.premission.PermissionListItem
 
 class AdbControllerImp(
@@ -48,11 +49,23 @@ class AdbControllerImp(
         success: (message: String) -> Unit,
         error: (message: String) -> Unit
     ) {
-        val activitiesClass =
-            GetBackStackCommand().execute(Any(), project, device)
-        val list = JBList(activitiesClass.mapIndexed
-        { index, className -> "$index-$className" })
-        showClassPopup("Activities", list, activitiesClass.map { it?.psiClassByNameFromProjct(project) })
+        val activitiesList = mutableListOf<String>()
+        val activitiesClass: List<ActivityData> = GetBackStackCommand().execute(Any(), project, device)
+
+        activitiesClass.forEachIndexed { index, activityData ->
+            activitiesList.add("\t$index-${activityData.appPackage}")
+
+            activityData.activitiesList.forEachIndexed { activityIndex, activity ->
+                activitiesList.add("\t\t\t\t$activityIndex-${activity}")
+            }
+        }
+
+        val list = JBList(activitiesList)
+        showClassPopup(
+            "Activities",
+            list,
+            activitiesList.map { it.trim().substringAfter("-").psiClassByNameFromProjct(project) }
+        )
     }
 
     override fun currentActivity(

--- a/src/main/kotlin/spock/adb/command/GetActivityCommand.kt
+++ b/src/main/kotlin/spock/adb/command/GetActivityCommand.kt
@@ -5,6 +5,6 @@ import com.intellij.openapi.project.Project
 
 class GetActivityCommand : Command<Any, String?> {
     override fun execute(p: Any, project: Project, device: IDevice): String? {
-        return GetBackStackCommand().execute(p, project, device).firstOrNull()
+        return GetBackStackCommand().execute(p, project, device).firstOrNull()?.activitiesList?.first()
     }
 }

--- a/src/main/kotlin/spock/adb/command/GetBackStackCommand.kt
+++ b/src/main/kotlin/spock/adb/command/GetBackStackCommand.kt
@@ -1,13 +1,22 @@
-
 package spock.adb.command
 
 import com.android.ddmlib.IDevice
 import com.intellij.openapi.project.Project
+import spock.adb.models.ActivityData
 import java.util.concurrent.TimeUnit
 import spock.adb.ShellOutputReceiver
 
-class GetBackStackCommand : Command<Any, List<String?>> {
-    override fun execute(p: Any, project: Project, device: IDevice): List<String?> {
+class GetBackStackCommand : Command<Any, List<ActivityData>> {
+
+    companion object {
+        const val ACTIVITY_DELIMITER = "Running activities (most recent first):"
+        const val ACTIVITY_PREFIX = "Run #"
+        const val ACTIVITY_PREFIX_DELIMITER = "."
+        val extractAppRegex = Regex("(A=|I=)([a-zA-Z.]+)")
+        val extractActivityRegex = Regex("(u0\\s[a-zA-Z.]+/)([a-zA-Z.]+)")
+    }
+
+    override fun execute(p: Any, project: Project, device: IDevice): List<ActivityData> {
         val shellOutputReceiver = ShellOutputReceiver()
         device.executeShellCommand(
             "dumpsys activity activities | sed -En -e '/Running activities/,/Run #0/p'",
@@ -15,19 +24,37 @@ class GetBackStackCommand : Command<Any, List<String?>> {
             15L,
             TimeUnit.SECONDS
         )
-        return getCurrentRunningActivities(shellOutputReceiver)
+        return getCurrentRunningActivities(shellOutputReceiver.toString())
     }
 
-    private fun getCurrentRunningActivities(shellOutputReceiver: ShellOutputReceiver): List<String> {
-        return shellOutputReceiver.toString().split('\n')
-            .filter { it.contains("Run #") }
-            .map { it.substringAfter("u0") }
-            .map { it.substringAfter(" ").substringBefore(" ") }
-            .map {
-                if (it.contains("/."))
-                    it.replace("/", "")
-                else
-                    it.substringAfter("/")
+    private fun getCurrentRunningActivities(bulkActivitiesData: String): List<ActivityData> {
+        lateinit var appPackage: String
+
+        return bulkActivitiesData
+            .split(ACTIVITY_DELIMITER)
+            .filter { it.isNotBlank() }
+            .mapNotNull { bulkAppData ->
+                appPackage = extractAppRegex.find(bulkAppData)?.groups?.lastOrNull()?.value ?: return@mapNotNull null
+
+                ActivityData(
+                    appPackage = appPackage,
+                    activitiesList = bulkAppData
+                        .lines()
+                        .filter { it.trim().startsWith(ACTIVITY_PREFIX) }
+                        .mapNotNull { bulkActivityData: String ->
+                            extractActivityRegex
+                                .find(bulkActivityData)
+                                ?.groups
+                                ?.lastOrNull()
+                                ?.value
+                                ?.let { activityName ->
+                                    when {
+                                        activityName.startsWith(ACTIVITY_PREFIX_DELIMITER) -> "$appPackage$activityName"
+                                        else -> activityName
+                                    }
+                                }
+                        }
+                )
             }
     }
 }

--- a/src/main/kotlin/spock/adb/command/GetFragmentsCommand.kt
+++ b/src/main/kotlin/spock/adb/command/GetFragmentsCommand.kt
@@ -4,21 +4,79 @@ import com.android.ddmlib.IDevice
 import com.intellij.openapi.project.Project
 import java.util.concurrent.TimeUnit
 import spock.adb.ShellOutputReceiver
+import spock.adb.models.FragmentData
 
-class GetFragmentsCommand : Command<String, List<String?>?> {
-    override fun execute(p: String, project: Project, device: IDevice): List<String?>? {
+class GetFragmentsCommand : Command<String, List<FragmentData>> {
+
+    override fun execute(p: String, project: Project, device: IDevice): List<FragmentData> {
         val shellOutputReceiver = ShellOutputReceiver()
         device.executeShellCommand("dumpsys activity top", shellOutputReceiver, 15L, TimeUnit.SECONDS)
-        return getCurrentFragmentsFromLog(shellOutputReceiver)
+        return getCurrentFragmentsFromLog(shellOutputReceiver.toString())
     }
 
-    private fun getCurrentFragmentsFromLog(shellOutputReceiver: ShellOutputReceiver): List<String>? {
-        val task = shellOutputReceiver.toString().split("TASK").lastOrNull()
-        val addedFragments = if (task?.contains("NavHostFragment") == true)
-            task.split("Added Fragments:")[2]
-        else task?.split("Added Fragments:")?.lastOrNull()
-        return addedFragments?.lines()?.map { it.trim() }
-            ?.filter { (it.startsWith("#") && !it.contains("BackStackEntry")) }
-            ?.map { it.split("{").first().split(" ").last() }?.distinct()
+    private fun getCurrentFragmentsFromLog(dumpsys: String): List<FragmentData> {
+        val bulkTaskDetails = dumpsys.substringAfter("TASK", "")
+
+        return if (bulkTaskDetails.contains("NavHostFragment")) {
+            getFragmentsUsingOldMethod(bulkTaskDetails)
+        } else {
+            val bulkAddedFragmentsDetails = getBulkAddedFragmentsDetails(bulkTaskDetails)
+
+            val addedFragments = getAddedFragments(bulkAddedFragmentsDetails)
+
+            getFragments(addedFragments, bulkTaskDetails)
+        }
+    }
+
+    private fun getFragmentsUsingOldMethod(bulkTaskDetails: String): List<FragmentData> {
+        return bulkTaskDetails
+            .split("Added Fragments:")[2]
+            .lines()
+            .map { it.trim() }
+            .filter { (it.startsWith("#") && !it.contains("BackStackEntry")) }
+            .map {
+                FragmentData(it.split("{").first().split(" ").last())
+            }
+            .distinct()
+    }
+
+    private fun getBulkAddedFragmentsDetails(bulkTaskDetails: String): String {
+        return bulkTaskDetails
+            .substringAfterLast("Added Fragments:", "")
+            .substringBefore("Back Stack", "")
+    }
+
+    private fun getAddedFragments(bulkAddedFragmentsDetails: String): List<FragmentData> =
+        bulkAddedFragmentsDetails
+            .lines()
+            .filter { line -> line.isNotBlank() }
+            .map { line ->
+                FragmentData(
+                    line
+                        .substringAfter(": ", "")
+                        .substringBefore("{", ""),
+                    line
+                        .substringAfter("{", "")
+                        .substringBefore("}", "")
+                )
+            }
+
+    private fun getFragments(addedFragments: List<FragmentData>, bulkTaskDetails: String): List<FragmentData> {
+
+        var initDelimiter: String
+        var endDelimiter: String
+        addedFragments.forEachIndexed { index, fragment ->
+            initDelimiter = "${fragment.fragment}{${fragment.fragmentIdentifier}}"
+            endDelimiter = if (index == addedFragments.lastIndex) {
+                "mParent=$initDelimiter"
+            } else "${addedFragments[index + 1].fragment}{${addedFragments[index + 1].fragmentIdentifier}}"
+
+            fragment.innerFragments = getAddedFragments(getBulkAddedFragmentsDetails(bulkTaskDetails.substringAfter(initDelimiter, "").substringBefore(endDelimiter, "")))
+            if (fragment.innerFragments.isNotEmpty()) {
+                getFragments(fragment.innerFragments, bulkTaskDetails)
+            }
+        }
+
+        return addedFragments
     }
 }

--- a/src/main/kotlin/spock/adb/models/ActivityData.kt
+++ b/src/main/kotlin/spock/adb/models/ActivityData.kt
@@ -1,0 +1,3 @@
+package spock.adb.models
+
+class ActivityData(val appPackage: String, val activitiesList: List<String>)

--- a/src/main/kotlin/spock/adb/models/FragmentData.kt
+++ b/src/main/kotlin/spock/adb/models/FragmentData.kt
@@ -1,0 +1,7 @@
+package spock.adb.models
+
+class FragmentData(
+    val fragment: String,
+    val fragmentIdentifier: String = "",
+    var innerFragments: List<FragmentData> = emptyList()
+)


### PR DESCRIPTION
- The activity stack now shows activities by app package. This way, the user can clearly see to what package, the activity belongs to.
- The fragment stack can now show nested fragments and follows the same display rules as the activity stack command.

Here is an example of how activities are now displayed:

![image](https://user-images.githubusercontent.com/5049948/91844606-b0bd7800-ec4f-11ea-834a-b898030a7974.png)

