### PR TITLE
Add device abstraction with metadata, state and persisted selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,14 @@
 - **Dishonest success**: `connectDeviceOverIp` reported "connected to $ip" while its command was an empty stub that did nothing
 - **Compatibility**: `project.service<T>()` inlines a call to `ServicesKt.serviceNotFoundError`, absent before 2023.3, which would have thrown `NoSuchMethodError` on the oldest supported builds. Replaced with the non-inline `getService` in both services
 
+### Device management
+- The device dropdown now shows model, Android version, API level, architecture, and whether the device is an emulator or a handset, instead of just the raw ddmlib name. Offline, unauthorized and bootloader devices are labelled as such
+- **The selected device is persisted between sessions.** `AppSetting.selectedDevice` has existed since settings were introduced but was never read or written
+- Menu actions now ignore devices that cannot accept commands, and say why when none are usable (for example "Pixel 7 is unauthorized"), rather than failing part-way through a command
+- When no device was previously selected the plugin now prefers an online device rather than whichever happened to be first
+- Device metadata is read on a background thread; `IDevice.getProperty` blocks, so this must never happen while the dropdown is being rendered
+- Confirmation prompts name the target device, so it is unambiguous which of several attached devices an action will affect
+
 ### Security
 - **Shell injection via the device.** ADB commands are built by string interpolation and run through the device shell. The two fields the user types into were interpolated inside hand-written quotes — `input text '$p'` and `am start ... -d "$p"` — so a value containing the matching quote character closed it early and everything after ran as shell on the connected device. Pasting a crafted deep link was enough. All interpolated values now go through `ShellQuote.quote`, which single-quotes and escapes embedded quotes
 - Every other interpolation site was hardened the same way: package names, activity components, permission names and animation scales

--- a/detekt-config.yml
+++ b/detekt-config.yml
@@ -4,3 +4,8 @@
 formatting:
   Indentation:
     active: false
+
+complexity:
+  LongParameterList:
+    # Test fixture builders legitimately mirror the shape of the data class under test.
+    excludes: ['**/test/**']

--- a/src/main/kotlin/spock/adb/AdbController.kt
+++ b/src/main/kotlin/spock/adb/AdbController.kt
@@ -3,13 +3,14 @@ package spock.adb
 import com.android.ddmlib.IDevice
 import spock.adb.command.GetApplicationPermission
 import spock.adb.command.Network
