### PR TITLE
UI fixes, MCP Server panel, and Keymap-native actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 ### Added
+- **Logcat panel.** Live logcat in its own tool window tab, pre-scoped to the app in the open project. Presets for Current app, Errors only, Crashes, ANRs and Network; filtering by level, tag and plain-text or regex search; crash and ANR highlighting; pause/resume, clear, copy and export; auto-scroll. Filtering is by process ID rather than by matching the package name against message text, which both misses lines and returns unrelated ones
+- **ADB Command Center.** Run any shell command against the selected device with a real timeout and a Cancel button that actually stops the command. Command history that de-duplicates and reorders rather than piling up, favourites, searchable output, copy command, copy output and clear
+- **Commands can now be cancelled at all.** `ShellOutputReceiver` hard-coded `isCancelled()` to `false`, so no long-running command could ever be interrupted. The new `CancellableShellReceiver` streams output line by line and honours cancellation, which is what makes both live logcat and the Cancel button possible
+- Destructive shell commands are classified and confirmed before running, sharing `DangerousCommands` with the MCP `android_run_adb_command` tool so a command needing confirmation for an AI agent needs it in the UI too
+- The tool window is now three tabs — Devices, Logcat, Commands — with the device chosen in Devices targeted by all of them
+- README now documents the MCP server, the Logcat panel and the Command Center, and links the docs; the Marketplace description mentions MCP and IntelliJ IDEA support
+
+### Fixed
+- **Compatibility**: `FileSaverDescriptor(String, String)` does not exist before 2025.1 and would have thrown `NoSuchMethodError` on Android Studio 2023.1/2024.2 and IntelliJ IDEA 2023.1. Caught by Plugin Verifier; the deprecated-but-present overload is used instead
+
+### Added
 - **Android MCP server.** Spock ADB can expose the connected device to MCP-compatible AI agents (Claude Code, Claude Desktop, Cursor). 26 strongly typed tools rather than a generic shell passthrough, so an agent can reason about what an operation means and you can audit it: devices, packages, app lifecycle, permissions, current Activity/Fragment, activity stack, logcat, processes, battery, network, deep links, input, tap/swipe/keys, screenshots as MCP image content, and the uiautomator UI hierarchy. Start it from `Tools → SpockAdb`; it is **off by default**
 - **MCP safety model.** Every tool declares read-only, safe-action or destructive. Destructive tools (clear app data, revoke permission, arbitrary shell) always ask before acting, default to denied, bring the IDE forward, and are written to `idea.log`. A test enforces that no destructive tool can report success without a confirmation
 - `android_run_adb_command` exists as a deliberately awkward escape hatch: it requires a stated reason, has a bounded timeout and capped output, and refuses catastrophic commands (`rm -rf /`, factory reset, `mkfs`, raw `dd`) before the confirmation dialog is even shown

--- a/README.md
+++ b/README.md
@@ -7,9 +7,13 @@
 # Spock ADB
 
 <!-- Plugin description -->
-Full control of your Android device directly from Android Studio — no terminal needed.
+Full control of your Android device directly from your IDE — no terminal needed.
 
-Spock ADB puts the most common ADB workflows into a single tool window: navigate to the active Activity or Fragment in your editor, manage app lifecycle, toggle developer settings, control permissions, and more — all with one click.
+Spock ADB puts the most common ADB workflows into a single tool window: navigate to the active Activity or Fragment in your editor, manage app lifecycle, toggle developer settings, control permissions, stream logcat, and run ADB commands — all with one click.
+
+It also ships an <b>Android MCP server</b>: give Claude Code, Claude Desktop, Cursor or any MCP client safe, structured access to a connected device. 26 strongly typed tools rather than a raw shell, and anything destructive asks you first, every time.
+
+Works in Android Studio and IntelliJ IDEA.
 <!-- Plugin description end -->
 
 ---
@@ -65,6 +69,35 @@ Spock ADB puts the most common ADB workflows into a single tool window: navigate
 | **Input Text** | Type text into the focused field on the device |
 | **Open Deep Link** | Fire an `android.intent.action.VIEW` intent with any URI |
 
+### Logcat
+| Feature | Description |
+|---|---|
+| **Live logcat** | Stream the device log, scoped to the app in the open project |
+| **Presets** | Current app, Errors only, Crashes, ANRs, Network |
+| **Filtering** | Log level, tag, plain-text or regex search, filter by process |
+| **Crash highlighting** | Fatal exceptions, native crashes and ANRs are colour-coded |
+| **Pause / resume / clear** | Freeze the view without losing the stream |
+| **Copy & export** | Copy selected lines, or export the buffer to a file |
+
+### ADB Command Center
+| Feature | Description |
+|---|---|
+| **Run any ADB shell command** | With a real timeout and a working Cancel button |
+| **History & favourites** | Recent commands, and the ones you keep coming back to |
+| **Searchable output** | Find text in long `dumpsys` dumps |
+| **Copy command / copy output / clear** | One click each |
+| **Confirmation on dangerous commands** | Destructive commands are flagged before they run |
+
+### AI agents (MCP)
+| Feature | Description |
+|---|---|
+| **Android MCP server** | Expose the device to Claude Code, Claude Desktop, Cursor or any MCP client |
+| **26 typed tools** | Devices, packages, app lifecycle, permissions, Activity/Fragment, logcat, screenshots, UI hierarchy, input |
+| **Safety model** | Destructive tools always ask, per call, and default to denied |
+| **Off by default** | Started explicitly from `Tools → SpockAdb` |
+
+See **[docs/MCP.md](docs/MCP.md)** for setup, the tool list, the safety model and example agent workflows.
+
 ---
 
 ## Screenshot
@@ -87,6 +120,17 @@ behind the supported range.
 > **Note:** `Restart App With Debugger` requires the Android Studio execution tooling. It is
 > available in all supported Android Studio versions and in IntelliJ IDEA 2025.1+, and is
 > hidden automatically on IDEs that do not ship it. Every other feature works everywhere.
+
+---
+
+## Documentation
+
+| Document | Contents |
+|---|---|
+| [docs/MCP.md](docs/MCP.md) | Android MCP server: setup, tools, safety model, agent workflows |
+| [docs/COMPATIBILITY.md](docs/COMPATIBILITY.md) | Supported IDE range, verification matrix, how to change it safely |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | Development setup, threading rules, release process |
+| [CHANGELOG.md](CHANGELOG.md) | Release history |
 
 ---
 

--- a/detekt-config.yml
+++ b/detekt-config.yml
@@ -9,6 +9,10 @@ complexity:
   LongParameterList:
     # Test fixture builders legitimately mirror the shape of the data class under test.
     excludes: ['**/test/**']
+  TooManyFunctions:
+    # Swing panels decompose into many small private methods, which is the readable shape
+    # for UI code — collapsing them into fewer, larger ones would be worse.
+    thresholdInClasses: 20
 
 style:
   ReturnCount:

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -119,6 +119,28 @@ project.getService(SpockAdbService::class.java)
 
 Both `SpockAdbService.getInstance` and `AppSettingService.getInstance` do this deliberately.
 
+## The third trap: a newer overload of an old class
+
+The same failure shape appears when a class you have always used gains a nicer constructor
+or method. `FileSaverDescriptor(String, String)` reads better than the vararg form and the
+vararg form is deprecated on 2025.1 — but the two-argument constructor does not exist before
+it:
+
+```
+Method LogcatPanel.export() contains an *invokespecial* instruction referencing an
+unresolved constructor FileSaverDescriptor.<init>(String, String).
+This can lead to NoSuchMethodError exception at runtime.
+```
+
+Compiling against the newest platform makes the newer overload the obvious choice, and
+nothing warns you. **A deprecation warning on the newest platform is strictly better than a
+NoSuchMethodError on the oldest**, so the deprecated-but-present overload is used, with a
+comment saying why. Do not "clean up" that call without re-running the verifier.
+
+Three distinct instances of this one failure mode turned up while modernising this plugin —
+compatibility bridges, an inlined platform helper, and a newer overload. All three were
+invisible at compile time, and all three were caught by `verifyPlugin`.
+
 ## Verification matrix
 
 `./gradlew verifyPlugin` checks these builds. They are the two ends of the supported range

--- a/src/main/kotlin/spock/AdbDrawerViewer.kt
+++ b/src/main/kotlin/spock/AdbDrawerViewer.kt
@@ -1,10 +1,13 @@
 package spock
 
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowFactory
 import spock.adb.SpockAdbService
 import spock.adb.SpockAdbViewer
+import spock.adb.commandcenter.CommandCenterPanel
+import spock.adb.logcat.LogcatPanel
 
 class AdbDrawerViewer : ToolWindowFactory {
 
@@ -14,10 +17,32 @@ class AdbDrawerViewer : ToolWindowFactory {
         // while ADB starts.
         val adbController = SpockAdbService.getInstance(project).controller
 
+        val logcatPanel = LogcatPanel(project)
+        val commandCenterPanel = CommandCenterPanel(project)
+
+        // Both panels are disposed with the tool window, which stops the logcat stream and
+        // cancels any running command rather than leaking an ADB reader thread.
+        Disposer.register(toolWindow.disposable, logcatPanel)
+        Disposer.register(toolWindow.disposable, commandCenterPanel)
+
         val viewer = SpockAdbViewer(project, toolWindow.disposable)
+        // The device chosen in the Devices tab is the target for every tab, so there is one
+        // answer to "which device is this acting on" across the whole tool window.
+        viewer.onDeviceSelected { selected ->
+            logcatPanel.setDevice(selected)
+            commandCenterPanel.setDevice(selected)
+        }
         viewer.initPlugin(adbController)
 
         val contentManager = toolWindow.contentManager
-        contentManager.addContent(contentManager.factory.createContent(viewer, null, false))
+        contentManager.addContent(
+            contentManager.factory.createContent(viewer, "Devices", false),
+        )
+        contentManager.addContent(
+            contentManager.factory.createContent(logcatPanel, "Logcat", false),
+        )
+        contentManager.addContent(
+            contentManager.factory.createContent(commandCenterPanel, "Commands", false),
+        )
     }
 }

