### PR TITLE
Support IntelliJ IDEA and fix NoSuchMethodError on older Android Studio

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,6 +77,46 @@ jobs:
           name: ${{ steps.artifact.outputs.filename }}
           path: ./build/distributions/content/*/*
 
+  verify:
+    name: Plugin Verifier
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Fetch Sources
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: 17
+          cache: gradle
+
+      - name: Free Disk Space
+        run: |
+          # The verifier downloads one full IDE per target; the default runner image
+          # does not leave enough room for five of them.
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
+          df -h /
+
+      - name: Cache Verifier IDEs
+        uses: actions/cache@v4
+        with:
+          path: ~/.pluginVerifier
+          key: plugin-verifier-${{ hashFiles('build.gradle.kts') }}
+          restore-keys: plugin-verifier-
+
+      - name: Run Plugin Verifier
+        run: ./gradlew verifyPlugin
+
+      - name: Upload Verifier Report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: plugin-verifier-report
+          path: ./build/reports/pluginVerifier
+          if-no-files-found: ignore
+
   releaseDraft:
     name: Release Draft
     if: github.event_name != 'pull_request'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,18 @@
 - **API level detection**: `getApiVersion()` read `ro.build.version.release` (the marketing version, e.g. "8.1.0"), which fails integer parsing and pushed modern devices down the pre-Honeycomb back stack parsing path. Replaced with `apiLevel()`, reading `ro.build.version.sdk` and preferring ddmlib's cached value
 - **Crash**: `GetApplicationBackStackCommand` called `tasks.last()` on a possibly empty list, throwing `NoSuchElementException` on a truncated `dumpsys` dump
 
+### Compatibility
+- **The plugin now works in IntelliJ IDEA, not just Android Studio.** The descriptor declared `<depends>com.intellij.modules.androidstudio</depends>`, which made the Marketplace report the plugin as incompatible with IntelliJ IDEA. Every Android API the plugin uses ships inside the `org.jetbrains.android` plugin rather than the Android Studio platform, so the dependency bought no API guarantees and only restricted reach
+- **Fixed a `NoSuchMethodError` on Android Studio 2023.1 through 2024.x.** `sinceBuild` was `231` while compiling against platform `251`. Kotlin emits compatibility-bridge overrides that `invokespecial` into every default method a platform interface had at compile time, so `AdbDrawerViewer` — the tool window factory, and therefore the plugin's entry point — referenced `ToolWindowFactory.manage` and `isApplicableAsync`, neither of which exists on 231. The tool window could not open. Fixed with `-Xjvm-default=all`
+- **Declared the missing Java plugin dependency.** The plugin navigates to sources through `JavaPsiFacade` and `PsiShortNamesCache` without declaring `com.intellij.modules.java`, which Plugin Verifier reported as a compatibility problem on every target
+- Restored Plugin Verifier and wired it into CI, now covering Android Studio 231/242/251 and IntelliJ IDEA 231/251. All five report `Compatible`
+- `Restart App With Debugger` is feature-detected at runtime and hidden on IDEs without the Android Studio execution tooling, instead of failing with `NoClassDefFoundError`
+- Replaced the deprecated `ToolWindowManagerListener.stateChanged()` override and the deprecated `AndroidVersion.getApiLevel()` call
+- Added `docs/COMPATIBILITY.md` documenting the supported range, the verification matrix and how to change it
+
 ### Changed
+- Application ID resolution reads through the stable `AndroidModel` interface instead of the Gradle-specific `GradleAndroidModel`, and now prefers application modules over libraries — in a multi-module project the previous code used an arbitrary facet and could resolve the wrong module or none at all
+- A project with no resolvable application ID now reports an actionable message; previously the nullable result was passed through `.toString()`, producing the literal string `"null"` and the misleading error `Application null not installed`
 - ADB output parsing extracted from the command classes into pure functions in `spock.adb.parser` (`ActivityParser`, `BackStackParser`, `ApplicationBackStackParser`, `FragmentDumpParser`), so it can be tested without a connected device
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -73,11 +73,28 @@ Spock ADB puts the most common ADB workflows into a single tool window: navigate
 
 ---
 
+## Supported IDEs
+
+| IDE | Versions |
+|---|---|
+| **Android Studio** | 2023.1 (Hedgehog) and later |
+| **IntelliJ IDEA** | 2023.1 and later, with the bundled Android plugin |
+
+Every release is checked against both IDEs with JetBrains Plugin Verifier before it ships.
+See [docs/COMPATIBILITY.md](docs/COMPATIBILITY.md) for the full matrix and the reasoning
+behind the supported range.
+
+> **Note:** `Restart App With Debugger` requires the Android Studio execution tooling. It is
+> available in all supported Android Studio versions and in IntelliJ IDEA 2025.1+, and is
+> hidden automatically on IDEs that do not ship it. Every other feature works everywhere.
+
+---
+
 ## Installation
 
 **JetBrains Marketplace:** [Spock ADB](https://plugins.jetbrains.com/plugin/11591-spock-adb)
 
-Or install directly in Android Studio: `Settings → Plugins → Marketplace → search "Spock ADB"`
+Or install directly from your IDE: `Settings → Plugins → Marketplace → search "Spock ADB"`
 
 ---
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,16 @@ version = pluginVersion
 
 kotlin {
     jvmToolchain(17)
+
+    compilerOptions {
+        // Without this, Kotlin emits "compatibility bridge" overrides in classes that
+        // implement platform Kotlin interfaces (e.g. ToolWindowFactory). Those bridges
+        // `invokespecial` every default method the interface had at *compile* time, so a
+        // plugin compiled against 251 and run on 231 dies with NoSuchMethodError on
+        // ToolWindowFactory.manage / isApplicableAsync — in AdbDrawerViewer, the plugin's
+        // entry point. Verified with Plugin Verifier against AI-231; see docs/COMPATIBILITY.md.
+        freeCompilerArgs.add("-Xjvm-default=all")
+    }
 }
 
 // Configure project's dependencies
@@ -120,6 +130,31 @@ intellijPlatform {
             name = "Spock Adb"
             email = "ahmed.wahdan@outlook.com"
             url = "https://github.com/WahdanZ"
+        }
+    }
+
+    pluginVerification {
+        // Problems that are understood and handled at runtime, each justified in the file.
+        ignoredProblemsFile = file("verifier-ignored-problems.txt")
+
+        failureLevel = listOf(
+            org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask.FailureLevel.COMPATIBILITY_PROBLEMS,
+            org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask.FailureLevel.INVALID_PLUGIN,
+            org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask.FailureLevel.NOT_DYNAMIC,
+        )
+
+        ides {
+            // Oldest supported Android Studio (Hedgehog, build AI-231) — the sinceBuild floor.
+            ide(org.jetbrains.intellij.platform.gradle.IntelliJPlatformType.AndroidStudio, "2023.1.1.28")
+            // A mid-range Android Studio, to catch breakage between the two ends.
+            ide(org.jetbrains.intellij.platform.gradle.IntelliJPlatformType.AndroidStudio, "2024.2.1.12")
+            // Current stable Android Studio — the compile target.
+            ide(org.jetbrains.intellij.platform.gradle.IntelliJPlatformType.AndroidStudio, "2025.1.1.14")
+            // IntelliJ IDEA with the bundled Android plugin. The plugin no longer declares
+            // com.intellij.modules.androidstudio, so IDEA is a supported target and must be
+            // verified rather than assumed.
+            ide(org.jetbrains.intellij.platform.gradle.IntelliJPlatformType.IntellijIdeaCommunity, "2023.1.5")
+            ide(org.jetbrains.intellij.platform.gradle.IntelliJPlatformType.IntellijIdeaCommunity, "2025.1")
         }
     }
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -1,0 +1,129 @@
+# Compatibility strategy
+
+This document records **how** the supported range is decided, not just what it currently
+is. Every claim below is produced by `./gradlew verifyPlugin`, not by inspection.
+
+## Supported range
+
+| Target | Builds | Status |
+|---|---|---|
+| Android Studio | 2023.1 (Hedgehog) and later | Supported, verified |
+| IntelliJ IDEA | 2023.1 and later, with the bundled Android plugin | Supported, verified |
+
+- `sinceBuild = 231`
+- `untilBuild` is left open so new IDE releases do not require a republish.
+- Compiled against Android Studio 2025.1.1.14 (platform 251), Java 17, Kotlin 2.2.
+
+## Why the plugin is no longer Android Studio only
+
+Until 3.0.0 the descriptor declared:
+
+```xml
+<depends>com.intellij.modules.androidstudio</depends>
+```
+
+That is a hard gate: the Marketplace lists the plugin as **incompatible with IntelliJ
+IDEA**, and IDEA refuses to install it, regardless of whether the code would actually run.
+
+It turns out to have bought nothing. Every Android API the plugin uses —
+`com.android.ddmlib`, `AndroidFacet`, `AndroidModel`, `AndroidSdkUtils`, and the execution
+tooling — is packaged inside `plugins/android/lib/*.jar`, i.e. the `org.jetbrains.android`
+plugin, which the descriptor already depends on. None of them come from the Android Studio
+platform itself.
+
+The dependency was therefore removed, and IntelliJ IDEA was added to the verification
+matrix so the claim is checked rather than assumed.
+
+Two dependencies were added at the same time:
+
+- `com.intellij.modules.platform` — the standard base dependency.
+- `com.intellij.modules.java` — the plugin navigates to Activity and Fragment sources
+  through `JavaPsiFacade` and `PsiShortNamesCache`. Plugin Verifier reported using Java
+  PSI without declaring the Java plugin as a compatibility problem on **every** target.
+
+## The one feature that is not universally available
+
+`Restart App With Debugger` needs
+`com.android.tools.idea.execution.common.debug.AndroidDebugger`, part of the Android Studio
+execution stack. It is present in every supported Android Studio build and in IntelliJ IDEA
+2025.1, but not in the Android plugin bundled with IntelliJ IDEA 2023.1.
+
+Rather than gate the whole plugin on it, `spock.adb.compat.DebuggerSupport` feature-detects
+the class before the `Debugger` class is loaded:
+
+- the action is hidden in the tool window when unavailable, and
+- the command reports a clear message instead of dying with `NoClassDefFoundError`.
+
+The corresponding verifier finding is listed in `verifier-ignored-problems.txt` with the
+reasoning. **If the guard is removed, delete that entry and let the verifier fail.**
+
+## The `sinceBuild` trap, and why compiling against a newer platform is not free
+
+`sinceBuild = 231` was previously declared while compiling against platform 251. That
+combination was **not** actually compatible with 231, and the verifier proved it:
+
+```
+Method spock.AdbDrawerViewer.manage(...) contains an *invokespecial* instruction
+referencing an unresolved method com.intellij.openapi.wm.ToolWindowFactory.manage(...).
+This can lead to NoSuchMethodError exception at runtime.
+
+Method spock.AdbDrawerViewer.isApplicableAsync(...) contains an *invokespecial* instruction
+referencing an unresolved method ToolWindowFactory.isApplicableAsync(...).
+```
+
+`ToolWindowFactory` is a Kotlin interface with default methods. When a Kotlin class
+implements it, the compiler emits *compatibility bridge* overrides that `invokespecial`
+into every default method the interface had **at compile time**. Compiled against 251, the
+bridges reference `manage` and `isApplicableAsync`, which do not exist on 231.
+
+`AdbDrawerViewer` is the tool window factory — the plugin's entry point — so this was not a
+corner case: the tool window would fail to open on Android Studio 2023.1 through 2024.x.
+
+The fix is one compiler flag in `build.gradle.kts`:
+
+```kotlin
+freeCompilerArgs.add("-Xjvm-default=all")
+```
+
+which stops the bridges being generated. After it, all five targets report `Compatible`.
+
+The general lesson, and the rule for this repository: **lowering `sinceBuild` is a claim
+that must be verified.** Compiling against a newer platform can inject references to APIs
+that do not exist in older ones, without any warning at compile time.
+
+## Verification matrix
+
+`./gradlew verifyPlugin` checks these builds. They are the two ends of the supported range
+plus a midpoint, on both IDEs:
+
+| IDE | Version | Why |
+|---|---|---|
+| Android Studio | 2023.1.1.28 | The `sinceBuild` floor |
+| Android Studio | 2024.2.1.12 | Midpoint, catches breakage between the ends |
+| Android Studio | 2025.1.1.14 | Current stable, the compile target |
+| IntelliJ IDEA Community | 2023.1.5 | IDEA floor, no Android execution tooling |
+| IntelliJ IDEA Community | 2025.1 | Current IDEA |
+
+CI runs this on every push and pull request as the `Plugin Verifier` job, and uploads the
+report. `failureLevel` includes `COMPATIBILITY_PROBLEMS`, `INVALID_PLUGIN` and
+`NOT_DYNAMIC`, so a regression fails the build rather than producing a warning.
+
+## Changing the supported range
+
+1. Change `pluginSinceBuild` in `gradle.properties` and/or `androidStudioVersion`.
+2. Update the `ides { }` block in `build.gradle.kts` so the new floor is verified.
+3. Run `./gradlew verifyPlugin` and read the report — do not rely on the build passing
+   alone, since deprecation and internal-API findings do not fail it.
+4. Update the table at the top of this file.
+
+## Known remaining findings
+
+Two deprecated API usages remain, both deliberate:
+
+- `org.joor.Reflect.on(Class)` — inside `Debugger`'s reflective fallback path for older
+  Android Studio builds. Replacing it means dropping that fallback.
+- The IntelliJ form runtime's generated `$$$setupUI$$$` is invoked reflectively from
+  Kotlin constructors, because the form compiler only injects the call automatically into
+  Java constructors.
+
+Neither is a compatibility problem; both are recorded here so they are not rediscovered.

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,8 +4,13 @@ pluginGroup=com.wahdan
 pluginName=SpockAdb
 pluginVersion=3.0.0
 
-# Compile against the latest stable Android Studio (Meerkat) so all current APIs are available.
-# sinceBuild=231 means Hedgehog (2023.1.1) and every release after it is supported.
+# Supported range: Android Studio 2023.1 (Hedgehog) and IntelliJ IDEA 2023.1, and later.
+#
+# sinceBuild=231 is verified, not assumed: `./gradlew verifyPlugin` checks the plugin against
+# Android Studio 231/242/251 and IntelliJ IDEA 231/251 on every CI run. Lowering this value
+# without extending that matrix has previously shipped a plugin that could not open its own
+# tool window on older builds. See docs/COMPATIBILITY.md before changing it.
+#
 # untilBuild is left empty so new releases are accepted without a plugin update.
 pluginSinceBuild=231
 pluginUntilBuild=

--- a/src/main/kotlin/spock/adb/AdbControllerImp.kt
+++ b/src/main/kotlin/spock/adb/AdbControllerImp.kt
@@ -28,8 +28,18 @@ class AdbControllerImp(
         AndroidDebugBridge.addDeviceChangeListener(this)
     }
 
-    private fun getApplicationID(device: IDevice) =
-        GetApplicationIDCommand().execute(Any(), project, device).toString()
+    /**
+     * The previous implementation called `.toString()` on a nullable result, so a project
+     * with no resolvable application ID produced the literal string "null" and every
+     * downstream command failed with `Application null not installed`. Fail with an
+     * actionable message instead.
+     */
+    private fun getApplicationID(device: IDevice): String =
+        GetApplicationIDCommand().execute(Any(), project, device)
+            ?: throw IllegalStateException(
+                "Could not determine the application ID for this project. " +
+                    "Open an Android project and make sure its Gradle sync has finished.",
+            )
 
     override fun refresh() {
         AndroidDebugBridge.removeDeviceChangeListener(this)

--- a/src/main/kotlin/spock/adb/IDeivceHellper.kt
+++ b/src/main/kotlin/spock/adb/IDeivceHellper.kt
@@ -115,13 +115,17 @@ fun IDevice.getNetworkState(network: Network): NetworkState {
  * and were silently treated as "unknown", pushing modern devices down the pre-Honeycomb
  * parsing path. `ro.build.version.sdk` is the API level and is always an integer.
  *
- * ddmlib's cached [IDevice.getVersion] is preferred when it is already populated, since it
- * avoids a shell round trip; the property read is the fallback.
+ * ddmlib's cached property table is consulted first since it avoids a shell round trip;
+ * an explicit `getprop` is the fallback.
  */
 fun IDevice.apiLevel(): Int? {
-    @Suppress("DEPRECATION")
-    val cached = runCatching { version.apiLevel }.getOrNull()
-    if (cached != null && cached > 0) return cached
+    // ddmlib caches device properties, so this usually avoids a shell round trip.
+    // Read the property directly rather than IDevice.version.apiLevel, which is deprecated.
+    runCatching { getProperty("ro.build.version.sdk") }
+        .getOrNull()
+        ?.trim()
+        ?.toIntOrNull()
+        ?.let { return it }
 
     val outputReceiver = ShellOutputReceiver()
     executeShellCommand("getprop ro.build.version.sdk", outputReceiver, 15L, TimeUnit.SECONDS)

--- a/src/main/kotlin/spock/adb/SpockAdbViewer.kt
+++ b/src/main/kotlin/spock/adb/SpockAdbViewer.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.ui.SimpleToolWindowPanel
 import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.openapi.wm.ex.ToolWindowManagerListener
 import spock.adb.command.*
+import spock.adb.compat.DebuggerSupport
 import spock.adb.premission.CheckBoxDialog
 import java.awt.event.ActionEvent
 import javax.swing.*
@@ -265,7 +266,11 @@ class SpockAdbViewer(
                 SpockAction.CLEAR_APP_DATA -> clearAppDataButton.isVisible = it.isSelected
                 SpockAction.CLEAR_APP_DATA_RESTART -> clearAppDataAndRestartButton.isVisible = it.isSelected
                 SpockAction.RESTART -> restartAppButton.isVisible = it.isSelected
-                SpockAction.RESTART_DEBUG -> restartAppWithDebuggerButton.isVisible = it.isSelected
+                // Attaching a debugger needs the Android Studio execution tooling, which is
+                // absent in some IDEs that bundle the Android plugin. Hide the action there
+                // rather than offering a button that can only report an error.
+                SpockAction.RESTART_DEBUG ->
+                    restartAppWithDebuggerButton.isVisible = it.isSelected && DebuggerSupport.isAvailable
                 SpockAction.TEST_PROCESS_DEATH -> testProcessDeathButton.isVisible = it.isSelected
                 SpockAction.FORCE_KILL -> forceKillAppButton.isVisible = it.isSelected
                 SpockAction.UNINSTALL -> uninstallAppButton.isVisible = it.isSelected
@@ -355,24 +360,27 @@ class SpockAdbViewer(
     }
 
     private fun setToolWindowListener() {
+        val toolWindow = ToolWindowManager.getInstance(project).getToolWindow(TOOL_WINDOW_ID) ?: return
 
-        ToolWindowManager
-            .getInstance(project)
-            .run {
-                val toolWindow = getToolWindow("Spock ADB")
-                if (toolWindow != null) {
-                    project.messageBus.connect()
-                        .subscribe(ToolWindowManagerListener.TOPIC, object : ToolWindowManagerListener {
-                            override fun stateChanged() {
-                                if (toolWindow.isVisible) {
-                                    removeDeveloperOptionsListeners()
-                                    ApplicationManager.getApplication().executeOnPooledThread {
-                                        setDeveloperOptionsValues()
-                                    }
-                                }
-                            }
-                        })
-                }
-            }
+        project.messageBus
+            .connect()
+            .subscribe(
+                ToolWindowManagerListener.TOPIC,
+                object : ToolWindowManagerListener {
+                    // The no-argument stateChanged() is deprecated; the ToolWindowManager
+                    // overload has been available since 2020.1.
+                    override fun stateChanged(toolWindowManager: ToolWindowManager) {
+                        if (!toolWindow.isVisible) return
+                        removeDeveloperOptionsListeners()
+                        ApplicationManager.getApplication().executeOnPooledThread {
+                            setDeveloperOptionsValues()
+                        }
+                    }
+                },
+            )
+    }
+
+    private companion object {
+        const val TOOL_WINDOW_ID = "Spock ADB"
     }
 }

--- a/src/main/kotlin/spock/adb/command/GetApplicationIDCommand.kt
+++ b/src/main/kotlin/spock/adb/command/GetApplicationIDCommand.kt
@@ -1,16 +1,48 @@
 package spock.adb.command
 
 import com.android.ddmlib.IDevice
-import com.android.tools.idea.gradle.project.model.GradleAndroidModel
+import com.android.tools.idea.model.AndroidModel
 import com.intellij.facet.ProjectFacetManager
 import com.intellij.openapi.project.Project
 import org.jetbrains.android.facet.AndroidFacet
 
+/**
+ * Resolves the application ID (package name) of the app module in the open project.
+ *
+ * Two changes over the previous implementation:
+ *
+ *  - It reads through the [AndroidModel] interface rather than the Gradle-specific
+ *    `GradleAndroidModel`. `AndroidModel` is the stable abstraction that
+ *    `GradleAndroidModel` implements, it is present in the `org.jetbrains.android`
+ *    plugin shipped by both Android Studio and IntelliJ IDEA, and it also covers
+ *    non-Gradle Android projects.
+ *  - It prefers application modules over libraries. Previously the first facet in an
+ *    arbitrary order was used, so in a multi-module project the plugin could act on a
+ *    library module and resolve no (or the wrong) application ID.
+ */
 class GetApplicationIDCommand : Command<Any, String?> {
-    override fun execute(p: Any, project: Project, device: IDevice): String? {
-        return ProjectFacetManager.getInstance(project)
-            .getFacets(AndroidFacet.ID)
-            .firstOrNull()
-            ?.let { GradleAndroidModel.get(it)?.applicationId }
+
+    override fun execute(p: Any, project: Project, device: IDevice): String? =
+        resolve(project)
+
+    companion object {
+        fun resolve(project: Project): String? {
+            val facets = ProjectFacetManager.getInstance(project).getFacets(AndroidFacet.ID)
+            if (facets.isEmpty()) return null
+
+            // App modules first; libraries only as a last resort so single-module library
+            // projects still behave as they did before.
+            val ordered = facets.sortedByDescending { it.isApplicationModule() }
+
+            return ordered.firstNotNullOfOrNull { facet -> facet.applicationId() }
+        }
+
+        private fun AndroidFacet.isApplicationModule(): Boolean =
+            runCatching { configuration.isAppProject }.getOrDefault(false)
+
+        private fun AndroidFacet.applicationId(): String? =
+            runCatching { AndroidModel.get(this)?.applicationId }
+                .getOrNull()
+                ?.takeIf { it.isNotBlank() && it != AndroidModel.UNINITIALIZED_APPLICATION_ID }
     }
 }

--- a/src/main/kotlin/spock/adb/command/RestartAppWithDebuggerCommand.kt
+++ b/src/main/kotlin/spock/adb/command/RestartAppWithDebuggerCommand.kt
@@ -2,9 +2,11 @@ package spock.adb.command
 
 import com.android.ddmlib.IDevice
 import com.intellij.openapi.project.Project
-
-import spock.adb.*
-import spock.adb.debugger.Debugger
+import spock.adb.ShellOutputReceiver
+import spock.adb.compat.DebuggerSupport
+import spock.adb.forceKillApp
+import spock.adb.getDefaultActivityForApplication
+import spock.adb.isAppInstall
 import java.util.concurrent.TimeUnit
 
 class RestartAppWithDebuggerCommand : Command<String, Unit> {
@@ -23,7 +25,7 @@ class RestartAppWithDebuggerCommand : Command<String, Unit> {
                             TimeUnit.SECONDS
                         )
 
-                        Debugger(project, device, p).attach()
+                        DebuggerSupport.attach(project, device, p)
                     }
                     else -> throw Exception("No Default Activity Found")
                 }

--- a/src/main/kotlin/spock/adb/compat/DebuggerSupport.kt
+++ b/src/main/kotlin/spock/adb/compat/DebuggerSupport.kt
@@ -1,0 +1,52 @@
+package spock.adb.compat
+
+import com.android.ddmlib.IDevice
+import com.intellij.openapi.project.Project
+
+/**
+ * Guards the one integration point that is not guaranteed to exist in every IDE that
+ * ships the `org.jetbrains.android` plugin.
+ *
+ * Everything else this plugin uses (ddmlib, `AndroidFacet`, `AndroidModel`, `AndroidSdkUtils`)
+ * lives in `org.jetbrains.android` and is therefore available wherever that plugin is
+ * installed. The debugger attach path additionally needs
+ * `com.android.tools.idea.execution.common.debug.AndroidDebugger`, which is part of the
+ * Android Studio execution stack and may be absent in a plain IntelliJ IDEA install.
+ *
+ * Rather than hard-depending on Android Studio for the whole plugin — which is what
+ * `<depends>com.intellij.modules.androidstudio</depends>` did, and why the Marketplace
+ * listed the plugin as incompatible with IntelliJ IDEA — the check is scoped to this one
+ * feature, which reports a clear message when unavailable instead of failing with a
+ * NoClassDefFoundError.
+ */
+object DebuggerSupport {
+
+    private const val ANDROID_DEBUGGER_CLASS =
+        "com.android.tools.idea.execution.common.debug.AndroidDebugger"
+
+    const val UNAVAILABLE_MESSAGE: String =
+        "Attaching the debugger requires the Android Studio execution tooling, " +
+            "which is not available in this IDE. The app was restarted without a debugger."
+
+    val isAvailable: Boolean by lazy {
+        runCatching {
+            Class.forName(ANDROID_DEBUGGER_CLASS, false, DebuggerSupport::class.java.classLoader)
+        }.isSuccess
+    }
+
+    /**
+     * Attaches the debugger to [packageName] on [device].
+     *
+     * @throws UnsupportedOperationException when the IDE does not ship the Android
+     *   execution tooling. The `Debugger` class is only touched after the availability
+     *   check so that its dependencies are never linked on an IDE that lacks them.
+     */
+    fun attach(project: Project, device: IDevice, packageName: String) {
+        if (!isAvailable) throw UnsupportedOperationException(UNAVAILABLE_MESSAGE)
+        doAttach(project, device, packageName)
+    }
+
+    private fun doAttach(project: Project, device: IDevice, packageName: String) {
+        spock.adb.debugger.Debugger(project, device, packageName).attach()
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -25,8 +25,24 @@
         </ul>
     ]]></description>
 
+    <!--
+      Dependencies deliberately stop at `org.jetbrains.android`.
+
+      Every Android API this plugin uses — ddmlib, AndroidFacet, AndroidModel,
+      AndroidSdkUtils and the execution tooling — ships inside the org.jetbrains.android
+      plugin, not the Android Studio platform. Declaring
+      `com.intellij.modules.androidstudio` therefore bought no API guarantees and only
+      restricted the plugin to Android Studio, which is why the Marketplace reported it as
+      incompatible with IntelliJ IDEA. The single Android Studio specific integration, the
+      debugger attach, is feature-detected at runtime by spock.adb.compat.DebuggerSupport.
+
+      `com.intellij.modules.java` is required for the Java PSI used to navigate to
+      Activity and Fragment sources (JavaPsiFacade, PsiShortNamesCache); it was previously
+      used without being declared.
+    -->
+    <depends>com.intellij.modules.platform</depends>
+    <depends>com.intellij.modules.java</depends>
     <depends>org.jetbrains.android</depends>
-    <depends>com.intellij.modules.androidstudio</depends>
 
     <extensions defaultExtensionNs="com.intellij">
         <applicationService serviceImplementation="spock.adb.AppSettingService"/>

--- a/verifier-ignored-problems.txt
+++ b/verifier-ignored-problems.txt
@@ -1,0 +1,22 @@
+# Plugin Verifier - problems that are known, understood and handled at runtime.
+#
+# Line format is <plugin-id>, <version>, <problem message prefix>, separated by colons.
+# An empty version field applies the rule to every version.
+# Note - comment lines must not contain a colon, the CLI rejects the file if they do.
+#
+# --- com.android.tools.idea.execution.common on IntelliJ IDEA 2023.1 ---
+#
+# "Restart App With Debugger" needs AndroidDebugger and AndroidProcessHandler from the
+# Android Studio execution stack. Those classes are present in every Android Studio build
+# we support and in IntelliJ IDEA 2025.1, but not in the Android plugin bundled with
+# IntelliJ IDEA 2023.1.
+#
+# spock.adb.compat.DebuggerSupport feature-detects the class before the Debugger class is
+# ever loaded, and reports a clear message instead of failing. Every other feature works on
+# IDEA 2023.1, so refusing to load the whole plugin there would cost far more than the one
+# unavailable action. The static reference the verifier sees is therefore intentional, and
+# unreachable when the classes are missing.
+#
+# If DebuggerSupport is removed or its guard weakened, delete this entry and let the
+# verifier fail.
+com.wahdan.com.wahdan.spockAdb::Package 'com.android.tools.idea.execution' is not found


### PR DESCRIPTION
> Stacked on #50. Review that first; this PR's diff is only the compatibility work.

Two compatibility claims in the descriptor were wrong. Both are now **verified by Plugin Verifier** rather than assumed.

## 1. The plugin was needlessly Android Studio only

This is the cause of the Marketplace showing 3.0.0 as **"Non compatible"** with IntelliJ IDEA:

```xml
<depends>com.intellij.modules.androidstudio</depends>
```

It is a hard gate — IDEA refuses to install the plugin regardless of whether the code would run. And it bought nothing. Every Android API used here (ddmlib, `AndroidFacet`, `AndroidModel`, `AndroidSdkUtils`, the execution tooling) ships inside `plugins/android/lib/*.jar` — the `org.jetbrains.android` plugin the descriptor **already** depends on — not the Android Studio platform.

Removed it, and added the two dependencies that were genuinely missing: `com.intellij.modules.platform`, and `com.intellij.modules.java` for the Java PSI used to navigate to sources. The verifier reported the undeclared Java usage as a compatibility problem on *every* target.

## 2. `sinceBuild=231` did not actually work on 231

`sinceBuild` was `231` while compiling against platform `251`. The verifier found two `NoSuchMethodError` risks:

```
Method spock.AdbDrawerViewer.manage(...) contains an *invokespecial* instruction
referencing an unresolved method ToolWindowFactory.manage(...).
This can lead to NoSuchMethodError exception at runtime.

Method spock.AdbDrawerViewer.isApplicableAsync(...) ... unresolved ...
```

`ToolWindowFactory` is a Kotlin interface with default methods, and Kotlin emits *compatibility bridge* overrides that `invokespecial` into every default method the interface had **at compile time**.

`AdbDrawerViewer` is the tool window factory — **the plugin's entry point** — so this was not a corner case: the tool window would fail to open on Android Studio 2023.1 through 2024.x. Fixed with one flag, `-Xjvm-default=all`.

## Verification

Restored `verifyPlugin` and added a CI job. All five targets now report **Compatible**:

| IDE | Version | Before | After |
|---|---|---|---|
| Android Studio | 2023.1.1.28 | 3 problems (2× NoSuchMethodError) | ✅ Compatible |
| Android Studio | 2024.2.1.12 | — | ✅ Compatible |
| Android Studio | 2025.1.1.14 | 1 problem | ✅ Compatible |
| IntelliJ IDEA | 2023.1.5 | blocked by descriptor | ✅ Compatible |
| IntelliJ IDEA | 2025.1 | blocked by descriptor | ✅ Compatible |

`failureLevel` includes `COMPATIBILITY_PROBLEMS`, so regressions break the build.

`Restart App With Debugger` needs the Android Studio execution stack, absent in IDEA 2023.1. Rather than gate the whole plugin on one action, `DebuggerSupport` feature-detects the class **before** `Debugger` is loaded; the action is hidden where unavailable instead of failing with `NoClassDefFoundError`. The corresponding verifier finding is listed in `verifier-ignored-problems.txt` with its justification.

## Also fixed

- **Wrong module in multi-module projects.** Application ID resolution used an arbitrary `AndroidFacet`, so it could resolve a library module or none at all. Now prefers application modules and reads through the stable `AndroidModel` interface instead of the Gradle-specific `GradleAndroidModel`.
- **Misleading error.** An unresolvable application ID was passed through `.toString()`, producing the literal string `"null"` and the error `Application null not installed`.
- Dropped the deprecated `ToolWindowManagerListener.stateChanged()` override and `AndroidVersion.getApiLevel()` call.

`docs/COMPATIBILITY.md` records the supported range, the matrix, and how to change it safely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)