+import spock.adb.device.ConnectedDevice
 import spock.adb.premission.ListItem
 
 interface AdbController {
     fun refresh()
 
-    /** Reads the device list once. [block] is invoked on the EDT. */
-    fun connectedDevices(block: (devices: List<IDevice>) -> Unit)
+    /** Reads the device list once, with metadata resolved. [block] is invoked on the EDT. */
+    fun connectedDevices(block: (devices: List<ConnectedDevice>) -> Unit)
 
     /**
      * Subscribes to the device list: [block] is invoked on the EDT with the current devices
@@ -17,7 +18,7 @@ interface AdbController {
      * supported, which is the tool window; menu actions use [connectedDevices] instead so
      * they do not replace it.
      */
-    fun observeDevices(block: (devices: List<IDevice>) -> Unit)
+    fun observeDevices(block: (devices: List<ConnectedDevice>) -> Unit)
     fun currentBackStack(device: IDevice)
     fun currentApplicationBackStack(device: IDevice)
     fun currentActivity(device: IDevice)

--- a/src/main/kotlin/spock/adb/AdbControllerImp.kt
+++ b/src/main/kotlin/spock/adb/AdbControllerImp.kt
@@ -13,6 +13,8 @@ import com.intellij.ui.components.JBLabel
 import com.intellij.util.ui.JBUI
 import org.jetbrains.android.sdk.AndroidSdkUtils
 import spock.adb.command.*
+import spock.adb.device.ConnectedDevice
+import spock.adb.device.DeviceInfoReader
 import spock.adb.models.ActivityData
 import spock.adb.models.BackStackData
 import spock.adb.models.FragmentData
@@ -37,17 +39,24 @@ class AdbControllerImp(
     private val log = Logger.getInstance(AdbControllerImp::class.java)
 
     @Volatile
-    private var updateDeviceList: ((List<IDevice>) -> Unit)? = null
+    private var updateDeviceList: ((List<ConnectedDevice>) -> Unit)? = null
 
     init {
         AndroidDebugBridge.addDeviceChangeListener(this)
     }
 
-    private fun devices(): List<IDevice> =
+    /**
+     * Reads the device list and resolves each device's metadata.
+     *
+     * Runs on a pooled thread: `IDevice.getProperty` blocks, so the UI must never do this
+     * itself while rendering the device dropdown.
+     */
+    private fun devices(): List<ConnectedDevice> =
         runCatching { debugBridgeProvider()?.devices?.toList() }
             .onFailure { log.warn("Could not read the connected device list from ADB", it) }
             .getOrNull()
             .orEmpty()
+            .map { ConnectedDevice(it, DeviceInfoReader.read(it)) }
 
     /** Device-change callbacks arrive on ddmlib threads; the listener updates Swing. */
     private fun publishDeviceList() {
@@ -84,14 +93,14 @@ class AdbControllerImp(
      * on the EDT and — for the connect/disconnect callbacks below — that Swing models were
      * mutated from a ddmlib thread.
      */
-    override fun connectedDevices(block: (devices: List<IDevice>) -> Unit) {
+    override fun connectedDevices(block: (devices: List<ConnectedDevice>) -> Unit) {
         ApplicationManager.getApplication().executeOnPooledThread {
             val devices = devices()
             onEdt { block(devices) }
         }
     }
 
-    override fun observeDevices(block: (devices: List<IDevice>) -> Unit) {
+    override fun observeDevices(block: (devices: List<ConnectedDevice>) -> Unit) {
         updateDeviceList = block
         connectedDevices(block)
     }

--- a/src/main/kotlin/spock/adb/DestructiveActionConfirmation.kt
+++ b/src/main/kotlin/spock/adb/DestructiveActionConfirmation.kt
@@ -1,8 +1,8 @@
 package spock.adb
 
-import com.android.ddmlib.IDevice
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.MessageDialogBuilder
+import spock.adb.device.DeviceInfo
 
 /**
  * Confirmation prompts for operations that destroy state on the device.
@@ -14,7 +14,7 @@ import com.intellij.openapi.ui.MessageDialogBuilder
  */
 object DestructiveActionConfirmation {
 
-    fun confirmUninstall(project: Project, device: IDevice): Boolean = ask(
+    fun confirmUninstall(project: Project, device: DeviceInfo): Boolean = ask(
         project,
         title = "Uninstall Application",
         message = "Uninstall the app from ${device.describe()}?\n\n" +
@@ -22,7 +22,7 @@ object DestructiveActionConfirmation {
         yesText = "Uninstall",
     )
 
-    fun confirmClearData(project: Project, device: IDevice, andRestart: Boolean): Boolean = ask(
+    fun confirmClearData(project: Project, device: DeviceInfo, andRestart: Boolean): Boolean = ask(
         project,
         title = if (andRestart) "Clear App Data and Restart" else "Clear App Data",
         message = "Clear all data for the app on ${device.describe()}?\n\n" +
@@ -30,7 +30,7 @@ object DestructiveActionConfirmation {
         yesText = "Clear Data",
     )
 
-    fun confirmRevokeAllPermissions(project: Project, device: IDevice): Boolean = ask(
+    fun confirmRevokeAllPermissions(project: Project, device: DeviceInfo): Boolean = ask(
         project,
         title = "Revoke All Permissions",
         message = "Revoke every runtime permission for the app on ${device.describe()}?\n\n" +
@@ -45,10 +45,4 @@ object DestructiveActionConfirmation {
             .noText("Cancel")
             .asWarning()
             .ask(project)
-
-    /** Device model plus serial, so the prompt is unambiguous with several devices attached. */
-    private fun IDevice.describe(): String {
-        val model = runCatching { name }.getOrNull()?.takeIf { it.isNotBlank() }
-        return if (model != null && model != serialNumber) "$model ($serialNumber)" else serialNumber
-    }
 }

--- a/src/main/kotlin/spock/adb/SpockAdbViewer.kt
+++ b/src/main/kotlin/spock/adb/SpockAdbViewer.kt
@@ -9,6 +9,7 @@ import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.openapi.wm.ex.ToolWindowManagerListener
 import spock.adb.command.*
 import spock.adb.compat.DebuggerSupport
+import spock.adb.device.ConnectedDevice
 import spock.adb.premission.CheckBoxDialog
 import java.awt.event.ActionEvent
 import java.awt.event.ItemEvent
@@ -40,7 +41,7 @@ class SpockAdbViewer(
     private lateinit var currentAppBackStackButton: JButton
     private lateinit var adbWifi: JButton
     private lateinit var setting: JButton
-    private var devices: List<IDevice> = emptyList()
+    private var devices: List<ConnectedDevice> = emptyList()
     private lateinit var enableDisableDontKeepActivities: JCheckBox
     private lateinit var enableDisableShowTaps: JCheckBox
     private lateinit var enableDisableShowLayoutBounds: JCheckBox
@@ -54,7 +55,10 @@ class SpockAdbViewer(
     private lateinit var inputOnDeviceButton: JButton
     private lateinit var openDeepLinkButton: JButton
     private lateinit var openDeveloperOptionsButton: JButton
-    private var selectedIDevice: IDevice? = null
+    private var selectedDevice: ConnectedDevice? = null
+
+    /** The ddmlib handle every command still operates on. */
+    private val selectedIDevice: IDevice? get() = selectedDevice?.device
 
     private lateinit var adbController: AdbController
 
@@ -143,7 +147,8 @@ class SpockAdbViewer(
             // model is emptied. Indexing straight into `devices` threw
             // ArrayIndexOutOfBoundsException whenever the last device disconnected.
             if (event.stateChange == ItemEvent.SELECTED) {
-                selectedIDevice = devices.getOrNull(devicesListComboBox.selectedIndex)
+                selectedDevice = devices.getOrNull(devicesListComboBox.selectedIndex)
+                rememberSelectedDevice()
             }
         }
         activitiesBackStackButton.addActionListener {
@@ -187,22 +192,22 @@ class SpockAdbViewer(
             }
         }
         clearAppDataButton.addActionListener {
-            selectedIDevice?.let { device ->
-                if (DestructiveActionConfirmation.confirmClearData(project, device, andRestart = false)) {
+            selectedDevice?.let { (device, deviceInfo) ->
+                if (DestructiveActionConfirmation.confirmClearData(project, deviceInfo, andRestart = false)) {
                     adbController.clearAppData(device)
                 }
             }
         }
         clearAppDataAndRestartButton.addActionListener {
-            selectedIDevice?.let { device ->
-                if (DestructiveActionConfirmation.confirmClearData(project, device, andRestart = true)) {
+            selectedDevice?.let { (device, deviceInfo) ->
+                if (DestructiveActionConfirmation.confirmClearData(project, deviceInfo, andRestart = true)) {
                     adbController.clearAppDataAndRestart(device)
                 }
             }
         }
         uninstallAppButton.addActionListener {
-            selectedIDevice?.let { device ->
-                if (DestructiveActionConfirmation.confirmUninstall(project, device)) {
+            selectedDevice?.let { (device, deviceInfo) ->
+                if (DestructiveActionConfirmation.confirmUninstall(project, deviceInfo)) {
                     adbController.uninstallApp(device)
                 }
             }
@@ -233,8 +238,8 @@ class SpockAdbViewer(
             }
         }
         revokeAllPermissionsButton.addActionListener {
-            selectedIDevice?.let { device ->
-                if (DestructiveActionConfirmation.confirmRevokeAllPermissions(project, device)) {
+            selectedDevice?.let { (device, deviceInfo) ->
+                if (DestructiveActionConfirmation.confirmRevokeAllPermissions(project, deviceInfo)) {
                     adbController.grantOrRevokeAllPermissions(
                         device,
                         GetApplicationPermission.PermissionOperation.REVOKE,
@@ -324,14 +329,38 @@ class SpockAdbViewer(
 
             // Match on serial rather than instance identity: ddmlib hands out a new IDevice
             // after a reconnect, so identity comparison silently reset the selection.
-            val previousSerial = selectedIDevice?.serialNumber
-            selectedIDevice = connected.firstOrNull { it.serialNumber == previousSerial }
+            // Falls back to the serial persisted from the previous session, then to the
+            // first device that is actually usable, so the plugin does not default to an
+            // offline or unauthorised device.
+            val preferredSerial = selectedDevice?.serialNumber ?: persistedDeviceSerial()
+            selectedDevice = connected.firstOrNull { it.serialNumber == preferredSerial }
+                ?: connected.firstOrNull { it.info.isUsable }
                 ?: connected.firstOrNull()
 
             devicesListComboBox.model = DefaultComboBoxModel(
-                connected.map { it.name }.toTypedArray(),
+                connected.map { it.info.label() }.toTypedArray(),
             )
-            selectedIDevice?.let { devicesListComboBox.selectedIndex = connected.indexOf(it) }
+            selectedDevice?.let { devicesListComboBox.selectedIndex = connected.indexOf(it) }
+            devicesListComboBox.toolTipText = selectedDevice?.info?.describe()
+            rememberSelectedDevice()
+        }
+    }
+
+    private fun persistedDeviceSerial(): String? =
+        AppSettingService.getInstance().state.selectedDevice?.takeIf { it.isNotBlank() }
+
+    /**
+     * Persists the chosen device so it is reselected next session.
+     *
+     * `AppSetting.selectedDevice` has existed since the settings were introduced but was
+     * never read or written.
+     */
+    private fun rememberSelectedDevice() {
+        val service = AppSettingService.getInstance()
+        val current = service.state
+        val serial = selectedDevice?.serialNumber
+        if (current.selectedDevice != serial) {
+            service.loadState(current.copy(selectedDevice = serial))
         }
     }
 

--- a/src/main/kotlin/spock/adb/actions/BaseAction.kt
+++ b/src/main/kotlin/spock/adb/actions/BaseAction.kt
@@ -9,6 +9,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.popup.JBPopupFactory
 import spock.adb.AdbController
 import spock.adb.SpockAdbService
+import spock.adb.device.ConnectedDevice
 import spock.adb.notification.CommonNotifier.Companion.showNotifier
 
 abstract class BaseAction : AnAction() {
@@ -31,17 +32,31 @@ abstract class BaseAction : AnAction() {
         // owned by SpockAdbService, so unlike the previous implementation it is not disposed
         // out from under this callback — which used to cancel the work before it ran.
         controller.connectedDevices { devices ->
+            val usable = devices.filter { it.info.isUsable }
             when {
-                devices.isEmpty() ->
-                    showNotifier(project = project, content = "No connected devices", type = NotificationType.ERROR)
-                devices.size == 1 -> performAction(controller, devices.first())
-                else -> showDeviceList(project, devices) { performAction(controller, it) }
+                usable.isEmpty() -> showNotifier(
+                    project = project,
+                    content = if (devices.isEmpty()) {
+                        "No connected devices"
+                    } else {
+                        devices.joinToString(prefix = "No device is ready: ") {
+                            "${it.info.displayName} is ${it.info.state.label}"
+                        }
+                    },
+                    type = NotificationType.ERROR,
+                )
+                usable.size == 1 -> performAction(controller, usable.first().device)
+                else -> showDeviceList(project, usable) { performAction(controller, it.device) }
             }
         }
     }
 
-    private fun showDeviceList(project: Project, devices: List<IDevice>, block: (device: IDevice) -> Unit) {
-        val names = devices.map { it.name }
+    private fun showDeviceList(
+        project: Project,
+        devices: List<ConnectedDevice>,
+        block: (device: ConnectedDevice) -> Unit,
+    ) {
+        val names = devices.map { it.info.label() }
         JBPopupFactory.getInstance()
             .createPopupChooserBuilder(names)
             .setTitle("Devices")

--- a/src/main/kotlin/spock/adb/device/ConnectedDevice.kt
+++ b/src/main/kotlin/spock/adb/device/ConnectedDevice.kt
@@ -1,0 +1,16 @@
+package spock.adb.device
+
+import com.android.ddmlib.IDevice
+
+/**
+ * Pairs the ddmlib handle used to run commands with the metadata used to describe it.
+ *
+ * Commands still take an [IDevice]; this only carries the already-resolved [DeviceInfo] so
+ * the UI never has to read device properties (a blocking call) on the EDT.
+ */
+data class ConnectedDevice(
+    val device: IDevice,
+    val info: DeviceInfo,
+) {
+    val serialNumber: String get() = info.serialNumber
+}

--- a/src/main/kotlin/spock/adb/device/DeviceInfo.kt
+++ b/src/main/kotlin/spock/adb/device/DeviceInfo.kt
@@ -1,0 +1,82 @@
+package spock.adb.device
+
+/**
+ * Everything the UI needs to describe a device, read once on a background thread.
+ *
+ * The tool window previously showed only `IDevice.name`, which for a physical device is the
+ * raw model id and for an emulator is the AVD name. With more than one device attached
+ * there was no way to tell an emulator from a handset, an online device from an offline
+ * one, or which API level a command was about to run against.
+ */
+data class DeviceInfo(
+    val serialNumber: String,
+    val model: String,
+    val manufacturer: String,
+    /** Marketing version, e.g. "14". Empty when the device did not answer. */
+    val androidVersion: String,
+    val apiLevel: Int?,
+    /** Primary ABI, e.g. "arm64-v8a". Empty when the device did not answer. */
+    val abi: String,
+    val isEmulator: Boolean,
+    val state: DeviceState,
+) {
+
+    val isUsable: Boolean get() = state == DeviceState.ONLINE
+
+    /** Human name: manufacturer and model for a handset, the AVD name for an emulator. */
+    val displayName: String
+        get() = when {
+            model.isBlank() -> serialNumber
+            manufacturer.isBlank() || model.startsWith(manufacturer, ignoreCase = true) -> model
+            else -> "$manufacturer $model"
+        }
+
+    /**
+     * One line for the device dropdown, e.g.
+     * `Pixel 7 - Android 14 (API 34) - arm64-v8a`, with the state appended when the device
+     * is not ready to accept commands.
+     */
+    fun label(): String = buildString {
+        append(if (isEmulator) "Emulator: " else "Device: ")
+        append(displayName)
+
+        val version = androidVersionLabel()
+        if (version.isNotEmpty()) append(" - ").append(version)
+        if (abi.isNotEmpty()) append(" - ").append(abi)
+        if (state != DeviceState.ONLINE) append(" - ").append(state.label)
+    }
+
+    fun androidVersionLabel(): String = when {
+        androidVersion.isNotBlank() && apiLevel != null -> "Android $androidVersion (API $apiLevel)"
+        androidVersion.isNotBlank() -> "Android $androidVersion"
+        apiLevel != null -> "API $apiLevel"
+        else -> ""
+    }
+
+    /** Unambiguous identification for confirmation prompts and notifications. */
+    fun describe(): String =
+        if (displayName == serialNumber) serialNumber else "$displayName ($serialNumber)"
+
+    companion object {
+        /** Used when a device disconnects before its properties could be read. */
+        fun unknown(serialNumber: String) = DeviceInfo(
+            serialNumber = serialNumber,
+            model = "",
+            manufacturer = "",
+            androidVersion = "",
+            apiLevel = null,
+            abi = "",
+            isEmulator = false,
+            state = DeviceState.UNKNOWN,
+        )
+    }
+}
+
+enum class DeviceState(val label: String) {
+    ONLINE("online"),
+    OFFLINE("offline"),
+    UNAUTHORIZED("unauthorized"),
+    BOOTLOADER("bootloader"),
+    DISCONNECTED("disconnected"),
+    UNKNOWN("unknown"),
+}

--- a/src/main/kotlin/spock/adb/device/DeviceInfoReader.kt
+++ b/src/main/kotlin/spock/adb/device/DeviceInfoReader.kt
@@ -1,0 +1,73 @@
+package spock.adb.device
+
+import com.android.ddmlib.IDevice
+
+/**
+ * Builds a [DeviceInfo] from a ddmlib handle.
+ *
+ * `IDevice.getProperty` can block on a device that is slow or offline, so this must only be
+ * called from a background thread. Every read is guarded: an offline or unauthorised device
+ * answers some properties and not others, and a partially described device is far more
+ * useful than an exception.
+ */
+object DeviceInfoReader {
+
+    private const val PROP_MODEL = "ro.product.model"
+    private const val PROP_MANUFACTURER = "ro.product.manufacturer"
+    private const val PROP_RELEASE = "ro.build.version.release"
+    private const val PROP_SDK = "ro.build.version.sdk"
+    private const val PROP_ABI = "ro.product.cpu.abi"
+    private const val PROP_AVD_NAME = "ro.boot.qemu.avd_name"
+    private const val PROP_AVD_NAME_LEGACY = "ro.kernel.qemu.avd_name"
+
+    fun read(device: IDevice): DeviceInfo {
+        val serial = runCatching { device.serialNumber }.getOrNull().orEmpty()
+        val state = device.deviceState()
+
+        // An offline or unauthorised device will not answer property queries; skip them
+        // rather than blocking on each one in turn.
+        if (state != DeviceState.ONLINE) {
+            return DeviceInfo.unknown(serial).copy(
+                state = state,
+                isEmulator = runCatching { device.isEmulator }.getOrDefault(false),
+                model = device.avdNameOrEmpty(),
+            )
+        }
+
+        return DeviceInfo(
+            serialNumber = serial,
+            model = device.prop(PROP_MODEL).ifBlank { device.avdNameOrEmpty() },
+            manufacturer = device.prop(PROP_MANUFACTURER),
+            androidVersion = device.prop(PROP_RELEASE),
+            apiLevel = device.prop(PROP_SDK).toIntOrNull(),
+            abi = device.prop(PROP_ABI),
+            isEmulator = runCatching { device.isEmulator }.getOrDefault(false),
+            state = state,
+        )
+    }
+
+    private fun IDevice.prop(name: String): String =
+        runCatching { getProperty(name) }.getOrNull()?.trim().orEmpty()
+
+    /**
+     * Best-effort emulator name.
+     *
+     * `IDevice.getAvdName()` is deprecated in current ddmlib (its replacement returns a
+     * future), so the AVD name is read from the emulator's own properties instead, newest
+     * property first, falling back to the ddmlib display name.
+     */
+    private fun IDevice.avdNameOrEmpty(): String =
+        prop(PROP_AVD_NAME).ifBlank { prop(PROP_AVD_NAME_LEGACY) }
+            .ifBlank { runCatching { name }.getOrNull().orEmpty() }
+
+    private fun IDevice.deviceState(): DeviceState = runCatching {
+        when (state) {
+            IDevice.DeviceState.ONLINE -> DeviceState.ONLINE
+            IDevice.DeviceState.OFFLINE -> DeviceState.OFFLINE
+            IDevice.DeviceState.UNAUTHORIZED -> DeviceState.UNAUTHORIZED
+            IDevice.DeviceState.BOOTLOADER -> DeviceState.BOOTLOADER
+            IDevice.DeviceState.DISCONNECTED -> DeviceState.DISCONNECTED
+            else -> DeviceState.UNKNOWN
+        }
+    }.getOrDefault(DeviceState.UNKNOWN)
+}

--- a/src/test/kotlin/spock/adb/device/DeviceInfoTest.kt
+++ b/src/test/kotlin/spock/adb/device/DeviceInfoTest.kt
@@ -1,0 +1,75 @@
+package spock.adb.device
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class DeviceInfoTest {
+
+    private fun info(
+        serial: String = "39021FDJH00123",
+        model: String = "Pixel 7",
+        manufacturer: String = "Google",
+        androidVersion: String = "14",
+        apiLevel: Int? = 34,
+        abi: String = "arm64-v8a",
+        isEmulator: Boolean = false,
+        state: DeviceState = DeviceState.ONLINE,
+    ) = DeviceInfo(serial, model, manufacturer, androidVersion, apiLevel, abi, isEmulator, state)
+
+    @Test
+    fun `labels a physical device with version and architecture`() {
+        assertEquals("Device: Google Pixel 7 - Android 14 (API 34) - arm64-v8a", info().label())
+    }
+
+    @Test
+    fun `labels an emulator distinctly`() {
+        val label = info(model = "sdk_gphone64_arm64", manufacturer = "Google", isEmulator = true).label()
+
+        assertTrue(label.startsWith("Emulator: "), label)
+    }
+
+    @Test
+    fun `does not repeat the manufacturer when the model already carries it`() {
+        assertEquals("Samsung SM-G991B", info(model = "SM-G991B", manufacturer = "Samsung").displayName)
+        assertEquals("Google Pixel 7", info(model = "Pixel 7", manufacturer = "Google").displayName)
+        // A model that already begins with the manufacturer is not prefixed again.
+        assertEquals("Google Pixel", info(model = "Google Pixel", manufacturer = "Google").displayName)
+    }
+
+    @Test
+    fun `appends the state only when the device cannot accept commands`() {
+        assertFalse(info().label().contains("online"))
+        assertTrue(info(state = DeviceState.UNAUTHORIZED).label().endsWith("unauthorized"))
+        assertTrue(info(state = DeviceState.OFFLINE).label().endsWith("offline"))
+    }
+
+    @Test
+    fun `only an online device is usable`() {
+        assertTrue(info(state = DeviceState.ONLINE).isUsable)
+        listOf(DeviceState.OFFLINE, DeviceState.UNAUTHORIZED, DeviceState.BOOTLOADER, DeviceState.UNKNOWN)
+            .forEach { assertFalse(info(state = it).isUsable, it.name) }
+    }
+
+    @Test
+    fun `falls back to the serial when the device reported no model`() {
+        val unknown = DeviceInfo.unknown("emulator-5554")
+
+        assertEquals("emulator-5554", unknown.displayName)
+        assertEquals("emulator-5554", unknown.describe())
+    }
+
+    @Test
+    fun `omits version and architecture the device did not report`() {
+        assertEquals("Device: Google Pixel 7", info(androidVersion = "", apiLevel = null, abi = "").label())
+        assertEquals("", info(androidVersion = "", apiLevel = null).androidVersionLabel())
+        assertEquals("API 34", info(androidVersion = "").androidVersionLabel())
+        assertEquals("Android 14", info(apiLevel = null).androidVersionLabel())
+    }
+
+    @Test
+    fun `describe pairs the name with the serial so prompts are unambiguous`() {
+        assertEquals("Google Pixel 7 (39021FDJH00123)", info().describe())
+    }
+}


### PR DESCRIPTION
> Stacked on #53.

The device dropdown showed only `IDevice.name` — the raw model id for a handset, the AVD name for an emulator. With more than one device attached there was no way to tell an emulator from a phone, an online device from an unauthorised one, or which API level a command was about to run against.

## Device abstraction

- **`DeviceInfo`** — serial, model, manufacturer, Android version, API level, ABI, emulator flag, connection state.
- **`DeviceInfoReader`** — builds it from a ddmlib handle **on a background thread**. `IDevice.getProperty` blocks, so this must never run while the dropdown renders. Every read is individually guarded: an offline or unauthorised device answers some properties and not others, and a partially described device beats an exception.
- **`ConnectedDevice`** — pairs the handle commands run against with that metadata, so the UI never touches the device to describe it.

## Behaviour changes

- The dropdown now labels each device, e.g. `Device: Google Pixel 7 - Android 14 (API 34) - arm64-v8a`, appending the state when it is not ready.
- **The selected device is persisted across sessions.** `AppSetting.selectedDevice` has existed since settings were introduced but was never read or written.
- With no prior selection the plugin prefers a device that is actually **online**, rather than whichever ddmlib listed first.
- Menu actions filter out unusable devices and explain why when none remain (*"Pixel 7 is unauthorized"*) instead of failing part-way through a command.
- Confirmation prompts name the target device.

## Notes

`IDevice.getAvdName()` is deprecated in current ddmlib (its replacement returns a future), so the emulator name is read from the emulator's own properties instead. The verifier still reports only the two pre-existing joor deprecations — no new ones.

## Verification

48 tests passing. `test`, `detekt`, `buildPlugin`, `verifyPlugin` green — all five IDE targets **Compatible**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)