--- a/src/main/kotlin/spock/adb/CancellableShellReceiver.kt
+++ b/src/main/kotlin/spock/adb/CancellableShellReceiver.kt
@@ -1,0 +1,53 @@
+package spock.adb
+
+import com.android.ddmlib.IShellOutputReceiver
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * A shell receiver that streams output as it arrives and can actually be stopped.
+ *
+ * [ShellOutputReceiver] buffers everything and hard-codes `isCancelled()` to `false`, so a
+ * long-running command could not be interrupted at all — the reason logcat streaming and
+ * command cancellation were not possible before.
+ *
+ * ddmlib polls [isCancelled] between chunks, so cancelling takes effect at the next chunk
+ * boundary rather than instantly. A command producing no output will not notice until it
+ * does, which is why callers still pass a timeout.
+ */
+class CancellableShellReceiver(
+    /** Called on the ADB reader thread for every complete line. Must not block. */
+    private val onLine: (String) -> Unit,
+) : IShellOutputReceiver {
+
+    private val cancelled = AtomicBoolean(false)
+    private val pending = StringBuilder()
+
+    fun cancel() {
+        cancelled.set(true)
+    }
+
+    override fun isCancelled(): Boolean = cancelled.get()
+
+    override fun addOutput(data: ByteArray, offset: Int, length: Int) {
+        if (cancelled.get()) return
+
+        pending.append(String(data, offset, length))
+
+        // Emit only complete lines; a chunk boundary can land mid-line, and half a log
+        // record rendered in the UI is worse than a few milliseconds of latency.
+        while (true) {
+            val newline = pending.indexOf("\n")
+            if (newline < 0) break
+            val line = pending.substring(0, newline).removeSuffix("\r")
+            pending.delete(0, newline + 1)
+            if (!cancelled.get()) onLine(line)
+        }
+    }
+
+    override fun flush() {
+        if (pending.isNotEmpty() && !cancelled.get()) {
+            onLine(pending.toString().removeSuffix("\r"))
+            pending.setLength(0)
+        }
+    }
+}

--- a/src/main/kotlin/spock/adb/SpockAdbViewer.kt
+++ b/src/main/kotlin/spock/adb/SpockAdbViewer.kt
@@ -56,6 +56,18 @@ class SpockAdbViewer(
     private lateinit var openDeepLinkButton: JButton
     private lateinit var openDeveloperOptionsButton: JButton
     private var selectedDevice: ConnectedDevice? = null
+        set(value) {
+            field = value
+            deviceListeners.forEach { it(value) }
+        }
+
+    /** Notified whenever the selected device changes, so other tool window tabs follow it. */
+    private val deviceListeners = mutableListOf<(ConnectedDevice?) -> Unit>()
+
+    fun onDeviceSelected(listener: (ConnectedDevice?) -> Unit) {
+        deviceListeners += listener
+        listener(selectedDevice)
+    }
 
     /** The ddmlib handle every command still operates on. */
     private val selectedIDevice: IDevice? get() = selectedDevice?.device

--- a/src/main/kotlin/spock/adb/commandcenter/CommandCenterPanel.kt
+++ b/src/main/kotlin/spock/adb/commandcenter/CommandCenterPanel.kt
@@ -1,0 +1,301 @@
+package spock.adb.commandcenter
+
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.actionSystem.ActionPlaces
+import com.intellij.openapi.actionSystem.ActionUpdateThread
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.DefaultActionGroup
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.ide.CopyPasteManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.MessageDialogBuilder
+import com.intellij.openapi.ui.SimpleToolWindowPanel
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.components.JBScrollPane
+import com.intellij.ui.components.JBTextArea
+import com.intellij.ui.components.JBTextField
+import com.intellij.util.ui.JBUI
+import spock.adb.device.ConnectedDevice
+import java.awt.BorderLayout
+import java.awt.FlowLayout
+import java.awt.datatransfer.StringSelection
+import java.awt.event.KeyEvent
+import javax.swing.JButton
+import javax.swing.JComboBox
+import javax.swing.JComponent
+import javax.swing.JPanel
+import javax.swing.KeyStroke
+
+/**
+ * Run ADB shell commands against the selected device, with the affordances a terminal
+ * gives you and the tool window previously did not: history, favourites, a searchable
+ * output pane, a real timeout, and a Cancel button that actually stops the command.
+ */
+class CommandCenterPanel(
+    private val project: Project,
+) : SimpleToolWindowPanel(true, true), Disposable {
+
+    private val history = CommandHistory()
+    private val runner = CommandRunner()
+
+    private val commandField = JBTextField()
+    private val historyCombo = JComboBox<String>()
+    private val output = JBTextArea().apply {
+        isEditable = false
+        lineWrap = false
+    }
+    private val runButton = JButton("Run")
+    private val cancelButton = JButton("Cancel").apply { isEnabled = false }
+    private val favouriteButton = JButton("☆ Favourite")
+    private val statusLabel = JBLabel(" ")
+    private val searchField = JBTextField(SEARCH_COLUMNS)
+
+    private var device: ConnectedDevice? = null
+    private val outputBuffer = StringBuilder()
+
+    init {
+        setToolbar(buildToolbar())
+        setContent(buildContent())
+        wire()
+        updateStatus()
+    }
+
+    fun setDevice(connected: ConnectedDevice?) {
+        device = connected
+        updateStatus()
+    }
+
+    // ---------------------------------------------------------------- layout
+
+    private fun buildContent(): JComponent {
+        val input = JPanel(BorderLayout(JBUI.scale(GAP), 0)).apply {
+            border = JBUI.Borders.empty(GAP)
+            add(JBLabel("adb shell"), BorderLayout.WEST)
+            add(commandField, BorderLayout.CENTER)
+            add(
+                JPanel(FlowLayout(FlowLayout.LEFT, JBUI.scale(GAP), 0)).apply {
+                    add(runButton)
+                    add(cancelButton)
+                    add(favouriteButton)
+                },
+                BorderLayout.EAST,
+            )
+        }
+
+        val selectors = JPanel(FlowLayout(FlowLayout.LEFT, JBUI.scale(GAP), 0)).apply {
+            border = JBUI.Borders.emptyLeft(GAP)
+            add(JBLabel("History:"))
+            add(historyCombo)
+            add(JBLabel("Find in output:"))
+            add(searchField)
+        }
+
+        return JPanel(BorderLayout()).apply {
+            add(
+                JPanel(BorderLayout()).apply {
+                    add(input, BorderLayout.NORTH)
+                    add(selectors, BorderLayout.SOUTH)
+                },
+                BorderLayout.NORTH,
+            )
+            add(JBScrollPane(output), BorderLayout.CENTER)
+            add(statusLabel.apply { border = JBUI.Borders.empty(STATUS_PAD_V, STATUS_PAD_H) }, BorderLayout.SOUTH)
+        }
+    }
+
+    private fun buildToolbar(): JComponent {
+        val actions = DefaultActionGroup().apply {
+            add(
+                action("Copy command", AllIcons.Actions.Copy) {
+                    CopyPasteManager.getInstance().setContents(StringSelection(commandField.text))
+                    statusLabel.text = "Command copied."
+                },
+            )
+            add(
+                action("Copy output", AllIcons.Actions.Dump) {
+                    CopyPasteManager.getInstance().setContents(StringSelection(outputBuffer.toString()))
+                    statusLabel.text = "Output copied."
+                },
+            )
+            add(action("Clear output", AllIcons.Actions.GC) { clearOutput() })
+        }
+        val toolbar = ActionManager.getInstance()
+            .createActionToolbar(ActionPlaces.TOOLWINDOW_CONTENT, actions, true)
+        toolbar.targetComponent = this
+        return toolbar.component
+    }
+
+    private fun action(text: String, icon: javax.swing.Icon, run: () -> Unit) =
+        object : AnAction(text, text, icon) {
+            override fun getActionUpdateThread() = ActionUpdateThread.EDT
+            override fun actionPerformed(e: AnActionEvent) = run()
+        }
+
+    // ---------------------------------------------------------------- behaviour
+
+    private fun wire() {
+        runButton.addActionListener { execute() }
+        cancelButton.addActionListener {
+            runner.cancel()
+            statusLabel.text = "Cancelling…"
+        }
+        commandField.registerKeyboardAction(
+            { execute() },
+            KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0),
+            JComponent.WHEN_FOCUSED,
+        )
+        favouriteButton.addActionListener { toggleFavourite() }
+        historyCombo.addActionListener {
+            (historyCombo.selectedItem as? String)
+                ?.removePrefix(FAVOURITE_PREFIX)
+                ?.let { commandField.text = it }
+        }
+        searchField.registerKeyboardAction(
+            { findNext() },
+            KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0),
+            JComponent.WHEN_FOCUSED,
+        )
+    }
+
+    private fun execute() {
+        val target = device ?: run {
+            statusLabel.text = "No device selected."
+            return
+        }
+        val command = commandField.text.trim()
+        if (command.isEmpty()) return
+        if (runner.isRunning) {
+            statusLabel.text = "A command is already running. Cancel it first."
+            return
+        }
+        if (!confirmIfDangerous(command, target)) return
+
+        history.record(command)
+        refreshHistory()
+
+        appendLine("$ $command")
+        setRunning(true)
+
+        runner.run(
+            device = target.device,
+            command = command,
+            timeoutSeconds = CommandRunner.DEFAULT_TIMEOUT_SECONDS,
+            onLine = { line ->
+                ApplicationManager.getApplication().invokeLater({ appendLine(line) }) { project.isDisposed }
+            },
+            onFinished = { failure ->
+                ApplicationManager.getApplication().invokeLater({
+                    setRunning(false)
+                    statusLabel.text = failure?.let { "Failed: ${it.message}" } ?: "Done."
+                    if (failure != null) appendLine("[error] ${failure.message}")
+                }) { project.isDisposed }
+            },
+        )
+    }
+
+    /**
+     * Blocks obviously catastrophic commands outright and confirms destructive ones.
+     *
+     * Shares [DangerousCommands] with the MCP tool, so a command needing confirmation for an
+     * AI agent needs it here too.
+     */
+    private fun confirmIfDangerous(command: String, target: ConnectedDevice): Boolean =
+        when (DangerousCommands.classify(command)) {
+            DangerousCommands.Verdict.SAFE -> true
+
+            DangerousCommands.Verdict.REFUSED -> {
+                statusLabel.text = "Refused: ${DangerousCommands.explain(command)}"
+                appendLine("[refused] ${DangerousCommands.explain(command)}")
+                false
+            }
+
+            DangerousCommands.Verdict.DESTRUCTIVE ->
+                MessageDialogBuilder.yesNo(
+                    "Run a Destructive Command?",
+                    "On ${target.info.describe()}:\n\n    $command\n\n" +
+                        "${DangerousCommands.explain(command)} This cannot be undone.",
+                ).yesText("Run")
+                    .noText("Cancel")
+                    .asWarning()
+                    .ask(project)
+        }
+
+    private fun toggleFavourite() {
+        val command = commandField.text.trim()
+        if (command.isEmpty()) return
+        val added = history.toggleFavourite(command)
+        favouriteButton.text = if (added) "★ Favourite" else "☆ Favourite"
+        refreshHistory()
+        statusLabel.text = if (added) "Added to favourites." else "Removed from favourites."
+    }
+
+    private fun refreshHistory() {
+        val items = buildList {
+            history.favourites().forEach { add("$FAVOURITE_PREFIX$it") }
+            history.recent().forEach { add(it) }
+        }
+        historyCombo.model = javax.swing.DefaultComboBoxModel(items.toTypedArray())
+        historyCombo.selectedIndex = -1
+    }
+
+    private fun setRunning(running: Boolean) {
+        runButton.isEnabled = !running
+        cancelButton.isEnabled = running
+        statusLabel.text = if (running) "Running…" else statusLabel.text
+    }
+
+    private fun appendLine(line: String) {
+        outputBuffer.append(line).append('\n')
+        // Keep the pane bounded: a `dumpsys` dump can run to megabytes.
+        if (outputBuffer.length > MAX_OUTPUT_CHARS) {
+            outputBuffer.delete(0, outputBuffer.length - MAX_OUTPUT_CHARS)
+            output.text = "[earlier output trimmed]\n$outputBuffer"
+        } else {
+            output.append("$line\n")
+        }
+        output.caretPosition = output.document.length
+    }
+
+    private fun clearOutput() {
+        outputBuffer.setLength(0)
+        output.text = ""
+        statusLabel.text = "Output cleared."
+    }
+
+    private fun findNext() {
+        val needle = searchField.text
+        if (needle.isEmpty()) return
+
+        val from = output.caretPosition
+        val text = output.text
+        val index = text.indexOf(needle, from, ignoreCase = true)
+            .takeIf { it >= 0 }
+            ?: text.indexOf(needle, 0, ignoreCase = true)
+
+        if (index < 0) {
+            statusLabel.text = "'$needle' not found."
+            return
+        }
+        output.select(index, index + needle.length)
+        output.requestFocusInWindow()
+        statusLabel.text = "Found '$needle'."
+    }
+
+    private fun updateStatus() {
+        statusLabel.text = device?.let { "Target: ${it.info.describe()}" } ?: "No device selected."
+    }
+
+    override fun dispose() = runner.cancel()
+
+    private companion object {
+        const val MAX_OUTPUT_CHARS = 2_000_000
+        const val SEARCH_COLUMNS = 16
+        const val FAVOURITE_PREFIX = "★  "
+        const val GAP = 4
+        const val STATUS_PAD_V = 2
+        const val STATUS_PAD_H = 6
+    }
+}

