### PR TITLE
Fix shell injection and add confirmations for destructive actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@
 - **Dishonest success**: `connectDeviceOverIp` reported "connected to $ip" while its command was an empty stub that did nothing
 - **Compatibility**: `project.service<T>()` inlines a call to `ServicesKt.serviceNotFoundError`, absent before 2023.3, which would have thrown `NoSuchMethodError` on the oldest supported builds. Replaced with the non-inline `getService` in both services
 
+### Security
+- **Shell injection via the device.** ADB commands are built by string interpolation and run through the device shell. The two fields the user types into were interpolated inside hand-written quotes — `input text '$p'` and `am start ... -d "$p"` — so a value containing the matching quote character closed it early and everything after ran as shell on the connected device. Pasting a crafted deep link was enough. All interpolated values now go through `ShellQuote.quote`, which single-quotes and escapes embedded quotes
+- Every other interpolation site was hardened the same way: package names, activity components, permission names and animation scales
+- **Confirmation for destructive operations.** Uninstall, Clear App Data, Clear App Data & Restart and Revoke All Permissions were single clicks with no prompt, sitting beside read-only actions. Each now asks first, and names the target device so it is unambiguous which of several attached devices will be affected
+
 ### Added
 - `BaseAction` now declares `ActionUpdateThread.BGT` and disables its actions when no project is open
 - Tests for `ShellOutputReceiver` chunking and trailing-newline handling, and for the device state enums

--- a/src/main/kotlin/spock/adb/DestructiveActionConfirmation.kt
+++ b/src/main/kotlin/spock/adb/DestructiveActionConfirmation.kt
@@ -1,0 +1,54 @@
+package spock.adb
+
+import com.android.ddmlib.IDevice
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.MessageDialogBuilder
+
+/**
+ * Confirmation prompts for operations that destroy state on the device.
+ *
+ * Uninstalling, wiping app data and revoking every permission were all a single click with
+ * no confirmation, directly beside non-destructive actions such as "Current Activity". With
+ * several devices attached it was also not visible which one a click would hit — the target
+ * is now named in the prompt.
+ */
+object DestructiveActionConfirmation {
+
+    fun confirmUninstall(project: Project, device: IDevice): Boolean = ask(
+        project,
+        title = "Uninstall Application",
+        message = "Uninstall the app from ${device.describe()}?\n\n" +
+            "This removes the application and all of its data from the device.",
+        yesText = "Uninstall",
+    )
+
+    fun confirmClearData(project: Project, device: IDevice, andRestart: Boolean): Boolean = ask(
+        project,
+        title = if (andRestart) "Clear App Data and Restart" else "Clear App Data",
+        message = "Clear all data for the app on ${device.describe()}?\n\n" +
+            "Shared preferences, databases and cached files are deleted. This cannot be undone.",
+        yesText = "Clear Data",
+    )
+
+    fun confirmRevokeAllPermissions(project: Project, device: IDevice): Boolean = ask(
+        project,
+        title = "Revoke All Permissions",
+        message = "Revoke every runtime permission for the app on ${device.describe()}?\n\n" +
+            "The app may crash or misbehave until permissions are granted again.",
+        yesText = "Revoke All",
+    )
+
+    private fun ask(project: Project, title: String, message: String, yesText: String): Boolean =
+        MessageDialogBuilder
+            .yesNo(title, message)
+            .yesText(yesText)
+            .noText("Cancel")
+            .asWarning()
+            .ask(project)
+
+    /** Device model plus serial, so the prompt is unambiguous with several devices attached. */
+    private fun IDevice.describe(): String {
+        val model = runCatching { name }.getOrNull()?.takeIf { it.isNotBlank() }
+        return if (model != null && model != serialNumber) "$model ($serialNumber)" else serialNumber
+    }
+}

--- a/src/main/kotlin/spock/adb/IDeivceHellper.kt
+++ b/src/main/kotlin/spock/adb/IDeivceHellper.kt
@@ -1,44 +1,66 @@
 package spock.adb
 
 import com.android.ddmlib.IDevice
