### PR TITLE
Gate the descriptor that goes to the Marketplace

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,11 @@ jobs:
       - name: Build Plugin
         run: ./gradlew buildPlugin
 
+      # Catch a descriptor that would be unpublishable or invisible on the Marketplace at
+      # pull-request time, not at release time.
+      - name: Verify Marketplace Descriptor
+        run: scripts/verify-marketplace-descriptor.sh
+
       - name: Prepare Plugin Artifact
         id: artifact
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,17 @@ jobs:
         run: |
           ./gradlew patchChangelog --release-note="$CHANGELOG"
 
+      # The descriptor is what decides whether a release is visible at all. Build it and
+      # assert it before handing it to the Marketplace: an until-build cap or a changed
+      # plugin id publishes "successfully" and is then never served to any IDE. See
+      # scripts/verify-marketplace-descriptor.sh for the two releases that proved it.
+      - name: Verify Marketplace Descriptor
+        env:
+          EXPECTED_VERSION: ${{ github.event.release.tag_name }}
+        run: |
+          ./gradlew buildPlugin
+          EXPECTED_VERSION="${EXPECTED_VERSION#v}" scripts/verify-marketplace-descriptor.sh
+
       - name: Publish Plugin
         env:
           PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Added
+
+- `scripts/verify-marketplace-descriptor.sh` — gates the built descriptor before it reaches JetBrains Marketplace: the plugin id must be `com.wahdan.com.wahdan.spockAdb`, there must be no `until-build` cap, `since-build` must match `pluginSinceBuild`, and the version must match the release tag. Runs in `build.yml` on every pull request and in `release.yml` immediately before `publishPlugin`
+
+### Documentation
+
+- `docs/COMPATIBILITY.md` records why the Marketplace served 1.0.2 to modern IDEs for four years: 2.0.x shipped an `until-build` cap that silently expired the release, and 3.0.x renamed the plugin id so it could never reach listing 11591
+- `CONTRIBUTING.md` no longer claims a release is live "within a few minutes" — a green `release.yml` means uploaded, not approved and served — and says how to confirm which version an IDE is actually offered
+
 ## [4.0.0] - 2026-09-04
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,8 +158,10 @@ The CI (`build.yml`) will automatically:
 
 **3. CI publishes automatically**
 The `release.yml` workflow triggers and:
+- Checks the built descriptor with `scripts/verify-marketplace-descriptor.sh` — plugin id,
+  no `until-build`, `since-build`, and version-matches-tag — **before** publishing
 - Signs the plugin with your certificates