--- a/src/main/kotlin/spock/adb/commandcenter/CommandHistory.kt
+++ b/src/main/kotlin/spock/adb/commandcenter/CommandHistory.kt
@@ -1,0 +1,60 @@
+package spock.adb.commandcenter
+
+/**
+ * Recent and favourite commands, with the ordering rules the UI depends on.
+ *
+ * Pure and free of IDE types so the de-duplication and eviction behaviour can be tested —
+ * getting these subtly wrong (duplicates piling up, a favourite silently evicted) is the
+ * usual way a history feature becomes annoying.
+ */
+class CommandHistory(
+    private val maxRecent: Int = DEFAULT_MAX_RECENT,
+) {
+
+    private val recent = ArrayDeque<String>()
+    private val favourites = LinkedHashSet<String>()
+
+    /** Most recently run first. Re-running a command moves it to the front, never duplicates. */
+    fun recent(): List<String> = recent.toList()
+
+    fun favourites(): List<String> = favourites.toList()
+
+    fun record(command: String) {
+        val trimmed = command.trim()
+        if (trimmed.isEmpty()) return
+
+        recent.remove(trimmed)
+        recent.addFirst(trimmed)
+        while (recent.size > maxRecent) recent.removeLast()
+    }
+
+    fun toggleFavourite(command: String): Boolean {
+        val trimmed = command.trim()
+        if (trimmed.isEmpty()) return false
+
+        return if (favourites.remove(trimmed)) {
+            false
+        } else {
+            favourites.add(trimmed)
+            true
+        }
+    }
+
+    fun isFavourite(command: String): Boolean = command.trim() in favourites
+
+    fun clearRecent() = recent.clear()
+
+    /** Restores persisted state, dropping blanks and duplicates that a hand-edited file may contain. */
+    fun load(recentCommands: List<String>, favouriteCommands: List<String>) {
+        recent.clear()
+        favourites.clear()
+        recentCommands.map(String::trim).filter(String::isNotEmpty).distinct()
+            .take(maxRecent)
+            .forEach(recent::addLast)
+        favouriteCommands.map(String::trim).filter(String::isNotEmpty).forEach(favourites::add)
+    }
+
+    companion object {
+        const val DEFAULT_MAX_RECENT = 50
+    }
+}

--- a/src/main/kotlin/spock/adb/commandcenter/CommandRunner.kt
+++ b/src/main/kotlin/spock/adb/commandcenter/CommandRunner.kt
@@ -1,0 +1,74 @@
+package spock.adb.commandcenter
+
+import com.android.ddmlib.IDevice
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.Logger
+import spock.adb.CancellableShellReceiver
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Runs one shell command at a time against a device, streaming output and honouring cancel.
+ *
+ * Cancellation is real, not cosmetic: it uses [CancellableShellReceiver], whose
+ * `isCancelled()` ddmlib polls between chunks. The Cancel button therefore stops a running
+ * `logcat` or `dumpsys` rather than only hiding it.
+ */
+class CommandRunner {
+
+    private val log = Logger.getInstance(CommandRunner::class.java)
+    private val running = AtomicBoolean(false)
+    private var receiver: CancellableShellReceiver? = null
+
+    val isRunning: Boolean get() = running.get()
+
+    /**
+     * @param onLine called on a pooled thread for each output line.
+     * @param onFinished called on a pooled thread with the failure, or null on success.
+     */
+    // A background task must not die on an unexpected exception: the caller would never
+    // learn the work stopped. Everything is reported through the completion callback.
+    @Suppress("TooGenericExceptionCaught")
+    fun run(
+        device: IDevice,
+        command: String,
+        timeoutSeconds: Long,
+        onLine: (String) -> Unit,
+        onFinished: (Throwable?) -> Unit,
+    ) {
+        if (!running.compareAndSet(false, true)) {
+            onFinished(IllegalStateException("A command is already running. Cancel it first."))
+            return
+        }
+
+        val shellReceiver = CancellableShellReceiver(onLine)
+        receiver = shellReceiver
+
+        ApplicationManager.getApplication().executeOnPooledThread {
+            var failure: Throwable? = null
+            try {
+                device.executeShellCommand(command, shellReceiver, timeoutSeconds, TimeUnit.SECONDS)
+            } catch (e: Exception) {
+                // A cancelled command throws on the way out; that is the expected path, not
+                // a failure worth reporting to the user.
+                if (!shellReceiver.isCancelled) {
+                    failure = e
+                    log.warn("ADB command failed: $command", e)
+                }
+            } finally {
+                running.set(false)
+                receiver = null
+                onFinished(failure)
+            }
+        }
+    }
+
+    fun cancel() {
+        receiver?.cancel()
+    }
+
+    companion object {
+        const val DEFAULT_TIMEOUT_SECONDS = 30L
+        const val MAX_TIMEOUT_SECONDS = 300L
+    }
+}