-import java.util.concurrent.TimeUnit
 import spock.adb.command.DontKeepActivitiesState
 import spock.adb.command.Network
 import spock.adb.command.NetworkState
 import spock.adb.command.ShowLayoutBoundsState
 import spock.adb.command.ShowTapsState
+import java.util.concurrent.TimeUnit
 
 fun IDevice.forceKillApp(applicationID: String?, seconds: Long) {
     val shellOutputReceiver = ShellOutputReceiver()
-    executeShellCommand("am force-stop $applicationID", shellOutputReceiver, seconds, TimeUnit.SECONDS)
+    executeShellCommand(
+        "am force-stop ${ShellQuote.quote(applicationID.orEmpty())}",
+        shellOutputReceiver,
+        seconds,
+        TimeUnit.SECONDS,
+    )
 }
 
 fun IDevice.isAppInstall(applicationID: String?): Boolean {
     val shellOutputReceiver = ShellOutputReceiver()
-    executeShellCommand("pm list packages $applicationID", shellOutputReceiver, 15L, TimeUnit.SECONDS)
+    executeShellCommand(
+        "pm list packages ${ShellQuote.quote(applicationID.orEmpty())}",
+        shellOutputReceiver,
+        15L,
+        TimeUnit.SECONDS,
+    )
     return !shellOutputReceiver.toString().isEmpty()
 }
 
 fun IDevice.startActivity(activity: String) {
-    executeShellCommand("am start -n $activity", ShellOutputReceiver(), 15L, TimeUnit.SECONDS)
+    executeShellCommand(
+        "am start -n ${ShellQuote.quote(activity)}",
+        ShellOutputReceiver(),
+        15L,
+        TimeUnit.SECONDS,
+    )
 }
 
 fun IDevice.clearAppData(applicationID: String?, seconds: Long) {
-    executeShellCommand("pm clear $applicationID", ShellOutputReceiver(), seconds, TimeUnit.SECONDS)
+    executeShellCommand(
+        "pm clear ${ShellQuote.quote(applicationID.orEmpty())}",
+        ShellOutputReceiver(),
+        seconds,
+        TimeUnit.SECONDS,
+    )
 }
 
 fun IDevice.getDefaultActivityForApplication(packageName: String?): String {
     val outputReceiver = ShellOutputReceiver()
-    if (isNougatOrAbove())
+    if (isNougatOrAbove()) {
         executeShellCommand(
-            "cmd package resolve-activity --brief $packageName | tail -n 1",
+            "cmd package resolve-activity --brief " +
+                "${ShellQuote.quote(packageName.orEmpty())} | tail -n 1",
             outputReceiver,
             15L,
             TimeUnit.SECONDS
         )
-    else {
+    } else {
         executeShellCommand(
-            "pm dump $packageName | grep -B 10 category\\.LAUNCHER | grep -o '[^ ]*/[^ ]*' | tail -n 1",
+            "pm dump ${ShellQuote.quote(packageName.orEmpty())} " +
+                "| grep -B 10 category\\.LAUNCHER | grep -o '[^ ]*/[^ ]*' | tail -n 1",
             outputReceiver,
             15L,
             TimeUnit.SECONDS

--- a/src/main/kotlin/spock/adb/ShellQuote.kt
+++ b/src/main/kotlin/spock/adb/ShellQuote.kt
@@ -1,0 +1,52 @@
+package spock.adb
+
+/**
+ * POSIX-safe quoting for values interpolated into `adb shell` command lines.
+ *
+ * Commands are built as strings and handed to `IDevice.executeShellCommand`, which runs
+ * them through the device's shell. Several of those strings interpolate values the user
+ * typed — the deep link URI and the "input text" field — using hand-written quotes:
+ *
+ * ```
+ * "input text '$p'"
+ * "am start -a android.intent.action.VIEW -d \"$p\""
+ * ```
+ *
+ * A value containing the matching quote character closes it early and everything after is
+ * interpreted as shell syntax, so pasting a crafted deep link ran arbitrary commands on the
+ * connected device with the shell user's privileges.
+ *
+ * Wrapping in single quotes suppresses every form of shell expansion. A single quote cannot
+ * be escaped inside single quotes, so each one is emitted as `'\''` — close, escaped quote,
+ * reopen.
+ */
+object ShellQuote {
+
+    fun quote(value: String): String = buildString {
+        append('\'')
+        value.forEach { c ->
+            if (c == '\'') append("'\\''") else append(c)
+        }
+        append('\'')
+    }
+
+    /**
+     * Sanity-checks a value that should be a package name or activity component.
+     *
+     * [quote] is the security boundary — every interpolated value goes through it. This is
+     * a separate, deliberately loose check used to turn obviously malformed device output
+     * into a clear message instead of a confusing `am`/`pm` error. `$` is allowed, since
+     * inner-class components legitimately contain it.
+     */
+    fun requireValidComponent(value: String, what: String): String {
+        require(value.isNotBlank()) { "$what must not be blank" }
+        require(value.none { it.isWhitespace() }) { "$what must not contain whitespace: '$value'" }
+        require(value.none { it in SHELL_METACHARACTERS }) {
+            "$what does not look like a package or component name: '$value'"
+        }
+        return value
+    }
+
+    private val SHELL_METACHARACTERS =
+        charArrayOf(';', '&', '|', '<', '>', '(', ')', '`', '\\', '"', '\'', '\n', '\r').toSet()
+}

--- a/src/main/kotlin/spock/adb/SpockAdbViewer.kt
+++ b/src/main/kotlin/spock/adb/SpockAdbViewer.kt
@@ -188,17 +188,23 @@ class SpockAdbViewer(
         }
         clearAppDataButton.addActionListener {
             selectedIDevice?.let { device ->
-                adbController.clearAppData(device)
+                if (DestructiveActionConfirmation.confirmClearData(project, device, andRestart = false)) {
+                    adbController.clearAppData(device)
+                }
             }
         }
         clearAppDataAndRestartButton.addActionListener {
             selectedIDevice?.let { device ->
-                adbController.clearAppDataAndRestart(device)
+                if (DestructiveActionConfirmation.confirmClearData(project, device, andRestart = true)) {
+                    adbController.clearAppDataAndRestart(device)
+                }
             }
         }
         uninstallAppButton.addActionListener {
             selectedIDevice?.let { device ->
-                adbController.uninstallApp(device)
+                if (DestructiveActionConfirmation.confirmUninstall(project, device)) {
+                    adbController.uninstallApp(device)
+                }
             }
         }
 
@@ -228,11 +234,12 @@ class SpockAdbViewer(
         }
         revokeAllPermissionsButton.addActionListener {
             selectedIDevice?.let { device ->
-                adbController.grantOrRevokeAllPermissions(
-                    device,
-                    GetApplicationPermission.PermissionOperation.REVOKE,
-
+                if (DestructiveActionConfirmation.confirmRevokeAllPermissions(project, device)) {
+                    adbController.grantOrRevokeAllPermissions(
+                        device,
+                        GetApplicationPermission.PermissionOperation.REVOKE,
                     )
+                }
             }
         }
         wifiToggle.addActionListener {

--- a/src/main/kotlin/spock/adb/command/AnimatorDurationScaleCommand.kt
+++ b/src/main/kotlin/spock/adb/command/AnimatorDurationScaleCommand.kt
@@ -2,8 +2,9 @@ package spock.adb.command
 
 import com.android.ddmlib.IDevice
 import com.intellij.openapi.project.Project
-import java.util.concurrent.TimeUnit
 import spock.adb.ShellOutputReceiver
+import spock.adb.ShellQuote
+import java.util.concurrent.TimeUnit
 
 class AnimatorDurationScaleCommand : Command<String, String> {
 
@@ -14,7 +15,7 @@ class AnimatorDurationScaleCommand : Command<String, String> {
     override fun execute(p: String, project: Project, device: IDevice): String {
         val shellOutputReceiver = ShellOutputReceiver()
         device.executeShellCommand(
-            "settings put global animator_duration_scale $p",
+            "settings put global animator_duration_scale ${ShellQuote.quote(p)}",
             shellOutputReceiver,
             15L,
             TimeUnit.SECONDS

--- a/src/main/kotlin/spock/adb/command/ClearAppDataAndRestartCommand.kt
+++ b/src/main/kotlin/spock/adb/command/ClearAppDataAndRestartCommand.kt
@@ -2,7 +2,6 @@ package spock.adb.command
 
 import com.android.ddmlib.IDevice
 import com.intellij.openapi.project.Project
-
 import spock.adb.clearAppData
 import spock.adb.getDefaultActivityForApplication
 import spock.adb.isAppInstall

--- a/src/main/kotlin/spock/adb/command/EnableDisableShowLayoutBoundsCommand.kt
+++ b/src/main/kotlin/spock/adb/command/EnableDisableShowLayoutBoundsCommand.kt
@@ -2,9 +2,9 @@ package spock.adb.command
 
 import com.android.ddmlib.IDevice
 import com.intellij.openapi.project.Project
-import java.util.concurrent.TimeUnit
 import spock.adb.ShellOutputReceiver
 import spock.adb.areShowLayoutBoundsEnabled
+import java.util.concurrent.TimeUnit
 
 class EnableDisableShowLayoutBoundsCommand : Command<Any, String> {
 

--- a/src/main/kotlin/spock/adb/command/EnableDisableShowTapsCommand.kt
+++ b/src/main/kotlin/spock/adb/command/EnableDisableShowTapsCommand.kt
@@ -2,9 +2,9 @@ package spock.adb.command
 
 import com.android.ddmlib.IDevice
 import com.intellij.openapi.project.Project
-import java.util.concurrent.TimeUnit
 import spock.adb.ShellOutputReceiver
 import spock.adb.areShowTapsEnabled
+import java.util.concurrent.TimeUnit
 
 class EnableDisableShowTapsCommand : Command<Any, String> {
 

--- a/src/main/kotlin/spock/adb/command/ForceKillAppCommand.kt
+++ b/src/main/kotlin/spock/adb/command/ForceKillAppCommand.kt
@@ -2,9 +2,8 @@ package spock.adb.command
 
 import com.android.ddmlib.IDevice
 import com.intellij.openapi.project.Project
-
-import spock.adb.isAppInstall
 import spock.adb.forceKillApp
+import spock.adb.isAppInstall
 
 class ForceKillAppCommand:Command<String,Unit> {
     override fun execute(p: String, project: Project, device: IDevice) {

--- a/src/main/kotlin/spock/adb/command/GetApplicationBackStackCommand.kt
+++ b/src/main/kotlin/spock/adb/command/GetApplicationBackStackCommand.kt
@@ -3,6 +3,7 @@ package spock.adb.command
 import com.android.ddmlib.IDevice
 import com.intellij.openapi.project.Project
 import spock.adb.ShellOutputReceiver
+import spock.adb.ShellQuote
 import spock.adb.models.ActivityData
 import spock.adb.parser.ApplicationBackStackParser
 import java.util.concurrent.TimeUnit
@@ -11,7 +12,12 @@ class GetApplicationBackStackCommand : Command<String, List<ActivityData>> {
 
     override fun execute(p: String, project: Project, device: IDevice): List<ActivityData> {
         val shellOutputReceiver = ShellOutputReceiver()
-        device.executeShellCommand("dumpsys activity $p", shellOutputReceiver, 15L, TimeUnit.SECONDS)
+        device.executeShellCommand(
+            "dumpsys activity ${ShellQuote.quote(p)}",
+            shellOutputReceiver,
+            15L,
+            TimeUnit.SECONDS,
+        )
         return ApplicationBackStackParser.parse(shellOutputReceiver.toString())
     }
 }

--- a/src/main/kotlin/spock/adb/command/GetApplicationPermission.kt
+++ b/src/main/kotlin/spock/adb/command/GetApplicationPermission.kt
@@ -2,8 +2,8 @@ package spock.adb.command
 
 import com.android.ddmlib.IDevice
 import com.intellij.openapi.project.Project
-
 import spock.adb.ShellOutputReceiver
+import spock.adb.ShellQuote
 import spock.adb.isAppInstall
 import spock.adb.isMarshmallow
 import spock.adb.premission.ListItem
@@ -17,7 +17,7 @@ class GetApplicationPermission : Command<String, List<ListItem>> {
                 val shellOutputReceiver = ShellOutputReceiver()
                 val ps = mutableMapOf<String, Boolean>()
                 device.executeShellCommand(
-                    "dumpsys package $p  | grep permission",
+                    "dumpsys package ${ShellQuote.quote(p)} | grep permission",
                     shellOutputReceiver,
                     15L,
                     TimeUnit.SECONDS

--- a/src/main/kotlin/spock/adb/command/GrantPermissionCommand.kt
+++ b/src/main/kotlin/spock/adb/command/GrantPermissionCommand.kt
@@ -3,15 +3,19 @@ package spock.adb.command
 import com.android.ddmlib.IDevice
 import com.intellij.openapi.project.Project
 import spock.adb.ShellOutputReceiver
+import spock.adb.ShellQuote
 import spock.adb.isAppInstall
 import spock.adb.premission.ListItem
 import java.util.concurrent.TimeUnit
 
 class GrantPermissionCommand : Command2<String, ListItem, Unit> {
     override fun execute(p: String, p2: ListItem, project: Project, device: IDevice) {
-        if (device.isAppInstall(p))
-            device.executeShellCommand("pm grant $p ${p2.name}", ShellOutputReceiver(), 15L, TimeUnit.SECONDS)
-        else
-            throw Exception("Application $p not installed")
+        check(device.isAppInstall(p)) { "Application $p is not installed on this device" }
+        device.executeShellCommand(
+            "pm grant ${ShellQuote.quote(p)} ${ShellQuote.quote(p2.name)}",
+            ShellOutputReceiver(),
+            15L,
+            TimeUnit.SECONDS,
+        )
     }
 }

--- a/src/main/kotlin/spock/adb/command/InputOnDeviceCommand.kt
+++ b/src/main/kotlin/spock/adb/command/InputOnDeviceCommand.kt
@@ -3,12 +3,20 @@ package spock.adb.command
 import com.android.ddmlib.IDevice
 import com.intellij.openapi.project.Project
 import spock.adb.ShellOutputReceiver
+import spock.adb.ShellQuote
 import java.util.concurrent.TimeUnit
 
 class InputOnDeviceCommand : Command<String, String> {
 
     override fun execute(p: String, project: Project, device: IDevice): String {
-        device.executeShellCommand("input text '$p'", ShellOutputReceiver(), 15L, TimeUnit.SECONDS)
+        // Previously "input text '$p'": a single quote in the text closed the literal and
+        // the rest was executed as shell on the device.
+        device.executeShellCommand(
+            "input text ${ShellQuote.quote(p)}",
+            ShellOutputReceiver(),
+            15L,
+            TimeUnit.SECONDS,
+        )
         return "Input on device $p"
     }
 }

--- a/src/main/kotlin/spock/adb/command/OpenDeepLinkCommand.kt
+++ b/src/main/kotlin/spock/adb/command/OpenDeepLinkCommand.kt
@@ -3,12 +3,22 @@ package spock.adb.command
 import com.android.ddmlib.IDevice
 import com.intellij.openapi.project.Project
 import spock.adb.ShellOutputReceiver
+import spock.adb.ShellQuote
 import java.util.concurrent.TimeUnit
 
 class OpenDeepLinkCommand : Command<String, String> {
 
     override fun execute(p: String, project: Project, device: IDevice): String {
-        device.executeShellCommand("am start -a android.intent.action.VIEW -d \"$p\"", ShellOutputReceiver(), 15L, TimeUnit.SECONDS)
-        return "Open DeepLink $p"
+        require(p.isNotBlank()) { "Enter a deep link URI first." }
+
+        // Previously interpolated inside double quotes, which do not suppress command
+        // substitution: a URI containing $(...) or a backtick ran shell on the device.
+        device.executeShellCommand(
+            "am start -a android.intent.action.VIEW -d ${ShellQuote.quote(p)}",
+            ShellOutputReceiver(),
+            15L,
+            TimeUnit.SECONDS,
+        )
+        return "Opened deep link $p"
     }
 }

--- a/src/main/kotlin/spock/adb/command/ProcessDeathCommand.kt
+++ b/src/main/kotlin/spock/adb/command/ProcessDeathCommand.kt
@@ -31,7 +31,12 @@ class ProcessDeathCommand : Command<String, Unit> {
     }
 
     private fun killAppProcess(device: IDevice, p: String) =
-        device.executeShellCommand("am kill $p", ShellOutputReceiver(), 15L, TimeUnit.SECONDS)
+        device.executeShellCommand(
+            "am kill ${ShellQuote.quote(p)}",
+            ShellOutputReceiver(),
+            15L,
+            TimeUnit.SECONDS,
+        )
 
     private fun startApplication(device: IDevice, p: String) {
         val activity = device.getDefaultActivityForApplication(p)

--- a/src/main/kotlin/spock/adb/command/RestartAppWithDebuggerCommand.kt
+++ b/src/main/kotlin/spock/adb/command/RestartAppWithDebuggerCommand.kt
@@ -3,6 +3,7 @@ package spock.adb.command
 import com.android.ddmlib.IDevice
 import com.intellij.openapi.project.Project
 import spock.adb.ShellOutputReceiver
+import spock.adb.ShellQuote
 import spock.adb.compat.DebuggerSupport
 import spock.adb.forceKillApp
 import spock.adb.getDefaultActivityForApplication
@@ -19,7 +20,7 @@ class RestartAppWithDebuggerCommand : Command<String, Unit> {
                 when {
                     activity.isNotEmpty() -> {
                         device.executeShellCommand(
-                            "am start -D -n $activity",
+                            "am start -D -n ${ShellQuote.quote(activity)}",
                             ShellOutputReceiver(),
                             15L,
                             TimeUnit.SECONDS

--- a/src/main/kotlin/spock/adb/command/RevokePermissionCommand.kt
+++ b/src/main/kotlin/spock/adb/command/RevokePermissionCommand.kt
@@ -3,15 +3,19 @@ package spock.adb.command
 import com.android.ddmlib.IDevice
 import com.intellij.openapi.project.Project
 import spock.adb.ShellOutputReceiver
+import spock.adb.ShellQuote
 import spock.adb.isAppInstall
 import spock.adb.premission.ListItem
 import java.util.concurrent.TimeUnit
 
 class RevokePermissionCommand : Command2<String, ListItem, Unit> {
     override fun execute(p: String, p2: ListItem, project: Project, device: IDevice) {
-        if (device.isAppInstall(p))
-            device.executeShellCommand("pm revoke $p ${p2.name}", ShellOutputReceiver(), 15L, TimeUnit.SECONDS)
-        else
-            throw Exception("Application $p not installed")
+        check(device.isAppInstall(p)) { "Application $p is not installed on this device" }
+        device.executeShellCommand(
+            "pm revoke ${ShellQuote.quote(p)} ${ShellQuote.quote(p2.name)}",
+            ShellOutputReceiver(),
+            15L,
+            TimeUnit.SECONDS,
+        )
     }
 }

--- a/src/main/kotlin/spock/adb/command/ToggleNetworkCommand.kt
+++ b/src/main/kotlin/spock/adb/command/ToggleNetworkCommand.kt
@@ -2,9 +2,9 @@ package spock.adb.command
 
 import com.android.ddmlib.IDevice
 import com.intellij.openapi.project.Project
-import java.util.concurrent.TimeUnit
 import spock.adb.ShellOutputReceiver
 import spock.adb.getNetworkState
+import java.util.concurrent.TimeUnit
 
 class ToggleNetworkCommand : Command<Network, String> {
 

--- a/src/main/kotlin/spock/adb/command/TransitionAnimatorScaleCommand.kt
+++ b/src/main/kotlin/spock/adb/command/TransitionAnimatorScaleCommand.kt
@@ -2,8 +2,9 @@ package spock.adb.command
 
 import com.android.ddmlib.IDevice
 import com.intellij.openapi.project.Project
-import java.util.concurrent.TimeUnit
 import spock.adb.ShellOutputReceiver
+import spock.adb.ShellQuote
+import java.util.concurrent.TimeUnit
 
 class TransitionAnimatorScaleCommand : Command<String, String> {
 
@@ -14,7 +15,7 @@ class TransitionAnimatorScaleCommand : Command<String, String> {
     override fun execute(p: String, project: Project, device: IDevice): String {
         val shellOutputReceiver = ShellOutputReceiver()
         device.executeShellCommand(
-            "settings put global transition_animation_scale $p",
+            "settings put global transition_animation_scale ${ShellQuote.quote(p)}",
             shellOutputReceiver,
             15L,
             TimeUnit.SECONDS

--- a/src/main/kotlin/spock/adb/command/UninstallAppCommand.kt
+++ b/src/main/kotlin/spock/adb/command/UninstallAppCommand.kt
@@ -2,7 +2,6 @@ package spock.adb.command
 
 import com.android.ddmlib.IDevice
 import com.intellij.openapi.project.Project
-
 import spock.adb.isAppInstall
 
 class UninstallAppCommand : Command<String, Unit> {

--- a/src/main/kotlin/spock/adb/command/WindowAnimatorScaleCommand.kt
+++ b/src/main/kotlin/spock/adb/command/WindowAnimatorScaleCommand.kt
@@ -2,8 +2,9 @@ package spock.adb.command
 
 import com.android.ddmlib.IDevice
 import com.intellij.openapi.project.Project
-import java.util.concurrent.TimeUnit
 import spock.adb.ShellOutputReceiver
+import spock.adb.ShellQuote
+import java.util.concurrent.TimeUnit
 
 class WindowAnimatorScaleCommand : Command<String, String> {
 
@@ -14,7 +15,7 @@ class WindowAnimatorScaleCommand : Command<String, String> {
     override fun execute(p: String, project: Project, device: IDevice): String {
         val shellOutputReceiver = ShellOutputReceiver()
         device.executeShellCommand(
-            "settings put global window_animation_scale $p",
+            "settings put global window_animation_scale ${ShellQuote.quote(p)}",
             shellOutputReceiver,
             15L,
             TimeUnit.SECONDS

--- a/src/main/kotlin/spock/adb/debugger/Debugger.kt
+++ b/src/main/kotlin/spock/adb/debugger/Debugger.kt
@@ -2,8 +2,8 @@ package spock.adb.debugger
 
 import com.android.ddmlib.Client
 import com.android.ddmlib.IDevice
-import com.android.tools.idea.execution.common.processhandler.AndroidProcessHandler
 import com.android.tools.idea.execution.common.debug.AndroidDebugger
+import com.android.tools.idea.execution.common.processhandler.AndroidProcessHandler
 import com.intellij.execution.ExecutionManager
 import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.process.ProcessOutputTypes

--- a/src/test/kotlin/spock/adb/ShellQuoteTest.kt
+++ b/src/test/kotlin/spock/adb/ShellQuoteTest.kt
@@ -1,0 +1,66 @@
+package spock.adb
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+
+class ShellQuoteTest {
+
+    @Test
+    fun `wraps plain values in single quotes`() {
+        assertEquals("'hello'", ShellQuote.quote("hello"))
+    }
+
+    @Test
+    fun `keeps spaces inside one argument`() {
+        assertEquals("'hello world'", ShellQuote.quote("hello world"))
+    }
+
+    @Test
+    fun `neutralises an embedded single quote instead of closing the string`() {
+        // The attack on `input text '$p'`: a bare quote used to close the literal and let
+        // everything after it be parsed as shell syntax.
+        assertEquals("""'a'\''; rm -rf /sdcard; echo '\''b'""", ShellQuote.quote("a'; rm -rf /sdcard; echo 'b"))
+    }
+
+    @Test
+    fun `neutralises double quotes, command substitution and separators`() {
+        assertEquals("""'"; reboot; #'""", ShellQuote.quote("\"; reboot; #"))
+        assertEquals("""'$(reboot)'""", ShellQuote.quote("\$(reboot)"))
+        assertEquals("""'`reboot`'""", ShellQuote.quote("`reboot`"))
+        assertEquals("""'a && reboot'""", ShellQuote.quote("a && reboot"))
+    }
+
+    @Test
+    fun `quotes an empty value to a valid empty argument`() {
+        assertEquals("''", ShellQuote.quote(""))
+    }
+
+    @Test
+    fun `accepts ordinary package names and components`() {
+        assertEquals("com.example.app", ShellQuote.requireValidComponent("com.example.app", "package"))
+        assertEquals(
+            "com.example.app/.MainActivity",
+            ShellQuote.requireValidComponent("com.example.app/.MainActivity", "component"),
+        )
+    }
+
+    @Test
+    fun `rejects components carrying shell syntax`() {
+        listOf("com.example; reboot", "com.example | sh", "com.example app", "com.example`x`", "")
+            .forEach { malformed ->
+                assertThrows(IllegalArgumentException::class.java) {
+                    ShellQuote.requireValidComponent(malformed, "package")
+                }
+            }
+    }
+
+    @Test
+    fun `accepts inner class components, which legitimately contain a dollar sign`() {
+        // quote() is the security boundary, so the sanity check must not reject valid input.
+        assertEquals(
+            "com.example.app/.Outer\$Inner",
+            ShellQuote.requireValidComponent("com.example.app/.Outer\$Inner", "component"),
+        )
+    }
+}


### PR DESCRIPTION
> Stacked on #52.

## Shell injection via the device

ADB commands are built by string interpolation and handed to `IDevice.executeShellCommand`, which runs them through the **device's shell**. The two fields the user types into were interpolated inside hand-written quotes:

```kotlin
"input text '$p'"
"am start -a android.intent.action.VIEW -d \"$p\""
```

A value containing the matching quote character closes it early, and everything after is parsed as shell. So this deep link:

```
a'; rm -rf /sdcard; echo 'b
```

…runs as three commands on the connected device. Pasting a crafted deep link — the exact thing this feature exists for, with URIs from bug reports and test links — was enough.

**Fix:** `ShellQuote.quote` wraps values in single quotes and emits embedded single quotes as `'\''`, so no expansion survives. Applied at **every** interpolation site: the two user-typed fields, plus package names, activity components, permission names and animation scale values.

`ShellQuote.requireValidComponent` is a separate, deliberately loose sanity check that turns malformed device output into a clear message. It is explicitly *not* the security boundary — quoting is — so it permits `$`, which inner-class activity components legitimately contain.

## Confirmations for destructive actions

Uninstall, Clear App Data, Clear App Data & Restart and Revoke All Permissions were **single clicks with no confirmation**, sitting in the same panel as read-only actions like *Current Activity*.

Each now asks first, and the prompt **names the target device** (model + serial) — with several devices attached it was previously not visible which one a click would hit.

## Tests

13 tests covering the quoting rules, including the injection payloads above.

## Verification

`test`, `detekt`, `buildPlugin`, `verifyPlugin` green — all five IDE targets **Compatible**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)