-- Publishes to [JetBrains Marketplace](https://plugins.jetbrains.com/plugin/11591-spock-adb)
+- Publishes to [JetBrains Marketplace](https://plugins.jetbrains.com/plugin/11591-spockadb)
 - Uploads the signed `.zip` to the GitHub Release
 - Opens a PR that:
   - Moves `[Unreleased]` → `[3.0.0]` in `CHANGELOG.md`
@@ -167,7 +169,17 @@ The `release.yml` workflow triggers and:
 
 **4. Merge the post-release PR**
 
-That's it. The plugin is live on the marketplace within a few minutes.
+**5. Confirm the version is actually being served**
+
+A green `release.yml` means *uploaded*, not *live*. The new version goes through Marketplace
+approval and a compatibility-index rebuild, during which the plugin page can already show the
+new description while the IDE's Install button still offers the previous version. Check
+<https://plugins.jetbrains.com/plugin/11591/versions> for the version's state, then confirm in
+a real IDE (**Settings → Plugins → Marketplace**, after *Check for Updates*).
+
+If an IDE offers an *older* version than the one you published, that is a descriptor problem,
+not a caching problem — read
+[Why the Marketplace served 1.0.2 for four years](docs/COMPATIBILITY.md#why-the-marketplace-served-102-for-four-years).
 
 ---
 
@@ -175,8 +187,8 @@ That's it. The plugin is live on the marketplace within a few minutes.
 
 | Workflow | Trigger | What it does |
 |---|---|---|
-| `build.yml` | Push to `master` or any PR | Builds plugin, creates/updates draft GitHub Release with `.zip` |
-| `release.yml` | GitHub Release published | Signs & publishes to Marketplace, opens post-release PR |
+| `build.yml` | Push to `master` or any PR | Builds plugin, verifies the Marketplace descriptor, creates/updates draft GitHub Release with `.zip` |
+| `release.yml` | GitHub Release published | Verifies the descriptor, signs & publishes to Marketplace, opens post-release PR |
 | `bump-version.yml` | Manual (`workflow_dispatch`) | Bumps version in `gradle.properties` + `CHANGELOG.md`, opens PR |
 
 ---

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -14,6 +14,59 @@ is. Every claim below is produced by `./gradlew verifyPlugin`, not by inspection
 - `untilBuild` is left open so new IDE releases do not require a republish.
 - Compiled against Android Studio 2025.1.1.14 (platform 251), Java 17, Kotlin 2.2.
 
+## Why the Marketplace served 1.0.2 for four years
+
+Until 4.0.0, searching for the plugin in any current Android Studio or IntelliJ IDEA
+offered **1.0.2** — a 2019 build — even though 2.0.3 had shipped in 2022. The IDE was not
+wrong and the Marketplace was not stale. Neither of the newer releases was *serveable*:
+
+| Version | Descriptor | Result in a 2025 IDE |
+|---|---|---|
+| 1.0.2 | no `until-build` | The newest release still considered compatible — so this is what was offered |
+| 2.0.0 – 2.0.3 | `until-build=211.*` / `213.*`, `depends com.intellij.modules.androidstudio` | Filtered out: capped below the IDE's build |
+| 3.0.0, 3.0.1 | `<id>` renamed to `com.wahdan.spockAdb` | Never reached the Marketplace at all |
+| 4.0.0 | `since-build=231`, no `until-build`, no Android Studio gate | Serveable to Android Studio and IDEA 2023.1+ |
+
+Two separate mistakes, neither of which fails a build:
+
+**An `until-build` cap is a silent expiry date.** `pluginUntilBuild=213.*` was correct on the
+day 2.0.3 shipped and wrong three months later. The Marketplace does not report an error for
+this; it just stops offering the release and falls back to the newest upload without a cap.
+That fallback was 1.0.2. This is why `pluginUntilBuild` is now deliberately empty — see the
+comment in `gradle.properties`.
+
+**The plugin id is the Marketplace primary key.** 3.0.0 renamed `<id>` from
+`com.wahdan.com.wahdan.spockAdb` (a typo, but the published one) to the tidier
+`com.wahdan.spockAdb`. An id is not cosmetic: it identifies the listing. Both 3.x release
+workflow runs failed, no 3.x ever appeared on
+[listing 11591](https://plugins.jetbrains.com/plugin/11591-spockadb), and the id was
+restored before 4.0.0. **Do not rename it.** Publishing under a different id cannot update
+this listing, and users who installed the old id would not see the rename as an update.
+
+### The guard
+
+`scripts/verify-marketplace-descriptor.sh` asserts, against the built artifact rather than
+the source descriptor (`since-build`, `until-build` and `version` are all patched in by the
+Gradle plugin):
+
+- `<id>` is exactly `com.wahdan.com.wahdan.spockAdb`,
+- there is no `until-build` attribute,
+- `since-build` matches `pluginSinceBuild`,
+- `<version>` matches the release tag (release job only).
+
+It runs in the `Build` job on every pull request, and in the `Release` job immediately
+before `publishPlugin`, so neither mistake can ship again.
+
+### After a release: the version is not instant
+
+`publishPlugin` succeeding means *uploaded*, not *served*. A new version goes through
+Marketplace approval, and the compatibility index is rebuilt afterwards, so the plugin page
+can already show the new description and screenshots while the IDE's Install button still
+offers the previous compatible version. Check the actual state in the vendor console at
+<https://plugins.jetbrains.com/plugin/11591/versions> before assuming a descriptor bug —
+and if the IDE lags behind the plugin page, *Settings > Plugins > gear > Check for Updates*
+after restarting refreshes its cached repository listing.
+
 ## Why the plugin is no longer Android Studio only
 
 Until 3.0.0 the descriptor declared:

--- a/scripts/verify-marketplace-descriptor.sh
+++ b/scripts/verify-marketplace-descriptor.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# Gate on the descriptor that is about to be published to JetBrains Marketplace.
+#
+# Why this exists
+# ---------------
+# Between 2.0.3 (July 2022) and 4.0.0 the Marketplace served **1.0.2** to every modern
+# Android Studio and IntelliJ IDEA. Two independent descriptor mistakes caused it, and
+# neither failed a build:
+#
+#   * 2.0.0-2.0.3 shipped `until-build=211.*`/`213.*`. An until-build cap does not break
+#     anything at release time — it silently makes the release invisible to every IDE
+#     released after the cap, and the Marketplace falls back to the newest upload without
+#     one, which was 1.0.2.
+#   * 3.0.0 and 3.0.1 renamed `<id>` from `com.wahdan.com.wahdan.spockAdb` to
+#     `com.wahdan.spockAdb`. The plugin id is the Marketplace primary key, so those
+#     uploads could never land on listing 11591 at all.
+#
+# Both are cheap to assert and impossible to notice by reading a green build log, so they
+# are asserted here, against the built artifact rather than against the source descriptor
+# (since-build, until-build and version are all patched in by the Gradle plugin).
+#
+# Usage: scripts/verify-marketplace-descriptor.sh [distributions-dir]
+#        EXPECTED_VERSION=4.0.0 scripts/verify-marketplace-descriptor.sh
+
+set -euo pipefail
+
+# The id of Marketplace listing 11591 (https://plugins.jetbrains.com/plugin/11591-spockadb).
+# Changing it does not create a new version of this plugin — it orphans the release.
+readonly MARKETPLACE_PLUGIN_ID="com.wahdan.com.wahdan.spockAdb"
+
+DIST_DIR="${1:-build/distributions}"
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+fail() { echo "::error::$*" >&2; exit 1; }
+
+ZIP="$(find "$DIST_DIR" -maxdepth 1 -name '*.zip' | head -1)"
+[ -n "$ZIP" ] || fail "No plugin distribution found in $DIST_DIR — run ./gradlew buildPlugin first."
+
+unzip -qo "$ZIP" -d "$WORK_DIR/dist"
+
+# The distribution is <plugin>/lib/*.jar; the descriptor lives in whichever jar carries it,
+# not necessarily the one whose name matches the plugin.
+DESCRIPTOR=""
+for jar in "$WORK_DIR"/dist/*/lib/*.jar; do
+    if unzip -p "$jar" META-INF/plugin.xml > "$WORK_DIR/plugin.xml" 2>/dev/null; then
+        DESCRIPTOR="$WORK_DIR/plugin.xml"
+        break
+    fi
+done
+[ -n "$DESCRIPTOR" ] || fail "No META-INF/plugin.xml in any jar inside $(basename "$ZIP")."
+
+# An absent attribute or element is a legitimate result (an open-ended until-build is the
+# whole point), so these must return empty rather than a non-zero status under `set -e`.
+attr() { grep -o "<idea-version[^>]*" "$DESCRIPTOR" | grep -o "$1=\"[^\"]*\"" | cut -d'"' -f2 || true; }
+element() { grep -o "<$1>[^<]*</$1>" "$DESCRIPTOR" | head -1 | sed -E "s|</?$1>||g" || true; }
+
+ACTUAL_ID="$(element id)"
+ACTUAL_VERSION="$(element version)"
+SINCE_BUILD="$(attr since-build)"
+UNTIL_BUILD="$(attr until-build)"
+EXPECTED_SINCE="$(grep '^pluginSinceBuild=' gradle.properties | cut -d= -f2)"
+
+echo "Descriptor in $(basename "$ZIP"):"
+echo "  id           = ${ACTUAL_ID}"
+echo "  version      = ${ACTUAL_VERSION}"
+echo "  since-build  = ${SINCE_BUILD}"
+echo "  until-build  = ${UNTIL_BUILD:-<none>}"
+
+[ "$ACTUAL_ID" = "$MARKETPLACE_PLUGIN_ID" ] || fail \
+    "Plugin id is '${ACTUAL_ID}', expected '${MARKETPLACE_PLUGIN_ID}'. The id is the \
+Marketplace primary key: publishing under a different one does not update listing 11591, \
+it fails or creates an unrelated listing. This is what stopped 3.0.0 and 3.0.1 shipping."
+
+[ -z "$UNTIL_BUILD" ] || fail \
+    "Descriptor declares until-build='${UNTIL_BUILD}'. This release must stay open-ended: \
+a cap makes it invisible to every IDE newer than the cap, and the Marketplace silently \
+serves an older version instead. Leave pluginUntilBuild empty in gradle.properties."
+
+[ -n "$SINCE_BUILD" ] || fail "Descriptor has no since-build."
+[ "$SINCE_BUILD" = "$EXPECTED_SINCE" ] || fail \
+    "since-build is '${SINCE_BUILD}' but gradle.properties says pluginSinceBuild=${EXPECTED_SINCE}."
+
+if [ -n "${EXPECTED_VERSION:-}" ]; then
+    [ "$ACTUAL_VERSION" = "$EXPECTED_VERSION" ] || fail \
+        "Descriptor version is '${ACTUAL_VERSION}' but the release is '${EXPECTED_VERSION}'. \
+The release job checks out the tag, so this means gradle.properties was not bumped."
+fi
+
+echo "Descriptor is publishable to Marketplace listing 11591."


### PR DESCRIPTION
Searching for the plugin in a current Android Studio or IntelliJ IDEA offers **1.0.2** — a 2019 build — long after 2.0.3 shipped. Neither newer release was serveable, for two separate reasons that both produce a green build.

## Why 1.0.2

| Version | Descriptor | Result in a 2025 IDE |
|---|---|---|
| 1.0.2 | no `until-build` | newest still-compatible release → **this is what gets served** |
| 2.0.0 – 2.0.3 | `until-build=211.*` / `213.*` | filtered out — capped below the IDE's build |
| 3.0.0, 3.0.1 | `<id>` renamed to `com.wahdan.spockAdb` | never reached listing 11591; both release runs failed |
| 4.0.0 | `since-build=231`, open-ended, original id | serveable to Android Studio and IDEA 2023.1+ |

- **An `until-build` cap is a silent expiry date.** `213.*` was correct the day 2.0.3 shipped and wrong three months later. The Marketplace reports no error — it stops offering the release and falls back to the newest upload without a cap, which was 1.0.2.
- **The plugin id is the Marketplace primary key.** 3.0.0 renamed `<id>` from `com.wahdan.com.wahdan.spockAdb` to the tidier `com.wahdan.spockAdb`, so those uploads could not land on listing 11591 at all.

4.0.0 is already correct on both counts — I read the patched descriptor out of the jar in the published `com.wahdan.spockAdb-4.0.0.zip` to confirm it (`since-build="231"`, no `until-build`, original id). This PR adds the assertion that keeps it that way.

## Changes

- **`scripts/verify-marketplace-descriptor.sh`** — asserts the plugin id is exactly `com.wahdan.com.wahdan.spockAdb`, that there is no `until-build` attribute, that `since-build` matches `pluginSinceBuild`, and (release only) that `<version>` matches the release tag. It inspects the **built artifact**, not the source descriptor, because version, `since-build` and `until-build` are all patched in by the Gradle plugin.
- **`build.yml`** — runs the check after `buildPlugin`, so a bad descriptor fails at pull-request time.
- **`release.yml`** — runs it immediately before `publishPlugin`, so neither mistake can ship again.
- **`docs/COMPATIBILITY.md`** — new section recording the above, so the question has an answer in the repo.
- **`CONTRIBUTING.md`** — no longer claims a release is live "within a few minutes". A green `release.yml` means *uploaded*, not approved, indexed and served; adds a step for confirming which version an IDE is actually offered.

## Testing

Gradle cannot resolve the Android Studio 2025.1.1.14 artifact in my sandbox, so the script was tested directly instead of through a build:

- real published `4.0.0` artifact → **passes**, with `EXPECTED_VERSION=4.0.0`
- same artifact with `EXPECTED_VERSION=4.0.1` → fails on the version mismatch
- synthesised variant with `until-build="251.*"` (the 2.0.x mistake) → fails
- synthesised variant with `<id>com.wahdan.spockAdb</id>` (the 3.0.x mistake) → fails

Both workflow files parse as YAML and the script passes `bash -n`. CI on this PR is the first run of the check inside a real build.

## Note

This does not make 4.0.0 appear in the IDE any sooner — that is Marketplace-side approval and compatibility-index rebuild. Worth checking 4.0.0's state at https://plugins.jetbrains.com/plugin/11591/versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018W7aaYZfisooQqhECaFoQ1

---
_Generated by [Claude Code](https://claude.ai/code/session_018W7aaYZfisooQqhECaFoQ1)_