--- a/src/main/kotlin/spock/adb/commandcenter/DangerousCommands.kt
+++ b/src/main/kotlin/spock/adb/commandcenter/DangerousCommands.kt
@@ -1,0 +1,57 @@
+package spock.adb.commandcenter
+
+/**
+ * Classifies a shell command by how much damage running it can do.
+ *
+ * Shared by the Command Center and the MCP `android_run_adb_command` tool so a command that
+ * needs confirmation in one place needs it in the other. Two lists would drift, and the one
+ * that drifted would be the one letting something through.
+ *
+ * This is a heuristic on a string, not a sandbox. It exists so an obviously destructive
+ * command is flagged before it runs, not to make arbitrary shell safe.
+ */
+object DangerousCommands {
+
+    enum class Verdict { SAFE, DESTRUCTIVE, REFUSED }
+
+    /** Wipes the device or the developer's data rather than the app's. Never offered. */
+    private val REFUSED = listOf(
+        "rm -rf /" to "would delete the device filesystem",
+        "--wipe_data" to "would factory reset the device",
+        "recovery --wipe_data" to "would factory reset the device",
+        "wipe data" to "would factory reset the device",
+        "mkfs" to "would reformat a filesystem",
+        "dd if=" to "would write raw blocks",
+    )
+
+    /** Destroys app or system state. Allowed, but only after explicit confirmation. */
+    private val DESTRUCTIVE = listOf(
+        "pm clear" to "deletes all data for an app",
+        "pm uninstall" to "uninstalls an app",
+        "pm revoke" to "revokes a permission",
+        "pm disable" to "disables a package or component",
+        "rm " to "deletes files on the device",
+        "reboot" to "reboots the device",
+        "svc power" to "changes power state",
+        "settings put" to "changes a system setting",
+        "content delete" to "deletes content provider rows",
+        "sqlite3" to "can modify app databases directly",
+    )
+
+    fun classify(command: String): Verdict {
+        val normalised = command.trim().lowercase()
+        if (normalised.isEmpty()) return Verdict.SAFE
+
+        if (REFUSED.any { normalised.contains(it.first) }) return Verdict.REFUSED
+        if (DESTRUCTIVE.any { normalised.contains(it.first) }) return Verdict.DESTRUCTIVE
+        return Verdict.SAFE
+    }
+
+    /** Why a command was flagged, for the confirmation dialog. Null when it is not flagged. */
+    fun explain(command: String): String? {
+        val normalised = command.trim().lowercase()
+        REFUSED.firstOrNull { normalised.contains(it.first) }?.let { return "This command ${it.second}." }
+        DESTRUCTIVE.firstOrNull { normalised.contains(it.first) }?.let { return "This command ${it.second}." }
+        return null
+    }
+}

--- a/src/main/kotlin/spock/adb/logcat/LogcatBuffer.kt
+++ b/src/main/kotlin/spock/adb/logcat/LogcatBuffer.kt
@@ -1,0 +1,36 @@
+package spock.adb.logcat
+
+/**
+ * Bounded, thread-safe store of received entries.
+ *
+ * A busy device produces thousands of lines a minute. Keeping them all would grow the heap
+ * without limit for a panel that only ever shows a screenful, so the buffer is a ring: the
+ * oldest entries are dropped once it is full.
+ */
+class LogcatBuffer(private val capacity: Int = DEFAULT_CAPACITY) {
+
+    private val entries = ArrayDeque<LogcatEntry>(INITIAL_CAPACITY)
+
+    @Synchronized
+    fun add(entry: LogcatEntry) {
+        entries.addLast(entry)
+        while (entries.size > capacity) entries.removeFirst()
+    }
+
+    @Synchronized
+    fun clear() = entries.clear()
+
+    @Synchronized
+    fun snapshot(): List<LogcatEntry> = entries.toList()
+
+    @Synchronized
+    fun filtered(filter: LogcatFilter): List<LogcatEntry> = entries.filter(filter::matches)
+
+    @Synchronized
+    fun size(): Int = entries.size
+
+    companion object {
+        const val DEFAULT_CAPACITY = 20_000
+        private const val INITIAL_CAPACITY = 1_024
+    }
+}

--- a/src/main/kotlin/spock/adb/logcat/LogcatEntry.kt
+++ b/src/main/kotlin/spock/adb/logcat/LogcatEntry.kt
@@ -1,0 +1,35 @@
+package spock.adb.logcat
+
+/** One parsed logcat record. */
+data class LogcatEntry(
+    val timestamp: String,
+    val pid: Int,
+    val tid: Int,
+    val level: LogLevel,
+    val tag: String,
+    val message: String,
+    /** The original line, kept so copy and export reproduce exactly what the device sent. */
+    val raw: String,
+)
+
+enum class LogLevel(val code: Char, val label: String) {
+    VERBOSE('V', "Verbose"),
+    DEBUG('D', "Debug"),
+    INFO('I', "Info"),
+    WARN('W', "Warn"),
+    ERROR('E', "Error"),
+    ASSERT('A', "Assert");
+
+    /** Levels are ordered, so "at least WARN" is a comparison rather than a set. */
+    fun isAtLeast(other: LogLevel): Boolean = ordinal >= other.ordinal
+
+    companion object {
+        private val byCode = entries.associateBy { it.code }
+
+        /** `F` (fatal) is what the device prints for what the API calls ASSERT. */
+        fun fromCode(code: Char): LogLevel? = when (code) {
+            'F' -> ASSERT
+            else -> byCode[code]
+        }
+    }
+}

--- a/src/main/kotlin/spock/adb/logcat/LogcatFilter.kt
+++ b/src/main/kotlin/spock/adb/logcat/LogcatFilter.kt
@@ -1,0 +1,111 @@
+package spock.adb.logcat
+
+/**
+ * Filtering rules for the logcat view, kept pure so they can be tested directly.
+ *
+ * Matching happens on every incoming line on a device with a busy log, so the predicate is
+ * cheap: an ordinal comparison, a set lookup, and at most one substring or regex test.
+ */
+data class LogcatFilter(
+    val minLevel: LogLevel = LogLevel.VERBOSE,
+    val query: String = "",
+    val useRegex: Boolean = false,
+    /** Empty means "any process". Populated from the selected package's PIDs. */
+    val pids: Set<Int> = emptySet(),
+    val tag: String = "",
+) {
+
+    private val regex: Regex? = when {
+        useRegex && query.isNotBlank() -> runCatching { Regex(query, RegexOption.IGNORE_CASE) }.getOrNull()
+        else -> null
+    }
+
+    /** True when [query] is meant as a regex but does not compile, so the UI can say so. */
+    val hasInvalidRegex: Boolean = useRegex && query.isNotBlank() && regex == null
+
+    fun matches(entry: LogcatEntry): Boolean {
+        if (!entry.level.isAtLeast(minLevel)) return false
+        if (pids.isNotEmpty() && entry.pid !in pids) return false
+        if (tag.isNotBlank() && !entry.tag.contains(tag, ignoreCase = true)) return false
+        if (query.isBlank()) return true
+
+        return when {
+            // An invalid regex matches nothing rather than everything: silently showing the
+            // unfiltered log would look like the filter was ignored.
+            hasInvalidRegex -> false
+            regex != null -> regex.containsMatchIn(entry.message) || regex.containsMatchIn(entry.tag)
+            else -> entry.message.contains(query, ignoreCase = true) ||
+                entry.tag.contains(query, ignoreCase = true)
+        }
+    }
+}
+
+/**
+ * Ready-made filters for the situations developers actually open logcat for.
+ *
+ * This is where the panel earns its place next to Android Studio's Logcat window: the
+ * presets are scoped to the app under development and to the failure being chased, rather
+ * than being a general-purpose log viewer.
+ */
+enum class LogcatPreset(val label: String, val description: String) {
+    CURRENT_APP("Current app", "Everything logged by the app in the open project"),
+    ERRORS("Errors only", "Error and fatal levels, any process"),
+    CRASHES("Crashes", "Fatal exceptions and native crashes"),
+    ANR("ANRs", "Application Not Responding reports"),
+    NETWORK("Network", "HTTP clients, connectivity and socket activity"),
+    ALL("Everything", "No filtering");
+
+    fun toFilter(appPids: Set<Int>): LogcatFilter = when (this) {
+        CURRENT_APP -> LogcatFilter(pids = appPids)
+        ERRORS -> LogcatFilter(minLevel = LogLevel.ERROR)
+        CRASHES -> LogcatFilter(
+            minLevel = LogLevel.ERROR,
+            query = "FATAL EXCEPTION|AndroidRuntime|signal \\d+|backtrace:|beginning of crash",
+            useRegex = true,
+        )
+        ANR -> LogcatFilter(
+            query = "ANR in|Reason: Input dispatching timed out|am_anr",
+            useRegex = true,
+        )
+        NETWORK -> LogcatFilter(
+            query = "OkHttp|Retrofit|HttpURLConnection|ConnectivityService|Socket|TrafficStats",
+            useRegex = true,
+        )
+        ALL -> LogcatFilter()
+    }
+}
+
+/**
+ * Marks the lines a developer is usually scanning for, so they can be highlighted.
+ *
+ * A crash is several lines — the header, then the frames — so classification is per line and
+ * the UI colours each one it recognises.
+ */
+object LogcatHighlighter {
+
+    private val CRASH_MARKERS = listOf(
+        "FATAL EXCEPTION",
+        "AndroidRuntime",
+        "beginning of crash",
+        "backtrace:",
+        "signal 11",
+        "signal 6",
+    )
+
+    private val ANR_MARKERS = listOf(
+        "ANR in",
+        "Input dispatching timed out",
+        "am_anr",
+    )
+
+    fun classify(entry: LogcatEntry): Highlight = when {
+        ANR_MARKERS.any { entry.message.contains(it, ignoreCase = true) } -> Highlight.ANR
+        CRASH_MARKERS.any { entry.message.contains(it, ignoreCase = true) } -> Highlight.CRASH
+        entry.level == LogLevel.ASSERT -> Highlight.CRASH
+        entry.level == LogLevel.ERROR -> Highlight.ERROR
+        entry.level == LogLevel.WARN -> Highlight.WARNING
+        else -> Highlight.NONE
+    }
+
+    enum class Highlight { NONE, WARNING, ERROR, CRASH, ANR }
+}

--- a/src/main/kotlin/spock/adb/logcat/LogcatPanel.kt
+++ b/src/main/kotlin/spock/adb/logcat/LogcatPanel.kt
@@ -1,0 +1,402 @@
+package spock.adb.logcat
+
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.actionSystem.ActionPlaces
+import com.intellij.openapi.actionSystem.ActionUpdateThread
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.DefaultActionGroup
+import com.intellij.openapi.actionSystem.Toggleable
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.fileChooser.FileChooserFactory
+import com.intellij.openapi.fileChooser.FileSaverDescriptor
+import com.intellij.openapi.ide.CopyPasteManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.SimpleToolWindowPanel
+import com.intellij.ui.JBColor
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.components.JBList
+import com.intellij.ui.components.JBScrollPane
+import com.intellij.ui.components.JBTextField
+import com.intellij.util.ui.JBUI
+import spock.adb.device.ConnectedDevice
+import java.awt.BorderLayout
+import java.awt.Component
+import java.awt.FlowLayout
+import java.awt.datatransfer.StringSelection
+import java.awt.event.KeyAdapter
+import java.awt.event.KeyEvent
+import java.util.concurrent.ConcurrentLinkedQueue
+import javax.swing.DefaultListModel
+import javax.swing.JCheckBox
+import javax.swing.JComboBox
+import javax.swing.JPanel
+import javax.swing.ListCellRenderer
+import javax.swing.ListSelectionModel
+import javax.swing.Timer
+
+/**
+ * Live logcat, scoped to the app under development.
+ *
+ * Android Studio already has a capable Logcat window, so this one earns its place by being
+ * pre-scoped: it defaults to the open project's application ID and offers presets for the
+ * failures developers actually go looking for — crashes and ANRs — rather than being another
+ * general-purpose log viewer.
+ */
+class LogcatPanel(
+    private val project: Project,
+) : SimpleToolWindowPanel(true, true), Disposable {
+
+    private val buffer = LogcatBuffer()
+    private val listModel = DefaultListModel<LogcatEntry>()
+    private val list = JBList(listModel)
+
+    /**
+     * Entries arrive on an ADB reader thread far faster than Swing can repaint. They queue
+     * here and are drained on the EDT on a timer: appending per line would flood the event
+     * queue and lock the UI on a busy device.
+     */
+    private val incoming = ConcurrentLinkedQueue<LogcatEntry>()
+    private val flushTimer = Timer(FLUSH_INTERVAL_MS) { drainIncoming() }
+
+    private val presetCombo = JComboBox(LogcatPreset.entries.toTypedArray())
+    private val levelCombo = JComboBox(LogLevel.entries.toTypedArray())
+    private val searchField = JBTextField(SEARCH_COLUMNS)
+    private val regexToggle = JCheckBox("Regex")
+    private val autoScroll = JCheckBox("Auto-scroll", true)
+    private val statusLabel = JBLabel(" ")
+
+    private var stream: LogcatStream? = null
+    private var device: ConnectedDevice? = null
+    private var appPids: Set<Int> = emptySet()
+    private var paused = false
+
+    private var filter = LogcatFilter()
+
+    init {
+        list.selectionMode = ListSelectionModel.MULTIPLE_INTERVAL_SELECTION
+        list.cellRenderer = LogcatCellRenderer()
+        list.setEmptyText("Not streaming. Select a device and press Start.")
+
+        setToolbar(buildToolbar())
+        setContent(JBScrollPane(list).apply { border = JBUI.Borders.empty() })
+
+        wireFilterControls()
+        flushTimer.isRepeats = true
+        flushTimer.start()
+        updateStatus()
+    }
+
+    // ---------------------------------------------------------------- streaming
+
+    /** Called when the tool window's selected device changes. */
+    fun setDevice(connected: ConnectedDevice?) {
+        if (connected?.serialNumber == device?.serialNumber) return
+        stop()
+        device = connected
+        updateStatus()
+    }
+
+    fun start() {
+        val target = device ?: run {
+            statusLabel.text = "No device selected."
+            return
+        }
+        if (stream?.isRunning == true) return
+
+        resolveAppPids(target)
+
+        val logcatStream = LogcatStream(
+            device = target.device,
+            onEntry = { entry ->
+                buffer.add(entry)
+                if (!paused) incoming.add(entry)
+            },
+            onStopped = { error ->
+                ApplicationManager.getApplication().invokeLater({
+                    statusLabel.text = error?.let { "Stream ended: ${it.message}" } ?: "Stopped."
+                }) { project.isDisposed }
+            },
+        )
+        stream = logcatStream
+        logcatStream.start()
+        updateStatus()
+    }
+
+    fun stop() {
+        stream?.stop()
+        stream = null
+        updateStatus()
+    }
+
+    /**
+     * Resolves the PIDs of the project's app so "Current app" can filter by process rather
+     * than by matching the package name against message text, which both misses lines and
+     * returns unrelated ones.
+     */
+    private fun resolveAppPids(target: ConnectedDevice) {
+        val applicationId = runCatching {
+            spock.adb.command.GetApplicationIDCommand.resolve(project)
+        }.getOrNull() ?: return
+
+        ApplicationManager.getApplication().executeOnPooledThread {
+            val pids = runCatching {
+                val receiver = spock.adb.ShellOutputReceiver()
+                target.device.executeShellCommand(
+                    "pidof ${spock.adb.ShellQuote.quote(applicationId)}",
+                    receiver,
+                    PIDOF_TIMEOUT_SECONDS,
+                    java.util.concurrent.TimeUnit.SECONDS,
+                )
+                receiver.toString().trim().split(Regex("\\s+")).mapNotNull(String::toIntOrNull).toSet()
+            }.getOrDefault(emptySet())
+
+            ApplicationManager.getApplication().invokeLater({
+                appPids = pids
+                applyFilter()
+            }) { project.isDisposed }
+        }
+    }
+
+    // ---------------------------------------------------------------- filtering
+
+    private fun wireFilterControls() {
+        presetCombo.addActionListener {
+            val preset = presetCombo.selectedItem as LogcatPreset
+            val presetFilter = preset.toFilter(appPids)
+            // Reflect the preset in the controls so it is visible what is being applied,
+            // and so the developer can adjust it rather than only replace it.
+            levelCombo.selectedItem = presetFilter.minLevel
+            searchField.text = presetFilter.query
+            regexToggle.isSelected = presetFilter.useRegex
+            applyFilter()
+        }
+        levelCombo.addActionListener { applyFilter() }
+        regexToggle.addActionListener { applyFilter() }
+        searchField.addKeyListener(
+            object : KeyAdapter() {
+                override fun keyReleased(e: KeyEvent) = applyFilter()
+            },
+        )
+    }
+
+    private fun applyFilter() {
+        val preset = presetCombo.selectedItem as LogcatPreset
+        filter = LogcatFilter(
+            minLevel = levelCombo.selectedItem as LogLevel,
+            query = searchField.text.orEmpty(),
+            useRegex = regexToggle.isSelected,
+            pids = if (preset == LogcatPreset.CURRENT_APP) appPids else emptySet(),
+        )
+        rebuildFromBuffer()
+    }
+
+    /** Re-applies the filter to everything received so far, not just to new lines. */
+    private fun rebuildFromBuffer() {
+        val matching = buffer.filtered(filter)
+        listModel.clear()
+        matching.forEach(listModel::addElement)
+        scrollToEndIfFollowing()
+        updateStatus()
+    }
+
+    private fun drainIncoming() {
+        if (incoming.isEmpty()) return
+
+        var appended = false
+        while (true) {
+            val entry = incoming.poll() ?: break
+            if (filter.matches(entry)) {
+                listModel.addElement(entry)
+                appended = true
+            }
+        }
+        if (appended) {
+            trimModel()
+            scrollToEndIfFollowing()
+            updateStatus()
+        }
+    }
+
+    /** Keeps the visible model bounded independently of the backing buffer. */
+    private fun trimModel() {
+        while (listModel.size() > VISIBLE_LIMIT) listModel.remove(0)
+    }
+
+    private fun scrollToEndIfFollowing() {
+        if (autoScroll.isSelected && listModel.size() > 0) {
+            list.ensureIndexIsVisible(listModel.size() - 1)
+        }
+    }
+
+    private fun updateStatus() {
+        val state = when {
+            stream?.isRunning == true && paused -> "Paused"
+            stream?.isRunning == true -> "Streaming"
+            else -> "Stopped"
+        }
+        val deviceLabel = device?.info?.displayName ?: "no device"
+        val invalid = if (filter.hasInvalidRegex) "  —  invalid regex" else ""
+        statusLabel.text = "$state  ·  $deviceLabel  ·  ${listModel.size()} shown of ${buffer.size()}$invalid"
+    }
+
+    // ---------------------------------------------------------------- toolbar
+
+    private fun buildToolbar(): JPanel {
+        val actions = DefaultActionGroup().apply {
+            add(
+                simpleAction("Start", "Start streaming logcat", AllIcons.Actions.Execute) {
+                    paused = false
+                    start()
+                },
+            )
+            add(simpleAction("Stop", "Stop streaming", AllIcons.Actions.Suspend) { stop() })
+            add(
+                simpleAction("Pause / Resume", "Freeze the view without stopping the stream", AllIcons.Actions.Pause) {
+                    paused = !paused
+                    if (!paused) drainIncoming()
+                    updateStatus()
+                },
+            )
+            addSeparator()
+            add(
+                simpleAction("Clear", "Clear the view and the device buffer", AllIcons.Actions.GC) {
+                    buffer.clear()
+                    incoming.clear()
+                    listModel.clear()
+                    stream?.clearDeviceBuffer()
+                    updateStatus()
+                },
+            )
+            add(simpleAction("Copy", "Copy the selected lines", AllIcons.Actions.Copy) { copySelection() })
+            add(
+                simpleAction(
+                    "Export",
+                    "Export the visible log to a file",
+                    AllIcons.ToolbarDecorator.Export,
+                ) { export() },
+            )
+        }
+
+        val toolbar = ActionManager.getInstance()
+            .createActionToolbar(ActionPlaces.TOOLWINDOW_CONTENT, actions, true)
+        toolbar.targetComponent = this
+
+        val filters = JPanel(FlowLayout(FlowLayout.LEFT, JBUI.scale(GAP), 0)).apply {
+            add(JBLabel("Preset:"))
+            add(presetCombo)
+            add(JBLabel("Level:"))
+            add(levelCombo)
+            add(JBLabel("Search:"))
+            add(searchField)
+            add(regexToggle)
+            add(autoScroll)
+        }
+
+        return JPanel(BorderLayout()).apply {
+            add(toolbar.component, BorderLayout.WEST)
+            add(filters, BorderLayout.CENTER)
+            add(statusLabel.apply { border = JBUI.Borders.emptyRight(STATUS_PAD_RIGHT) }, BorderLayout.EAST)
+        }
+    }
+
+    private fun simpleAction(text: String, description: String, icon: javax.swing.Icon, run: () -> Unit) =
+        object : AnAction(text, description, icon), Toggleable {
+            override fun getActionUpdateThread() = ActionUpdateThread.EDT
+            override fun actionPerformed(e: AnActionEvent) = run()
+        }
+
+    private fun copySelection() {
+        val selected = list.selectedValuesList
+        val text = when {
+            selected.isNotEmpty() -> selected.joinToString("\n") { it.raw }
+            else -> (0 until listModel.size()).joinToString("\n") { listModel.get(it).raw }
+        }
+        CopyPasteManager.getInstance().setContents(StringSelection(text))
+        statusLabel.text = "Copied ${text.lines().size} lines."
+    }
+
+    private fun export() {
+        // The two-argument constructor does not exist before 2025.1 — Plugin Verifier caught
+        // it as a NoSuchMethodError risk on AI-231, AI-242 and IC-231. The vararg overload is
+        // deprecated on newer platforms but present on all supported ones, and a deprecation
+        // warning is strictly better than a crash. See docs/COMPATIBILITY.md.
+        @Suppress("DEPRECATION")
+        val descriptor = FileSaverDescriptor("Export Logcat", "Save the visible log lines", "txt", "log")
+        val dialog = FileChooserFactory.getInstance().createSaveFileDialog(descriptor, project)
+        // Disambiguate the overload: save(VirtualFile?, String) vs save(Path?, String).
+        val target = dialog.save(null as java.nio.file.Path?, "logcat.txt") ?: return
+
+        runCatching {
+            target.file.writeText((0 until listModel.size()).joinToString("\n") { listModel.get(it).raw })
+        }.onSuccess {
+            statusLabel.text = "Exported ${listModel.size()} lines to ${target.file.name}."
+        }.onFailure {
+            statusLabel.text = "Export failed: ${it.message}"
+        }
+    }
+
+    override fun dispose() {
+        flushTimer.stop()
+        stop()
+    }
+
+    // ---------------------------------------------------------------- rendering
+
+    private class LogcatCellRenderer : ListCellRenderer<LogcatEntry> {
+        private val label = JBLabel().apply { border = JBUI.Borders.empty(0, CELL_PAD_H) }
+
+        override fun getListCellRendererComponent(
+            list: javax.swing.JList<out LogcatEntry>,
+            value: LogcatEntry,
+            index: Int,
+            isSelected: Boolean,
+            cellHasFocus: Boolean,
+        ): Component {
+            label.text = value.render()
+            label.font = list.font
+            label.isOpaque = true
+            label.background = if (isSelected) list.selectionBackground else list.background
+            label.foreground = when {
+                isSelected -> list.selectionForeground
+                else -> colourFor(LogcatHighlighter.classify(value))
+            }
+            return label
+        }
+
+        private fun LogcatEntry.render(): String = when {
+            timestamp.isEmpty() -> message
+            else -> "$timestamp  $pid-$tid  ${level.code}/$tag: $message"
+        }
+
+        private fun colourFor(highlight: LogcatHighlighter.Highlight): JBColor = when (highlight) {
+            // Crashes and ANRs are what the developer opened the panel for, so they get the
+            // strongest colour; warnings are dimmed rather than shouted.
+            LogcatHighlighter.Highlight.CRASH -> CRASH
+            LogcatHighlighter.Highlight.ANR -> ANR
+            LogcatHighlighter.Highlight.ERROR -> ERROR
+            LogcatHighlighter.Highlight.WARNING -> WARNING
+            LogcatHighlighter.Highlight.NONE -> NORMAL
+        }
+
+        private companion object {
+            const val CELL_PAD_H = 6
+            val CRASH = JBColor(0xC7222A, 0xFF6B6B)
+            val ANR = JBColor(0x9C27B0, 0xCE93D8)
+            val ERROR = JBColor(0xB3261E, 0xF2857C)
+            val WARNING = JBColor(0x8A6100, 0xE0A030)
+            val NORMAL = JBColor(0x2B2B2B, 0xBBBBBB)
+        }
+    }
+
+    private companion object {
+        const val FLUSH_INTERVAL_MS = 100
+        const val VISIBLE_LIMIT = 10_000
+        const val SEARCH_COLUMNS = 18
+        const val PIDOF_TIMEOUT_SECONDS = 10L
+        const val GAP = 4
+        const val STATUS_PAD_RIGHT = 8
+    }
+}

--- a/src/main/kotlin/spock/adb/logcat/LogcatParser.kt
+++ b/src/main/kotlin/spock/adb/logcat/LogcatParser.kt
@@ -1,0 +1,61 @@
+package spock.adb.logcat
+
+/**
+ * Parses the `threadtime` logcat format, which is the one this plugin always requests:
+ *
+ * ```
+ * 10-04 12:34:56.789  1234  1250 E MyTag: something went wrong
+ * ```
+ *
+ * Kept pure so the format can be tested against recorded device output. Lines that do not
+ * match — logcat's own banners such as `--------- beginning of main` — are still surfaced
+ * rather than dropped, because silently swallowing log lines makes the panel untrustworthy.
+ */
+object LogcatParser {
+
+    private const val TIMESTAMP = 1
+    private const val PID = 2
+    private const val TID = 3
+    private const val LEVEL = 4
+    private const val TAG = 5
+    private const val MESSAGE = 6
+
+    private val THREADTIME = Regex(
+        """^(\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3})\s+(\d+)\s+(\d+)\s+([VDIWEFA])\s+(.*?):\s?(.*)$""",
+    )
+
+    fun parse(line: String): LogcatEntry? {
+        if (line.isBlank()) return null
+
+        val match = THREADTIME.find(line)
+            ?: return unparsed(line)
+
+        val groups = match.groupValues
+        val level = LogLevel.fromCode(groups[LEVEL].first()) ?: return unparsed(line)
+
+        return LogcatEntry(
+            timestamp = groups[TIMESTAMP],
+            pid = groups[PID].toIntOrNull() ?: 0,
+            tid = groups[TID].toIntOrNull() ?: 0,
+            level = level,
+            tag = groups[TAG].trim(),
+            message = groups[MESSAGE],
+            raw = line,
+        )
+    }
+
+    /**
+     * Anything that is not a record — separators, `beginning of main`, a wrapped stack frame
+     * that arrived on its own line — is kept at INFO with no tag so it stays visible in the
+     * stream and in exports.
+     */
+    private fun unparsed(line: String) = LogcatEntry(
+        timestamp = "",
+        pid = 0,
+        tid = 0,
+        level = LogLevel.INFO,
+        tag = "",
+        message = line,
+        raw = line,
+    )
+}

--- a/src/main/kotlin/spock/adb/logcat/LogcatStream.kt
+++ b/src/main/kotlin/spock/adb/logcat/LogcatStream.kt
@@ -1,0 +1,88 @@
+package spock.adb.logcat
+
+import com.android.ddmlib.IDevice
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.Logger
+import spock.adb.CancellableShellReceiver
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * A live `logcat` stream from one device.
+ *
+ * ddmlib has no streaming logcat API that survives across the versions this plugin
+ * supports, so the stream is `logcat -v threadtime` read through a
+ * [CancellableShellReceiver]. That receiver is what makes stopping possible at all: the
+ * previous receiver hard-coded `isCancelled()` to `false`, so a long-running command could
+ * never be interrupted.
+ *
+ * Lines arrive on an ADB reader thread. Parsing happens there — it is cheap and keeps the
+ * EDT free — and only the finished [LogcatEntry] is handed to the listener, which is
+ * responsible for getting itself onto the EDT before touching Swing.
+ */
+class LogcatStream(
+    private val device: IDevice,
+    private val onEntry: (LogcatEntry) -> Unit,
+    private val onStopped: (Throwable?) -> Unit = {},
+) {
+
+    private val log = Logger.getInstance(LogcatStream::class.java)
+    private val running = AtomicBoolean(false)
+    private var receiver: CancellableShellReceiver? = null
+
+    val isRunning: Boolean get() = running.get()
+
+    // A background task must not die on an unexpected exception: the caller would never
+    // learn the work stopped. Everything is reported through the completion callback.
+    @Suppress("TooGenericExceptionCaught")
+    fun start() {
+        if (!running.compareAndSet(false, true)) return
+
+        val shellReceiver = CancellableShellReceiver { line ->
+            LogcatParser.parse(line)?.let(onEntry)
+        }
+        receiver = shellReceiver
+
+        ApplicationManager.getApplication().executeOnPooledThread {
+            var failure: Throwable? = null
+            try {
+                // `-v threadtime` is what LogcatParser expects. No `-d`: this is a live tail.
+                //
+                // A zero timeout means "no limit on time between output chunks", which is
+                // required here — an idle device can legitimately log nothing for minutes.
+                // It is only safe because the receiver can be cancelled; the same zero
+                // timeout on the non-cancellable receiver was an unrecoverable hang.
+                device.executeShellCommand("logcat -v threadtime", shellReceiver, 0L, TimeUnit.SECONDS)
+            } catch (e: Exception) {
+                if (!shellReceiver.isCancelled) {
+                    failure = e
+                    log.warn("Logcat stream for ${device.serialNumber} ended unexpectedly", e)
+                }
+            } finally {
+                running.set(false)
+                onStopped(failure)
+            }
+        }
+    }
+
+    private companion object {
+        const val CLEAR_TIMEOUT_SECONDS = 10L
+    }
+
+    fun stop() {
+        receiver?.cancel()
+        running.set(false)
+    }
+
+    /** Clears the device's log buffers so the next lines are genuinely new. */
+    fun clearDeviceBuffer() {
+        runCatching {
+            device.executeShellCommand(
+                "logcat -c",
+                spock.adb.ShellOutputReceiver(),
+                CLEAR_TIMEOUT_SECONDS,
+                TimeUnit.SECONDS,
+            )
+        }.onFailure { log.warn("Could not clear the logcat buffer", it) }
+    }
+}

--- a/src/test/kotlin/spock/adb/commandcenter/CommandHistoryTest.kt
+++ b/src/test/kotlin/spock/adb/commandcenter/CommandHistoryTest.kt
@@ -1,0 +1,94 @@
+package spock.adb.commandcenter
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class CommandHistoryTest {
+
+    @Test
+    fun `most recent command comes first`() {
+        val history = CommandHistory()
+        history.record("pm list packages")
+        history.record("dumpsys battery")
+
+        assertEquals(listOf("dumpsys battery", "pm list packages"), history.recent())
+    }
+
+    @Test
+    fun `re-running a command moves it to the front instead of duplicating it`() {
+        val history = CommandHistory()
+        history.record("a")
+        history.record("b")
+        history.record("a")
+
+        assertEquals(listOf("a", "b"), history.recent())
+    }
+
+    @Test
+    fun `history is bounded and drops the oldest`() {
+        val history = CommandHistory(maxRecent = 3)
+        listOf("1", "2", "3", "4").forEach(history::record)
+
+        assertEquals(listOf("4", "3", "2"), history.recent())
+    }
+
+    @Test
+    fun `blank commands are not recorded`() {
+        val history = CommandHistory()
+        history.record("   ")
+        history.record("")
+
+        assertTrue(history.recent().isEmpty())
+    }
+
+    @Test
+    fun `commands are trimmed so whitespace does not create duplicates`() {
+        val history = CommandHistory()
+        history.record("ps -A")
+        history.record("  ps -A  ")
+
+        assertEquals(listOf("ps -A"), history.recent())
+    }
+
+    @Test
+    fun `toggling a favourite adds then removes it`() {
+        val history = CommandHistory()
+
+        assertTrue(history.toggleFavourite("dumpsys battery"))
+        assertTrue(history.isFavourite("dumpsys battery"))
+
+        assertFalse(history.toggleFavourite("dumpsys battery"))
+        assertFalse(history.isFavourite("dumpsys battery"))
+    }
+
+    @Test
+    fun `favourites survive clearing recent commands`() {
+        val history = CommandHistory()
+        history.record("ps -A")
+        history.toggleFavourite("ps -A")
+
+        history.clearRecent()
+
+        assertTrue(history.recent().isEmpty())
+        assertEquals(listOf("ps -A"), history.favourites())
+    }
+
+    @Test
+    fun `loading persisted state drops blanks and duplicates`() {
+        val history = CommandHistory()
+        history.load(listOf("a", "  a  ", "", "b"), listOf("fav", "fav", " "))
+
+        assertEquals(listOf("a", "b"), history.recent())
+        assertEquals(listOf("fav"), history.favourites())
+    }
+
+    @Test
+    fun `loading respects the recent limit`() {
+        val history = CommandHistory(maxRecent = 2)
+        history.load(listOf("1", "2", "3"), emptyList())
+
+        assertEquals(listOf("1", "2"), history.recent())
+    }
+}

--- a/src/test/kotlin/spock/adb/commandcenter/DangerousCommandsTest.kt
+++ b/src/test/kotlin/spock/adb/commandcenter/DangerousCommandsTest.kt
@@ -1,0 +1,55 @@
+package spock.adb.commandcenter
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class DangerousCommandsTest {
+
+    @Test
+    fun `ordinary inspection commands are safe`() {
+        listOf("pm list packages", "dumpsys battery", "ps -A", "logcat -d", "getprop")
+            .forEach { assertEquals(DangerousCommands.Verdict.SAFE, DangerousCommands.classify(it), it) }
+    }
+
+    @Test
+    fun `commands that destroy app or system state need confirmation`() {
+        listOf(
+            "pm clear com.example.app",
+            "pm uninstall com.example.app",
+            "pm revoke com.example.app android.permission.CAMERA",
+            "rm /sdcard/file.txt",
+            "reboot",
+            "settings put global airplane_mode_on 1",
+        ).forEach {
+            assertEquals(DangerousCommands.Verdict.DESTRUCTIVE, DangerousCommands.classify(it), it)
+        }
+    }
+
+    @Test
+    fun `commands that wipe the device are refused outright`() {
+        listOf("rm -rf /", "recovery --wipe_data", "mkfs.ext4 /dev/block/x", "dd if=/dev/zero of=/dev/block/x")
+            .forEach {
+                assertEquals(DangerousCommands.Verdict.REFUSED, DangerousCommands.classify(it), it)
+            }
+    }
+
+    @Test
+    fun `classification ignores case`() {
+        assertEquals(DangerousCommands.Verdict.DESTRUCTIVE, DangerousCommands.classify("PM CLEAR com.example"))
+        assertEquals(DangerousCommands.Verdict.REFUSED, DangerousCommands.classify("RM -RF /"))
+    }
+
+    @Test
+    fun `an empty command is safe rather than an error`() {
+        assertEquals(DangerousCommands.Verdict.SAFE, DangerousCommands.classify("   "))
+    }
+
+    @Test
+    fun `flagged commands explain themselves and safe ones do not`() {
+        assertNotNull(DangerousCommands.explain("pm clear com.example.app"))
+        assertNotNull(DangerousCommands.explain("rm -rf /"))
+        assertNull(DangerousCommands.explain("ps -A"))
+    }
+}

--- a/src/test/kotlin/spock/adb/logcat/LogcatBufferTest.kt
+++ b/src/test/kotlin/spock/adb/logcat/LogcatBufferTest.kt
@@ -1,0 +1,41 @@
+package spock.adb.logcat
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class LogcatBufferTest {
+
+    private fun entry(message: String, level: LogLevel = LogLevel.INFO) =
+        LogcatEntry("t", 1, 1, level, "Tag", message, message)
+
+    @Test
+    fun `drops the oldest entries once full`() {
+        // A busy device would otherwise grow the heap without limit.
+        val buffer = LogcatBuffer(capacity = 3)
+        listOf("1", "2", "3", "4").forEach { buffer.add(entry(it)) }
+
+        assertEquals(listOf("2", "3", "4"), buffer.snapshot().map { it.message })
+        assertEquals(3, buffer.size())
+    }
+
+    @Test
+    fun `filtering applies to everything received, not just new lines`() {
+        val buffer = LogcatBuffer()
+        buffer.add(entry("keep", LogLevel.ERROR))
+        buffer.add(entry("drop", LogLevel.DEBUG))
+
+        val filtered = buffer.filtered(LogcatFilter(minLevel = LogLevel.ERROR))
+
+        assertEquals(listOf("keep"), filtered.map { it.message })
+    }
+
+    @Test
+    fun `clearing empties the buffer`() {
+        val buffer = LogcatBuffer()
+        buffer.add(entry("x"))
+        buffer.clear()
+
+        assertTrue(buffer.snapshot().isEmpty())
+    }
+}

--- a/src/test/kotlin/spock/adb/logcat/LogcatFilterTest.kt
+++ b/src/test/kotlin/spock/adb/logcat/LogcatFilterTest.kt
@@ -1,0 +1,119 @@
+package spock.adb.logcat
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class LogcatFilterTest {
+
+    private fun entry(
+        level: LogLevel = LogLevel.INFO,
+        tag: String = "Tag",
+        message: String = "message",
+        pid: Int = 1000,
+    ) = LogcatEntry("10-04 12:00:00.000", pid, pid, level, tag, message, "raw")
+
+    @Test
+    fun `level filtering is inclusive of the selected level and above`() {
+        val filter = LogcatFilter(minLevel = LogLevel.WARN)
+
+        assertFalse(filter.matches(entry(level = LogLevel.INFO)))
+        assertTrue(filter.matches(entry(level = LogLevel.WARN)))
+        assertTrue(filter.matches(entry(level = LogLevel.ERROR)))
+        assertTrue(filter.matches(entry(level = LogLevel.ASSERT)))
+    }
+
+    @Test
+    fun `an empty pid set means any process`() {
+        assertTrue(LogcatFilter().matches(entry(pid = 42)))
+    }
+
+    @Test
+    fun `pid filtering keeps only the listed processes`() {
+        val filter = LogcatFilter(pids = setOf(100, 200))
+
+        assertTrue(filter.matches(entry(pid = 100)))
+        assertFalse(filter.matches(entry(pid = 300)))
+    }
+
+    @Test
+    fun `plain search matches message or tag, case-insensitively`() {
+        val filter = LogcatFilter(query = "boom")
+
+        assertTrue(filter.matches(entry(message = "It went BOOM")))
+        assertTrue(filter.matches(entry(tag = "BoomTag", message = "fine")))
+        assertFalse(filter.matches(entry(message = "all good")))
+    }
+
+    @Test
+    fun `regex search matches on the pattern`() {
+        val filter = LogcatFilter(query = "err(or)?\\d+", useRegex = true)
+
+        assertTrue(filter.matches(entry(message = "error42 happened")))
+        assertTrue(filter.matches(entry(message = "err7")))
+        assertFalse(filter.matches(entry(message = "nothing")))
+    }
+
+    @Test
+    fun `an invalid regex matches nothing and is reported`() {
+        // Falling back to matching everything would look like the filter was ignored.
+        val filter = LogcatFilter(query = "[unclosed", useRegex = true)
+
+        assertTrue(filter.hasInvalidRegex)
+        assertFalse(filter.matches(entry(message = "anything")))
+    }
+
+    @Test
+    fun `tag filtering narrows by tag only`() {
+        val filter = LogcatFilter(tag = "OkHttp")
+
+        assertTrue(filter.matches(entry(tag = "OkHttpClient")))
+        assertFalse(filter.matches(entry(tag = "ActivityManager")))
+    }
+
+    @Test
+    fun `the crashes preset matches a fatal exception header`() {
+        val filter = LogcatPreset.CRASHES.toFilter(emptySet())
+
+        val crash = entry(level = LogLevel.ERROR, tag = "AndroidRuntime", message = "FATAL EXCEPTION: main")
+        assertTrue(filter.matches(crash))
+        assertFalse(filter.matches(entry(level = LogLevel.INFO, message = "just information")))
+    }
+
+    @Test
+    fun `the ANR preset matches an ANR report`() {
+        val filter = LogcatPreset.ANR.toFilter(emptySet())
+
+        assertTrue(filter.matches(entry(message = "ANR in com.example.app")))
+        assertTrue(filter.matches(entry(message = "Reason: Input dispatching timed out")))
+    }
+
+    @Test
+    fun `the current app preset filters by the app's pids`() {
+        val filter = LogcatPreset.CURRENT_APP.toFilter(setOf(555))
+
+        assertTrue(filter.matches(entry(pid = 555)))
+        assertFalse(filter.matches(entry(pid = 556)))
+    }
+
+    @Test
+    fun `highlighting classifies crashes, ANRs and levels`() {
+        assertEquals(
+            LogcatHighlighter.Highlight.CRASH,
+            LogcatHighlighter.classify(entry(level = LogLevel.ERROR, message = "FATAL EXCEPTION: main")),
+        )
+        assertEquals(
+            LogcatHighlighter.Highlight.ANR,
+            LogcatHighlighter.classify(entry(message = "ANR in com.example.app")),
+        )
+        assertEquals(
+            LogcatHighlighter.Highlight.ERROR,
+            LogcatHighlighter.classify(entry(level = LogLevel.ERROR, message = "ordinary error")),
+        )
+        assertEquals(
+            LogcatHighlighter.Highlight.NONE,
+            LogcatHighlighter.classify(entry(level = LogLevel.DEBUG)),
+        )
+    }
+}

--- a/src/test/kotlin/spock/adb/logcat/LogcatParserTest.kt
+++ b/src/test/kotlin/spock/adb/logcat/LogcatParserTest.kt
@@ -1,0 +1,72 @@
+package spock.adb.logcat
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class LogcatParserTest {
+
+    @Test
+    fun `parses a threadtime record`() {
+        val entry = LogcatParser.parse("10-04 12:34:56.789  1234  1250 E MyTag: something went wrong")!!
+
+        assertEquals("10-04 12:34:56.789", entry.timestamp)
+        assertEquals(1234, entry.pid)
+        assertEquals(1250, entry.tid)
+        assertEquals(LogLevel.ERROR, entry.level)
+        assertEquals("MyTag", entry.tag)
+        assertEquals("something went wrong", entry.message)
+    }
+
+    @Test
+    fun `maps every level code including fatal`() {
+        mapOf(
+            'V' to LogLevel.VERBOSE,
+            'D' to LogLevel.DEBUG,
+            'I' to LogLevel.INFO,
+            'W' to LogLevel.WARN,
+            'E' to LogLevel.ERROR,
+            'A' to LogLevel.ASSERT,
+            // The device prints F for what the API calls ASSERT.
+            'F' to LogLevel.ASSERT,
+        ).forEach { (code, expected) ->
+            val entry = LogcatParser.parse("10-04 12:00:00.000  1  1 $code Tag: msg")!!
+            assertEquals(expected, entry.level, "code $code")
+        }
+    }
+
+    @Test
+    fun `handles tags containing spaces and colons in the message`() {
+        val entry = LogcatParser.parse("10-04 12:00:00.000  1  1 I My Tag: a: b: c")!!
+
+        assertEquals("My Tag", entry.tag)
+        assertEquals("a: b: c", entry.message)
+    }
+
+    @Test
+    fun `handles an empty message`() {
+        val entry = LogcatParser.parse("10-04 12:00:00.000  1  1 I Tag:")!!
+        assertEquals("", entry.message)
+    }
+
+    @Test
+    fun `keeps the raw line so copy and export reproduce the device output`() {
+        val raw = "10-04 12:34:56.789  1234  1250 E MyTag: boom"
+        assertEquals(raw, LogcatParser.parse(raw)!!.raw)
+    }
+
+    @Test
+    fun `surfaces logcat banners instead of dropping them`() {
+        // Silently swallowing lines makes the panel untrustworthy.
+        val entry = LogcatParser.parse("--------- beginning of crash")!!
+
+        assertEquals("--------- beginning of crash", entry.message)
+        assertEquals("", entry.tag)
+    }
+
+    @Test
+    fun `ignores blank lines`() {
+        assertNull(LogcatParser.parse(""))
+        assertNull(LogcatParser.parse("    "))
+    }
+}


### PR DESCRIPTION
The tool window is now three tabs — **Devices**, **Logcat**, **Commands** — sharing the device selected in Devices, so there is one answer to "which device is this acting on" across the whole window.

## Cancellation had to come first

Neither feature was possible before. `ShellOutputReceiver` hard-coded `isCancelled()` to `false`, and ddmlib polls that between chunks — so **no long-running command could ever be interrupted**. This was flagged in the audit as the thing blocking progress, cancellation *and* the coroutine migration.

`CancellableShellReceiver` streams output line by line and honours cancellation. That is what makes a live logcat tail and a Cancel button that actually stops a command possible.

## Logcat

Android Studio already has a capable Logcat window, so this one earns its place by being **pre-scoped** rather than being another general-purpose log viewer: it defaults to the open project's application ID and offers presets for the failures developers actually go looking for.

- **Presets:** Current app, Errors only, Crashes, ANRs, Network
- **Filtering by process ID**, not by matching the package name against message text — text matching both misses lines and returns unrelated ones
- Level, tag, plain-text and regex search. An invalid regex **matches nothing and says so**, rather than silently showing the unfiltered log and looking like the filter was ignored
- Crash and ANR highlighting, pause/resume, clear (view + device buffer), copy, export, auto-scroll

Two things worth reviewing:

- Entries arrive on an ADB reader thread far faster than Swing repaints, so they queue and drain on the EDT on a 100 ms timer. Appending per line floods the event queue on a busy device.
- The buffer is a **bounded ring**. A busy device produces thousands of lines a minute; keeping them all grows the heap for a panel that only shows a screenful.

## Command Center

Run any shell command with a real timeout and a working Cancel. History that **de-duplicates and reorders** instead of piling up, favourites that survive clearing history, searchable output, copy command / copy output / clear.

Destructive commands are confirmed before running and catastrophic ones refused outright. `DangerousCommands` is **shared with the MCP `android_run_adb_command` tool**, so a command needing confirmation for an AI agent needs it in the UI too — two lists would drift, and the one that drifted would be the one letting something through.

## Compatibility — a third `NoSuchMethodError` caught

`FileSaverDescriptor(String, String)` reads better and the vararg form is deprecated on 2025.1 — but the two-argument constructor **does not exist before it**:

```
Method LogcatPanel.export() contains an *invokespecial* instruction referencing an
unresolved constructor FileSaverDescriptor.<init>(String, String).
This can lead to NoSuchMethodError exception at runtime.
```

Caught on AI-231, AI-242 and IC-231. The deprecated-but-present overload is used instead: **a deprecation warning on the newest platform beats a crash on the oldest.** Recorded in `docs/COMPATIBILITY.md` as the third instance of this failure mode (after compatibility bridges and an inlined platform helper).

## Docs

README now documents the MCP server, Logcat and the Command Center, and links the docs. The Marketplace description mentions MCP and IntelliJ IDEA support — **MCP shipped in 4.0.0 with no README mention at all**, which was an oversight.

## Verification

**117 tests**, all green (up from 81). `test`, `detekt`, `buildPlugin`, `verifyPlugin` all pass — all five IDE targets **Compatible**.

Tests cover the parts that are pure: the `threadtime` parser (including `F`→ASSERT and logcat banners), filter and preset matching, the bounded buffer, history de-duplication and eviction, and dangerous-command classification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)