### PR TITLE
Add a stdio transport that shares the whole MCP stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@
   `notifications/cancelled` (the call is interrupted and its response suppressed), and a
   worker pool so a cancellation arriving behind a slow tool call is still read
 - `McpBridgeServer` — a Unix domain socket in a `700` directory, falling back to loopback TCP
-  where `AF_UNIX` is unavailable or the path is too long for `sun_path`
+  where `AF_UNIX` is unavailable or the path is too long for `sun_path`. Every connection
+  presents the token on both transports; one that never does is closed after ten seconds, and
+  the session pool is bounded, so nothing that reaches the endpoint can hold threads open
 - `SpockAdbStdioLauncher` — the process an MCP client spawns. A dependency-free Java byte
   relay with no knowledge of MCP, so nothing about the protocol is implemented twice. It
   claims the real stdout and redirects `System.out` to stderr, so no log line can corrupt the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## [Unreleased]
 
+### Added
+
+- **stdio transport for the MCP server**, served by the same `McpProtocol`, `ToolRegistry`,
+  safety model, device services and audit trail as the HTTP transport — a tool call arriving
+  over stdio is confirmed, recorded and logged exactly as the same call over HTTP
+- `Tools → SpockAdb → Copy MCP Client Configuration (stdio)`. **It contains no credential**:
+  the client is pointed at an endpoint descriptor, and the token stays in that `600` file
+- `McpStdioServer` — newline-delimited JSON-RPC framing, request cancellation via
+  `notifications/cancelled` (the call is interrupted and its response suppressed), and a
+  worker pool so a cancellation arriving behind a slow tool call is still read
+- `McpBridgeServer` — a Unix domain socket in a `700` directory, falling back to loopback TCP
+  where `AF_UNIX` is unavailable or the path is too long for `sun_path`
+- `SpockAdbStdioLauncher` — the process an MCP client spawns. A dependency-free Java byte
+  relay with no knowledge of MCP, so nothing about the protocol is implemented twice. It
+  claims the real stdout and redirects `System.out` to stderr, so no log line can corrupt the
+  protocol stream
+
 ## [4.0.1] - 2026-09-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ device. **Off by default**; you start it deliberately.
   see arguments, result, client, target device — and whether you approved or denied it
 - **Tools catalogue** grouped by safety, browsable before you start the server
 - Searchable, bounded request history
+- **HTTP and stdio**, served by one protocol implementation and one tool registry. The stdio
+  configuration carries no token at all, so it is safe to paste anywhere
 
 **Destructive tools always ask, per call, and default to denied.** An unattended IDE denies
 rather than approves.
@@ -166,7 +168,7 @@ Or from your IDE: `Settings → Plugins → Marketplace → search "Spock ADB"`
 2. Open the **Spock ADB** tool window (left-hand sidebar, or `Tools → SpockAdb`).
 3. Pick your device in **Devices** — every other tab follows it.
 4. Optional: `Tools → SpockAdb → Start MCP Server for AI Agents`, then
-   **Copy MCP Client Configuration** and paste it into your MCP client.
+   **Copy MCP Client Configuration (stdio)** — or **(HTTP)** — and paste it into your MCP client.
 
 ---
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -17,8 +17,9 @@ action.
 
 It shows what is actually true rather than a mock-up of it:
 
-- **Status** — running or stopped, the transport (`HTTP (127.0.0.1:<port>)`, not stdio), and
-  the tool count. Start / Stop / Restart / Copy Config / Settings.
+- **Status** — running or stopped, the transports actually accepting connections
+  (`HTTP (127.0.0.1:<port>)` and, when it bound, `stdio (unix:<path>)`), and the tool count.
+  Start / Stop / Restart / Copy Config / Settings.
 - **Tools tab** — the full catalogue of what an agent can do to your device, grouped by
   safety level with destructive first, searchable, and filterable to destructive only.
   Selecting a tool shows its description and argument schema. Available whether or not the
@@ -46,8 +47,36 @@ so a list of green and grey dots next to client names would be invented rather t
 ## Quick start
 
 1. `Tools → SpockAdb → Spock: Start MCP Server for AI Agents`
-2. `Tools → SpockAdb → Spock: Copy MCP Client Configuration`
-3. Paste into your MCP client's config. It looks like this:
+2. `Tools → SpockAdb → Spock: Copy MCP Client Configuration (stdio)` — or `(HTTP)` if your
+   client does not spawn processes
+3. Paste into your MCP client's config
+
+Both transports are started together and serve the same tools. Pick whichever your client
+supports; **prefer stdio**, because its configuration contains no credential.
+
+### stdio
+
+```json
+{
+  "mcpServers": {
+    "spock-adb": {
+      "command": "<the IDE's java>",
+      "args": [
+        "-cp", "<the Spock ADB plugin jar>",
+        "spock.adb.mcp.stdio.SpockAdbStdioLauncher",
+        "<IDE config>/spock-adb/mcp-stdio.properties"
+      ]
+    }
+  }
+}
+```
+
+There is no token in it. The client is pointed at an endpoint descriptor, and the token lives
+in that file with `600` permissions — so this config can be committed, pasted into a chat or
+attached to a bug report without leaking anything. The `java` named is the IDE's own, so the
+launcher runs on a JDK that is definitely present and new enough.
+
+### HTTP
 
 ```json
 {
@@ -61,20 +90,27 @@ so a list of green and grey dots next to client names would be invented rather t
 }
 ```
 
-The token is a credential for your device. It is generated locally, never leaves your
-machine unless you paste it somewhere, and can be rotated.
+This one **does** contain a credential for your device. It is generated locally, never leaves
+your machine unless you paste it somewhere, and can be rotated.
 
 ## Architecture
 
 ```
-MCP client  ->  McpHttpServer  ->  McpProtocol  ->  ToolRegistry
-                                                        |
-                                                        v
-                                    SpockAdbService / DeviceLister / commands
-                                                        |
-                                                        v
-                                                   ADB -> device
+MCP client --+-> McpHttpServer  --+
+             |                    |
+             +-> McpStdioServer --+->  McpProtocol  ->  ToolRegistry
+                                                             |
+                                                             v
+                                         SpockAdbService / DeviceLister / commands
+                                                             |
+                                                             v
+                                                        ADB -> device
 ```
+
+The transports meet at `McpProtocol` and share everything below it: one protocol
+implementation, one `ToolRegistry`, one safety model, one audit trail. A `tools/call` arriving
+over stdio is confirmed, recorded in the activity panel and written to `idea.log` exactly as
+the same call over HTTP, because it is the same call.
 
 The MCP layer **owns no ADB logic**. Tools resolve devices through the same
 `DebugBridgeProvider` and `DeviceLister` the tool window uses, and reuse the same command
@@ -84,6 +120,42 @@ of error messages, and no chance of the UI and the agent path drifting apart.
 `ToolRegistry` is deliberately shared: a future in-plugin AI assistant uses the same tool
 definitions and the same safety levels rather than a parallel implementation. Two
 implementations would drift, and the one that drifted would be the one enforcing safety.
+
+### How stdio reaches a plugin
+
+A client speaking stdio *spawns* its server and talks to that child process's stdin and
+stdout. The tools cannot live in that child: they need the running IDE's ADB bridge, its
+project model, and its confirmation dialogs. So the child — `SpockAdbStdioLauncher` — is a
+**byte relay and nothing else**. It copies bytes between its own stdio and a local stream
+endpoint in the IDE, where `McpStdioServer` serves the session against the shared
+`McpProtocol`.
+
+The relay is deliberately ignorant. It does not parse JSON-RPC, does not know what a tool is,
+and never rewrites anything passing through it, because the wire on both sides is identical:
+newline-delimited JSON-RPC, exactly as the MCP stdio spec defines it. A relay that understood
+the protocol would be a second implementation of it, and the second one would drift.
+
+It is written in Java with no dependencies, so `java -cp <plugin jar>` is enough to start it.
+The plugin does not bundle the Kotlin standard library — it uses the one inside the IDE — so a
+Kotlin launcher could not be started that way.
+
+**Stdout is the protocol stream.** One stray line on it corrupts the session, so the launcher
+claims the real stdout on its first statement and redirects `System.out` to stderr; nothing
+that later prints, in this code or any library, can reach the client. Diagnostics go to
+stderr, which MCP clients surface in their logs, and inside the IDE to `idea.log`.
+
+**Authorisation is the filesystem.** The endpoint is a Unix domain socket in a `700`
+directory, so another user cannot reach it. Where `AF_UNIX` is unavailable, or the config path
+is too long for `sun_path`, it falls back to a loopback TCP port — which any local process can
+reach — so the connection presents a token either way, read from a `600` file rather than
+carried in the client config. The token is the same one the HTTP transport uses, and rotating
+it rotates both.
+
+**Cancellation.** `notifications/cancelled` interrupts the thread running that request and
+suppresses its response, per spec — the client has already stopped waiting. Requests run on a
+worker pool rather than the reading thread, precisely so a cancellation arriving behind a slow
+tool call can still be read. Stopping the server closes live sessions, which ends the relay
+processes rather than stranding them.
 
 ### Why a self-hosted HTTP server
 
@@ -239,15 +311,21 @@ Recorded honestly so the gaps are not mistaken for features:
   it needs a file-transfer story first.
 - **MCP activity panel.** Calls are recorded (`McpServerService.recentCalls()`) and
   destructive ones are logged, but there is no tool window tab showing them live yet.
-- **stdio transport.** Clients that only speak stdio need a small bridge process; HTTP works
-  with Claude Code and Cursor today.
 - **Per-tool allow-lists** so a developer can disable individual tools.
 - **File push/pull.**
 
 ## Testing
 
-The protocol, the safety model and the transport are all tested without a device:
+The protocol, the safety model and both transports are all tested without a device:
 `FakeToolContext` stands in for the IDE and ADB. The tests that matter most assert that
 destructive tools cannot succeed unasked, that catastrophic commands are refused before the
 dialog, and that an unauthorised or wrong-token request is rejected — including a token that
 is a prefix of the real one, since the comparison is constant-time.
+
+The stdio transport is tested over a real pipe against the real `McpProtocol` — `initialize`,
+`tools/list`, `tools/call`, an invalid request, malformed JSON, an unknown tool, a failing
+tool, cancellation and shutdown — so the claim that it re-implements nothing is checked rather
+than asserted. The launcher is tested as an actual spawned process, because the two things
+most likely to be wrong about it are only true of a real one: that it exits when its client
+closes stdin or the IDE stops the server, and that it writes nothing but protocol messages to
+stdout.

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -37,12 +37,13 @@ It shows what is actually true rather than a mock-up of it:
 The panel names the connected client only when the client identifies itself in `initialize`,
 and says so plainly when it has not:
 
-> No client has identified itself yet. HTTP is stateless, so clients are only known once
-> they call initialize.
+> No client has identified itself yet. On either transport, a client is only known once it
+> calls initialize.
 
-There is no per-client presence list. Plain HTTP POST has no connection to be "online" on,
-so a list of green and grey dots next to client names would be invented rather than observed.
-**What the transport does not expose is reported as unknown, not guessed.**
+There is no per-client presence list. Plain HTTP POST has no connection to be "online" on at
+all, and a stdio session is a connection but carries no identity before `initialize`, so a list
+of green and grey dots next to client names would be invented rather than observed.
+**What a transport does not expose is reported as unknown, not guessed.**
 
 ## Quick start
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -144,12 +144,17 @@ claims the real stdout on its first statement and redirects `System.out` to stde
 that later prints, in this code or any library, can reach the client. Diagnostics go to
 stderr, which MCP clients surface in their logs, and inside the IDE to `idea.log`.
 
-**Authorisation is the filesystem.** The endpoint is a Unix domain socket in a `700`
-directory, so another user cannot reach it. Where `AF_UNIX` is unavailable, or the config path
-is too long for `sun_path`, it falls back to a loopback TCP port — which any local process can
-reach — so the connection presents a token either way, read from a `600` file rather than
-carried in the client config. The token is the same one the HTTP transport uses, and rotating
-it rotates both.
+**Every connection presents the token**, on both transports, as one line checked before the
+session starts. The filesystem is defence in depth, not a substitute: a Unix domain socket in a
+`700` directory is preferred because another user cannot reach it at all, and where `AF_UNIX`
+is unavailable — or the config path is too long for `sun_path` — the endpoint falls back to a
+loopback TCP port, which any local process can connect to. The token is read from a `600` file
+rather than carried in the client config, and is the same one the HTTP transport uses, so
+rotating it rotates both.
+
+A connection that opens and then says nothing is closed after ten seconds, and the session pool
+is bounded. Without both, anything that could reach the endpoint could hold threads open until
+real clients could not get one — which in the TCP fallback means any local process.
 
 **Cancellation.** `notifications/cancelled` interrupts the thread running that request and
 suppresses its response, per spec — the client has already stopped waiting. Requests run on a

--- a/src/main/java/spock/adb/mcp/stdio/SpockAdbStdioLauncher.java
+++ b/src/main/java/spock/adb/mcp/stdio/SpockAdbStdioLauncher.java
@@ -135,8 +135,13 @@ public final class SpockAdbStdioLauncher {
             } catch (IOException ignored) {
                 // The client exited and closed the pipe. That is how a session ends.
             } finally {
-                // Tell the IDE the client has gone, which ends its session loop too.
-                closeQuietly(connection);
+                // Half-close: tell the IDE the client has gone without tearing down the read
+                // side. Closing the whole channel here aborts the main thread's read mid-call,
+                // which surfaces as AsynchronousCloseException and gets reported as a lost
+                // connection — on the ordinary path where the client just closed stdin. After
+                // the half-close the IDE sees end of stream, ends its session and closes its
+                // end, and the read below finishes cleanly.
+                shutdownOutputQuietly(connection);
             }
         }, "spock-adb-stdio-in");
         pump.setDaemon(true);
@@ -160,11 +165,11 @@ public final class SpockAdbStdioLauncher {
         }
     }
 
-    private static void closeQuietly(SocketChannel connection) {
+    private static void shutdownOutputQuietly(SocketChannel connection) {
         try {
-            connection.close();
+            connection.shutdownOutput();
         } catch (IOException ignored) {
-            // Nothing useful to do while shutting down.
+            // The connection is already gone, which is the state this was aiming for.
         }
     }
 

--- a/src/main/java/spock/adb/mcp/stdio/SpockAdbStdioLauncher.java
+++ b/src/main/java/spock/adb/mcp/stdio/SpockAdbStdioLauncher.java
@@ -148,14 +148,9 @@ public final class SpockAdbStdioLauncher {
         AtomicBoolean clientClosedStdin = new AtomicBoolean(false);
         Thread pump = new Thread(() -> {
             try {
-                copy(System.in, toIde);
-                // Reached only on end of stream: the client deliberately closed stdin. Set
-                // before the half-close below, so the IDE cannot react and end the read on
+                // Set before the half-close below, so the IDE cannot react and end the read on
                 // the main thread before this is visible to it.
-                clientClosedStdin.set(true);
-            } catch (IOException ignored) {
-                // The client exited and closed the pipe. That is how a session ends.
-                clientClosedStdin.set(true);
+                clientClosedStdin.set(pumpToIde(System.in, toIde));
             } finally {
                 // Half-close: tell the IDE the client has gone without tearing down the read
                 // side. Closing the whole channel here aborts the main thread's read mid-call,
@@ -171,6 +166,38 @@ public final class SpockAdbStdioLauncher {
 
         copy(fromIde, protocolOut);
         return clientClosedStdin.get();
+    }
+
+    /**
+     * Pumps stdin to the IDE, reporting which side ended it.
+     *
+     * The two directions fail for opposite reasons and must not be conflated: stdin breaking
+     * means the client has gone, which ends a session normally, while a write failing means
+     * the IDE's socket is already gone while the client is still talking, which is a lost
+     * connection. Treating both as a client shutdown let a mid-session disconnect exit 0.
+     *
+     * @return true if the client ended it, by closing stdin or exiting; false if the write to
+     *     the IDE failed.
+     */
+    private static boolean pumpToIde(InputStream source, OutputStream destination) {
+        byte[] buffer = new byte[BUFFER_BYTES];
+        while (true) {
+            int read;
+            try {
+                read = source.read(buffer);
+            } catch (IOException clientGone) {
+                return true;
+            }
+            if (read == -1) {
+                return true;
+            }
+            try {
+                destination.write(buffer, 0, read);
+                destination.flush();
+            } catch (IOException ideGone) {
+                return false;
+            }
+        }
     }
 
     /**

--- a/src/main/java/spock/adb/mcp/stdio/SpockAdbStdioLauncher.java
+++ b/src/main/java/spock/adb/mcp/stdio/SpockAdbStdioLauncher.java
@@ -16,6 +16,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * The process an MCP client spawns for the stdio transport.
@@ -82,7 +83,18 @@ public final class SpockAdbStdioLauncher {
 
         try (SocketChannel connection = connect(endpoint)) {
             handshake(connection, endpoint.getProperty("token", ""));
-            relay(connection, protocolOut);
+            if (!relay(connection, protocolOut)) {
+                // The IDE hung up while the client was still talking. The likeliest causes are
+                // a stale token in the descriptor and a server that has been stopped, and both
+                // look identical from here: the bridge closes the connection without a word.
+                // Exiting 0 would present either as a server that started and cleanly chose to
+                // do nothing, which is the least useful thing a client could be told.
+                fail("Spock ADB: the IDE closed the connection without serving the session."
+                        + " The MCP server may have been stopped, or the token in "
+                        + descriptorFile + " may be stale — re-copy the configuration from"
+                        + " Tools > SpockAdb > Copy MCP Client Configuration (stdio).");
+                System.exit(EXIT_CONNECTION_LOST);
+            }
         } catch (IOException e) {
             fail("Spock ADB: lost the connection to the IDE (" + e.getMessage() + ")."
                     + " The MCP server may have been stopped.");
@@ -124,16 +136,26 @@ public final class SpockAdbStdioLauncher {
      * long as the session does; the client-to-IDE direction runs on a daemon thread, which
      * lets the process exit the moment the IDE closes the connection rather than waiting on
      * a stdin read that will never return.
+     *
+     * @return true if the client ended the session by closing stdin, which is the ordinary
+     *     way one ends and a success; false if the IDE hung up first, which is a failure
+     *     however quiet it looked.
      */
-    private static void relay(SocketChannel connection, OutputStream protocolOut) throws IOException {
+    private static boolean relay(SocketChannel connection, OutputStream protocolOut) throws IOException {
         InputStream fromIde = Channels.newInputStream(connection);
         OutputStream toIde = Channels.newOutputStream(connection);
 
+        AtomicBoolean clientClosedStdin = new AtomicBoolean(false);
         Thread pump = new Thread(() -> {
             try {
                 copy(System.in, toIde);
+                // Reached only on end of stream: the client deliberately closed stdin. Set
+                // before the half-close below, so the IDE cannot react and end the read on
+                // the main thread before this is visible to it.
+                clientClosedStdin.set(true);
             } catch (IOException ignored) {
                 // The client exited and closed the pipe. That is how a session ends.
+                clientClosedStdin.set(true);
             } finally {
                 // Half-close: tell the IDE the client has gone without tearing down the read
                 // side. Closing the whole channel here aborts the main thread's read mid-call,
@@ -148,6 +170,7 @@ public final class SpockAdbStdioLauncher {
         pump.start();
 
         copy(fromIde, protocolOut);
+        return clientClosedStdin.get();
     }
 
     /**

--- a/src/main/java/spock/adb/mcp/stdio/SpockAdbStdioLauncher.java
+++ b/src/main/java/spock/adb/mcp/stdio/SpockAdbStdioLauncher.java
@@ -35,12 +35,16 @@ import java.util.Properties;
  * corrupts the session. {@link System#out} is therefore redirected to stderr on the first
  * line of {@link #main}, and the real stdout is held privately by the relay.
  *
- * <p>Usage: {@code java -cp <plugin.jar> spock.adb.mcp.stdio.SpockAdbStdioLauncher [descriptor]}
+ * <p>Usage: {@code java -cp <plugin.jar> spock.adb.mcp.stdio.SpockAdbStdioLauncher <descriptor>}
+ *
+ * <p>The descriptor path is required rather than defaulted. The IDE writes it under its own
+ * configuration directory, which differs per IDE, per version and per platform, so there is no
+ * single location a default could name that would be right — and a default naming the wrong
+ * place is worse than none. Copy the ready-made configuration from
+ * <em>Tools &gt; SpockAdb &gt; Copy MCP Client Configuration (stdio)</em>, which fills in the
+ * real path for the IDE that generated it.
  */
 public final class SpockAdbStdioLauncher {
-
-    /** Where the IDE writes the endpoint descriptor when no path is given. */
-    public static final String DEFAULT_DESCRIPTOR = ".spock-adb/mcp-stdio.properties";
 
     private static final int EXIT_NO_ENDPOINT = 2;
     private static final int EXIT_CONNECTION_LOST = 3;
@@ -55,9 +59,15 @@ public final class SpockAdbStdioLauncher {
         OutputStream protocolOut = new FileOutputStream(FileDescriptor.out);
         System.setOut(new PrintStream(new FileOutputStream(FileDescriptor.err), true));
 
-        Path descriptorFile = args.length > 0
-                ? Path.of(args[0])
-                : Path.of(System.getProperty("user.home"), DEFAULT_DESCRIPTOR);
+        if (args.length < 1) {
+            fail("Spock ADB: usage: java -cp <plugin jar> "
+                    + SpockAdbStdioLauncher.class.getName() + " <descriptor>."
+                    + " Copy the ready-made configuration from Tools > SpockAdb >"
+                    + " Copy MCP Client Configuration (stdio), which fills in the path.");
+            System.exit(EXIT_NO_ENDPOINT);
+            return;
+        }
+        Path descriptorFile = Path.of(args[0]);
 
         Properties endpoint;
         try {

--- a/src/main/java/spock/adb/mcp/stdio/SpockAdbStdioLauncher.java
+++ b/src/main/java/spock/adb/mcp/stdio/SpockAdbStdioLauncher.java
@@ -1,0 +1,165 @@
+package spock.adb.mcp.stdio;
+
+import java.io.FileDescriptor;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.StandardProtocolFamily;
+import java.net.UnixDomainSocketAddress;
+import java.nio.channels.Channels;
+import java.nio.channels.SocketChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Properties;
+
+/**
+ * The process an MCP client spawns for the stdio transport.
+ *
+ * It is a byte relay and nothing else. It does not parse JSON-RPC, does not know what a tool
+ * is, and has no opinion about MCP: it copies bytes between its own stdin/stdout and the
+ * running IDE's stdio bridge, which serves the session with the same {@code McpProtocol} and
+ * the same {@code ToolRegistry} the HTTP transport uses. Keeping it ignorant is the point —
+ * a relay that understood the protocol would be a second implementation of it, and the two
+ * would drift.
+ *
+ * <p>Written in Java, with no dependencies, so it runs on nothing but the JDK the IDE already
+ * ships: the plugin does not bundle the Kotlin standard library (it uses the one inside the
+ * IDE), so a Kotlin launcher could not be started from a plain {@code java -cp} command.
+ *
+ * <p><b>Nothing may be printed to stdout.</b> Stdout is the protocol stream; one stray line
+ * corrupts the session. {@link System#out} is therefore redirected to stderr on the first
+ * line of {@link #main}, and the real stdout is held privately by the relay.
+ *
+ * <p>Usage: {@code java -cp <plugin.jar> spock.adb.mcp.stdio.SpockAdbStdioLauncher [descriptor]}
+ */
+public final class SpockAdbStdioLauncher {
+
+    /** Where the IDE writes the endpoint descriptor when no path is given. */
+    public static final String DEFAULT_DESCRIPTOR = ".spock-adb/mcp-stdio.properties";
+
+    private static final int EXIT_NO_ENDPOINT = 2;
+    private static final int EXIT_CONNECTION_LOST = 3;
+    private static final int BUFFER_BYTES = 8192;
+
+    private SpockAdbStdioLauncher() {
+    }
+
+    public static void main(String[] args) {
+        // Claim the real stdout before anything can print to it, then point System.out at
+        // stderr so that a future println here, or in any library, cannot corrupt the stream.
+        OutputStream protocolOut = new FileOutputStream(FileDescriptor.out);
+        System.setOut(new PrintStream(new FileOutputStream(FileDescriptor.err), true));
+
+        Path descriptorFile = args.length > 0
+                ? Path.of(args[0])
+                : Path.of(System.getProperty("user.home"), DEFAULT_DESCRIPTOR);
+
+        Properties endpoint;
+        try {
+            endpoint = readDescriptor(descriptorFile);
+        } catch (IOException e) {
+            fail("Spock ADB: no MCP endpoint at " + descriptorFile + "."
+                    + " Start the server in the IDE: Tools > SpockAdb >"
+                    + " Spock: Start MCP Server for AI Agents.");
+            System.exit(EXIT_NO_ENDPOINT);
+            return;
+        }
+
+        try (SocketChannel connection = connect(endpoint)) {
+            handshake(connection, endpoint.getProperty("token", ""));
+            relay(connection, protocolOut);
+        } catch (IOException e) {
+            fail("Spock ADB: lost the connection to the IDE (" + e.getMessage() + ")."
+                    + " The MCP server may have been stopped.");
+            System.exit(EXIT_CONNECTION_LOST);
+        }
+    }
+
+    private static Properties readDescriptor(Path file) throws IOException {
+        Properties properties = new Properties();
+        try (InputStream in = Files.newInputStream(file)) {
+            properties.load(in);
+        }
+        return properties;
+    }
+
+    private static SocketChannel connect(Properties endpoint) throws IOException {
+        String transport = endpoint.getProperty("transport", "unix");
+        if ("unix".equals(transport)) {
+            Path socket = Path.of(endpoint.getProperty("socket", ""));
+            SocketChannel channel = SocketChannel.open(StandardProtocolFamily.UNIX);
+            channel.connect(UnixDomainSocketAddress.of(socket));
+            return channel;
+        }
+        int port = Integer.parseInt(endpoint.getProperty("port", "0"));
+        return SocketChannel.open(new InetSocketAddress(InetAddress.getLoopbackAddress(), port));
+    }
+
+    /** One line, before the session: the bridge closes the connection if it does not match. */
+    private static void handshake(SocketChannel connection, String token) throws IOException {
+        OutputStream out = Channels.newOutputStream(connection);
+        out.write((token + "\n").getBytes(StandardCharsets.UTF_8));
+        out.flush();
+    }
+
+    /**
+     * Copies bytes in both directions until either end closes.
+     *
+     * The IDE-to-client direction runs on this thread so the process stays alive exactly as
+     * long as the session does; the client-to-IDE direction runs on a daemon thread, which
+     * lets the process exit the moment the IDE closes the connection rather than waiting on
+     * a stdin read that will never return.
+     */
+    private static void relay(SocketChannel connection, OutputStream protocolOut) throws IOException {
+        InputStream fromIde = Channels.newInputStream(connection);
+        OutputStream toIde = Channels.newOutputStream(connection);
+
+        Thread pump = new Thread(() -> {
+            try {
+                copy(System.in, toIde);
+            } catch (IOException ignored) {
+                // The client exited and closed the pipe. That is how a session ends.
+            } finally {
+                // Tell the IDE the client has gone, which ends its session loop too.
+                closeQuietly(connection);
+            }
+        }, "spock-adb-stdio-in");
+        pump.setDaemon(true);
+        pump.start();
+
+        copy(fromIde, protocolOut);
+    }
+
+    /**
+     * Flushes after every read rather than at the end.
+     *
+     * A JSON-RPC message the client is waiting on must not sit in an 8 KB buffer until the
+     * next one arrives, which is exactly what a plain transferTo would do.
+     */
+    private static void copy(InputStream source, OutputStream destination) throws IOException {
+        byte[] buffer = new byte[BUFFER_BYTES];
+        int read;
+        while ((read = source.read(buffer)) != -1) {
+            destination.write(buffer, 0, read);
+            destination.flush();
+        }
+    }
+
+    private static void closeQuietly(SocketChannel connection) {
+        try {
+            connection.close();
+        } catch (IOException ignored) {
+            // Nothing useful to do while shutting down.
+        }
+    }
+
+    /** Diagnostics go to stderr, which MCP clients surface in their logs. */
+    private static void fail(String message) {
+        System.err.println(message);
+    }
+}

--- a/src/main/kotlin/spock/adb/mcp/McpServerPanel.kt
+++ b/src/main/kotlin/spock/adb/mcp/McpServerPanel.kt
@@ -350,11 +350,13 @@ class McpServerPanel(
     }
 
     /**
-     * Reports only what the transport actually tells us.
+     * Reports only what the transports actually tell us.
      *
-     * Plain HTTP POST is stateless: there is no connection to be "online" on, and a client
-     * that never calls `initialize` reports no identity at all. Presence indicators per
-     * client would be invented, so they are not shown.
+     * Neither one knows who is calling until the client says so in `initialize`, for two
+     * different reasons: plain HTTP POST is stateless, so there is no connection to be
+     * "online" on at all, and a stdio session is a connection but still carries no identity
+     * before that first message. Either way a per-client presence indicator would be invented
+     * rather than observed, so none is shown.
      */
     private fun refreshClientLabel(running: Boolean) {
         val client = service.connectedClient()
@@ -364,7 +366,7 @@ class McpServerPanel(
             // Wrapped as HTML: a plain JBLabel clips rather than wrapping, and this sentence
             // is longer than a docked tool window is wide.
             client == null ->
-                "<html>No client has identified itself yet — HTTP is stateless, so a client " +
+                "<html>No client has identified itself yet — on either transport, a client " +
                     "is only known once it calls initialize.</html>"
             else -> {
                 val version = client.version?.let { " $it" }.orEmpty()

--- a/src/main/kotlin/spock/adb/mcp/McpServerPanel.kt
+++ b/src/main/kotlin/spock/adb/mcp/McpServerPanel.kt
@@ -328,8 +328,9 @@ class McpServerPanel(
         statusLabel.foreground = if (running) RUNNING else JBColor.GRAY
 
         detailLabel.text = when {
-            // The transport is HTTP on loopback, not stdio. Say what it actually is.
-            running -> "·  Transport: HTTP (127.0.0.1:${service.port})  ·  Tools: $toolCount"
+            // Name the transports that are actually accepting connections. The stdio bridge
+            // is reported only when it bound, since it can fail while HTTP keeps working.
+            running -> "·  Transports: ${transports()}  ·  Tools: $toolCount"
             else -> "·  Not accepting connections  ·  Tools available: $toolCount"
         }
         detailLabel.foreground = JBColor.GRAY
@@ -340,6 +341,12 @@ class McpServerPanel(
         copyConfigButton.isEnabled = running
 
         refreshClientLabel(running)
+    }
+
+    private fun transports(): String {
+        val http = "HTTP (127.0.0.1:${service.port})"
+        val stdio = service.stdioEndpoint?.let { "stdio (${it.describe()})" }
+        return listOfNotNull(http, stdio).joinToString(", ")
     }
 
     /**

--- a/src/main/kotlin/spock/adb/mcp/McpServerService.kt
+++ b/src/main/kotlin/spock/adb/mcp/McpServerService.kt
@@ -85,7 +85,10 @@ class McpServerService : PersistentStateComponent<McpSettings>, Disposable {
     fun stop() {
         server?.stop()
         server = null
-        bridge?.stop()
+        // dispose(), not stop(): stop() releases the socket but keeps the executors, and
+        // start() always builds a fresh McpBridgeServer, so a stop/start cycle — which is
+        // exactly what Restart MCP Server does — would strand the previous one's threads.
+        bridge?.dispose()
         bridge = null
         protocol = null
         settings.enabled = false
@@ -248,12 +251,7 @@ class McpServerService : PersistentStateComponent<McpSettings>, Disposable {
         PathManager.getJarPathForClass(SpockAdbStdioLauncher::class.java)
             ?: PathManager.getPluginsPath()
 
-    override fun dispose() {
-        // stop() clears the field, so take the reference first or the executors leak.
-        val stdio = bridge
-        stop()
-        stdio?.dispose()
-    }
+    override fun dispose() = stop()
 
     private fun generateToken(): String {
         val bytes = ByteArray(TOKEN_BYTES)

--- a/src/main/kotlin/spock/adb/mcp/McpServerService.kt
+++ b/src/main/kotlin/spock/adb/mcp/McpServerService.kt
@@ -1,12 +1,19 @@
 package spock.adb.mcp
 
+import com.google.gson.GsonBuilder
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.PathManager
 import com.intellij.openapi.components.PersistentStateComponent
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
 import com.intellij.openapi.diagnostic.Logger
+import spock.adb.mcp.stdio.McpBridgeServer
+import spock.adb.mcp.stdio.SpockAdbStdioLauncher
+import java.nio.file.Path
 import java.security.SecureRandom
 import java.util.Base64
 import java.util.concurrent.atomic.AtomicReference
@@ -33,6 +40,7 @@ class McpServerService : PersistentStateComponent<McpSettings>, Disposable {
     private val history = McpRequestHistory()
 
     private var server: McpHttpServer? = null
+    private var bridge: McpBridgeServer? = null
     private var protocol: McpProtocol? = null
 
     /** Notified after each recorded call so the activity panel can update live. */
@@ -41,6 +49,9 @@ class McpServerService : PersistentStateComponent<McpSettings>, Disposable {
     val isRunning: Boolean get() = server?.port != null
     val port: Int? get() = server?.port
     val token: String get() = settings.token
+
+    /** Where the stdio bridge is listening, or null when it could not be started. */
+    val stdioEndpoint: McpBridgeServer.Endpoint? get() = bridge?.endpoint
 
     override fun getState(): McpSettings = settings
 
@@ -62,6 +73,7 @@ class McpServerService : PersistentStateComponent<McpSettings>, Disposable {
         val httpServer = McpHttpServer(mcpProtocol, settings.token)
         val boundPort = httpServer.start(settings.port)
         server = httpServer
+        startStdioBridge(mcpProtocol)
         settings.enabled = true
         // Remember the port the OS handed out so the generated client config keeps working
         // across restarts.
@@ -73,9 +85,38 @@ class McpServerService : PersistentStateComponent<McpSettings>, Disposable {
     fun stop() {
         server?.stop()
         server = null
+        bridge?.stop()
+        bridge = null
         protocol = null
         settings.enabled = false
     }
+
+    /**
+     * Starts the stdio bridge beside the HTTP transport, on the same [McpProtocol] instance.
+     *
+     * Both transports therefore share one protocol implementation, one ToolRegistry, one
+     * safety model and one audit trail — a call arriving over stdio is recorded, confirmed
+     * and logged exactly as the same call over HTTP.
+     *
+     * A failure here does not fail [start]: stdio is one of two ways in, and losing it should
+     * not take the working one down with it.
+     */
+    private fun startStdioBridge(mcpProtocol: McpProtocol) {
+        val stdioBridge = McpBridgeServer(
+            handle = mcpProtocol::handle,
+            token = settings.token,
+            diagnostics = { message, error -> if (error == null) log.info(message) else log.warn(message, error) },
+        )
+        runCatching { stdioBridge.start(endpointDirectory()) }
+            .onSuccess { bridge = stdioBridge }
+            .onFailure {
+                log.warn("MCP stdio bridge unavailable; the HTTP transport is unaffected", it)
+                stdioBridge.dispose()
+            }
+    }
+
+    /** Per-IDE, so two IDEs running the server at once do not fight over one socket. */
+    private fun endpointDirectory(): Path = Path.of(PathManager.getConfigPath(), "spock-adb")
 
     /** Invalidates the current token, which disconnects every client using it. */
     @Synchronized
@@ -156,7 +197,63 @@ class McpServerService : PersistentStateComponent<McpSettings>, Disposable {
         """.trimIndent()
     }
 
-    override fun dispose() = stop()
+    /**
+     * Configuration snippet for a client that speaks stdio.
+     *
+     * Unlike the HTTP form this carries **no credential**: it points the client at the
+     * launcher and at the endpoint descriptor, and the token stays in that `600` file. A
+     * config pasted into a chat, a bug report or a shared dotfile therefore gives away
+     * nothing — the file it names is readable only by the developer.
+     *
+     * Built with Gson rather than string interpolation because these are filesystem paths:
+     * a Windows path in a hand-rolled JSON string would produce `C:\Users`, which is invalid
+     * JSON and would be silently mangled where it is not.
+     */
+    fun stdioClientConfiguration(): String {
+        val descriptor = stdioEndpoint?.descriptorFile?.toString()
+            ?: endpointDirectory().resolve(McpBridgeServer.DESCRIPTOR_NAME).toString()
+
+        val server = JsonObject().apply {
+            addProperty("command", javaExecutable())
+            add(
+                "args",
+                JsonArray().apply {
+                    add("-cp")
+                    add(launcherClasspath())
+                    add(SpockAdbStdioLauncher::class.java.name)
+                    add(descriptor)
+                },
+            )
+        }
+        val config = JsonObject().apply {
+            add("mcpServers", JsonObject().apply { add("spock-adb", server) })
+        }
+        return GsonBuilder().setPrettyPrinting().create().toJson(config)
+    }
+
+    /**
+     * The IDE's own JVM.
+     *
+     * Using it means the launcher runs on a JDK that is definitely present and definitely new
+     * enough, rather than whatever `java` happens to be on the developer's PATH — which on many
+     * machines is nothing at all.
+     */
+    private fun javaExecutable(): String {
+        val name = if (System.getProperty("os.name").startsWith("Windows")) "java.exe" else "java"
+        return Path.of(System.getProperty("java.home"), "bin", name).toString()
+    }
+
+    /** The plugin jar holding the launcher, resolved at runtime rather than guessed. */
+    private fun launcherClasspath(): String =
+        PathManager.getJarPathForClass(SpockAdbStdioLauncher::class.java)
+            ?: PathManager.getPluginsPath()
+
+    override fun dispose() {
+        // stop() clears the field, so take the reference first or the executors leak.
+        val stdio = bridge
+        stop()
+        stdio?.dispose()
+    }
 
     private fun generateToken(): String {
         val bytes = ByteArray(TOKEN_BYTES)

--- a/src/main/kotlin/spock/adb/mcp/actions/McpActions.kt
+++ b/src/main/kotlin/spock/adb/mcp/actions/McpActions.kt
@@ -88,6 +88,52 @@ class CopyMcpConfigurationAction : AnAction() {
     }
 }
 
+/**
+ * Copies the stdio client configuration.
+ *
+ * Separate from the HTTP one because the two are not interchangeable: this one contains no
+ * token, so the warning that belongs on the HTTP config would be a lie here, and a client
+ * that speaks stdio cannot use a URL.
+ */
+class CopyMcpStdioConfigurationAction : AnAction() {
+
+    override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
+
+    override fun update(event: AnActionEvent) {
+        event.presentation.isEnabled = McpServerService.getInstance().isRunning
+    }
+
+    override fun actionPerformed(event: AnActionEvent) {
+        val project = event.project ?: return
+        val service = McpServerService.getInstance()
+
+        if (!service.isRunning) {
+            CommonNotifier.showNotifier(
+                project = project,
+                content = "Start the MCP server first.",
+                type = NotificationType.WARNING,
+            )
+            return
+        }
+        if (service.stdioEndpoint == null) {
+            CommonNotifier.showNotifier(
+                project = project,
+                content = "The stdio bridge could not start on this machine — see idea.log. " +
+                    "Use 'Copy MCP Client Configuration' for the HTTP transport instead.",
+                type = NotificationType.WARNING,
+            )
+            return
+        }
+
+        CopyPasteManager.getInstance().setContents(StringSelection(service.stdioClientConfiguration()))
+        CommonNotifier.showNotifier(
+            project = project,
+            content = "MCP stdio configuration copied. It contains no token — the client " +
+                "reads one from a file only you can read.",
+        )
+    }
+}
+
 /** Stops then starts the server, which also re-reads the configured port. */
 class RestartMcpServerAction : AnAction() {
 

--- a/src/main/kotlin/spock/adb/mcp/actions/McpActions.kt
+++ b/src/main/kotlin/spock/adb/mcp/actions/McpActions.kt
@@ -44,7 +44,8 @@ class ToggleMcpServerAction : AnAction() {
                 CommonNotifier.showNotifier(
                     project = project,
                     content = "MCP server listening on 127.0.0.1:$port. " +
-                        "Use 'Spock: Copy MCP Client Configuration' to connect a client.",
+                        "Use 'Spock: Copy MCP Client Configuration (stdio)' — or (HTTP) — to " +
+                        "connect a client.",
                 )
             }
             .onFailure { error ->
@@ -119,7 +120,7 @@ class CopyMcpStdioConfigurationAction : AnAction() {
             CommonNotifier.showNotifier(
                 project = project,
                 content = "The stdio bridge could not start on this machine — see idea.log. " +
-                    "Use 'Copy MCP Client Configuration' for the HTTP transport instead.",
+                    "Use 'Copy MCP Client Configuration (HTTP)' instead.",
                 type = NotificationType.WARNING,
             )
             return

--- a/src/main/kotlin/spock/adb/mcp/stdio/McpBridgeServer.kt
+++ b/src/main/kotlin/spock/adb/mcp/stdio/McpBridgeServer.kt
@@ -14,6 +14,9 @@ import java.nio.channels.SocketChannel
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.attribute.PosixFileAttributeView
+import java.nio.file.attribute.PosixFilePermission
+import java.nio.file.attribute.PosixFilePermissions
 import java.security.MessageDigest
 import java.util.Properties
 import java.util.concurrent.Executors
@@ -97,8 +100,7 @@ class McpBridgeServer(
     @Synchronized
     fun start(directory: Path): Endpoint {
         stop()
-        Files.createDirectories(directory)
-        restrictToOwner(directory)
+        prepareDirectory(directory)
 
         val bound = bindUnixDomain(directory) ?: bindLoopback()
         channel = bound.first
@@ -299,33 +301,60 @@ class McpBridgeServer(
             complete.port?.let { setProperty("port", it.toString()) }
             setProperty("token", complete.token)
         }
-        // Written before the permissions are tightened, so create it empty and restrict it
-        // first: a token must never exist, even briefly, as a world-readable file.
+        // Created with its permissions, not created and then chmod-ed. POSIX checks
+        // permissions when a file is opened, so a descriptor another process opened during
+        // that window keeps working afterwards and reads the token as soon as it is written.
         Files.deleteIfExists(file)
-        Files.createFile(file)
-        restrictToOwner(file)
+        createRestricted(file)
         Files.newOutputStream(file).use { properties.store(it, "Spock ADB MCP stdio endpoint") }
         return complete
     }
 
-    /**
-     * Best effort `700` / `600`.
-     *
-     * POSIX permissions are the real protection for the Unix socket. On Windows the ACL model
-     * is different and the token is what protects the loopback port, so a failure here is
-     * reported rather than fatal.
-     */
-    private fun restrictToOwner(path: Path) {
-        try {
-            val view = Files.getFileAttributeView(
-                path,
-                java.nio.file.attribute.PosixFileAttributeView::class.java,
-            ) ?: return
-            val permissions = if (Files.isDirectory(path)) "rwx------" else "rw-------"
-            view.setPermissions(java.nio.file.attribute.PosixFilePermissions.fromString(permissions))
-        } catch (e: IOException) {
-            diagnostics("Could not restrict permissions on $path", e)
+    /** Creates the token file as `600` in one step, so it is never briefly readable. */
+    private fun createRestricted(file: Path) {
+        val owned = ownerOnly("rw-------")
+        if (owned == null) {
+            // No POSIX attributes — Windows, where the ACL model is different and the token is
+            // what protects the loopback port anyway.
+            Files.createFile(file)
+            return
         }
+        Files.createFile(file, owned)
+    }
+
+    /**
+     * Creates the endpoint directory as `700`, or tightens it if it is already there.
+     *
+     * The directory is what protects the Unix socket, which carries no permissions of its own
+     * worth relying on. Creating it with the permissions avoids the same window the token file
+     * avoids; an existing directory can only be tightened after the fact.
+     */
+    private fun prepareDirectory(directory: Path) {
+        val owned = ownerOnly("rwx------")
+        try {
+            when {
+                Files.isDirectory(directory) -> restrictExisting(directory, "rwx------")
+                owned == null -> Files.createDirectories(directory)
+                else -> Files.createDirectories(directory, owned)
+            }
+        } catch (e: IOException) {
+            diagnostics("Could not prepare $directory for the MCP stdio endpoint", e)
+        }
+    }
+
+    private fun ownerOnly(permissions: String): java.nio.file.attribute.FileAttribute<Set<PosixFilePermission>>? =
+        try {
+            java.nio.file.attribute.PosixFilePermissions.asFileAttribute(
+                PosixFilePermissions.fromString(permissions),
+            )
+        } catch (e: UnsupportedOperationException) {
+            diagnostics("POSIX permissions unavailable on this filesystem", e)
+            null
+        }
+
+    private fun restrictExisting(path: Path, permissions: String) {
+        val view = Files.getFileAttributeView(path, PosixFileAttributeView::class.java) ?: return
+        view.setPermissions(PosixFilePermissions.fromString(permissions))
     }
 
     enum class Transport { UNIX, TCP }

--- a/src/main/kotlin/spock/adb/mcp/stdio/McpBridgeServer.kt
+++ b/src/main/kotlin/spock/adb/mcp/stdio/McpBridgeServer.kt
@@ -183,18 +183,26 @@ class McpBridgeServer(
         )
     }
 
+    /**
+     * Waits for the next connection.
+     *
+     * Null means stop accepting, for either reason: the channel is gone, or accept() threw —
+     * which is how [stop] unblocks this loop, since closing the channel is the only thing that
+     * does. Both collapse into one value so the loop has a single exit.
+     */
+    private fun acceptNext(): SocketChannel? = try {
+        channel?.accept()
+    } catch (e: IOException) {
+        if (running.get()) diagnostics("MCP stdio bridge accept failed", e)
+        null
+    }
+
     // The accept loop must survive one bad connection: a client that dies mid-handshake is
     // routine and must not take the endpoint down with it.
     @Suppress("TooGenericExceptionCaught")
     private fun acceptLoop() {
         while (running.get()) {
-            val connection = try {
-                channel?.accept() ?: break
-            } catch (e: IOException) {
-                // Closing the channel to stop the server unblocks accept() by throwing.
-                if (running.get()) diagnostics("MCP stdio bridge accept failed", e)
-                break
-            }
+            val connection = acceptNext() ?: break
             connections.execute {
                 try {
                     session(connection)
@@ -212,7 +220,8 @@ class McpBridgeServer(
             InputStreamReader(Channels.newInputStream(connection), StandardCharsets.UTF_8),
         )
         val writer = OutputStreamWriter(
-            Channels.newOutputStream(connection), StandardCharsets.UTF_8,
+            Channels.newOutputStream(connection),
+            StandardCharsets.UTF_8,
         )
 
         val presented = reader.readLine()

--- a/src/main/kotlin/spock/adb/mcp/stdio/McpBridgeServer.kt
+++ b/src/main/kotlin/spock/adb/mcp/stdio/McpBridgeServer.kt
@@ -17,6 +17,7 @@ import java.nio.file.Path
 import java.security.MessageDigest
 import java.util.Properties
 import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -33,17 +34,24 @@ import java.util.concurrent.atomic.AtomicBoolean
  * The wire is identical to real stdio — newline-delimited JSON-RPC — so the relay never has to
  * understand, reframe or rewrite anything passing through it.
  *
- * Security. A Unix domain socket is used where the platform has one: it lives in a directory
- * only the developer can enter, so the filesystem does the authorisation and no credential
- * needs to exist. Where it is unavailable the endpoint falls back to a loopback TCP port,
- * which any local process can reach, so a token is required on both — one line, checked before
- * the session starts. The token lives in a `600` file that the client config points at rather
- * than embeds, so pasting a config into a client, or into a chat, does not paste a credential.
+ * Security. **Every connection presents the token**, on both transports, as one line checked
+ * before the session starts — the filesystem is defence in depth, never a substitute for it.
+ * A Unix domain socket is preferred where the platform has one, because it lives in a `700`
+ * directory and so is not reachable by another user at all; where it is unavailable the
+ * endpoint falls back to a loopback TCP port, which any local process can connect to. The
+ * token itself lives in a `600` file that the client config points at rather than embeds, so
+ * pasting a config into a client, or into a chat, does not paste a credential.
+ *
+ * A connection that opens and then says nothing is closed after [handshakeTimeoutSeconds].
+ * Without that it would hold a thread indefinitely, and enough of them would starve the pool
+ * of the slots real clients need — reachable by any local process in the TCP fallback.
  */
 class McpBridgeServer(
     private val handle: (String) -> String?,
     private val token: String,
     private val diagnostics: (String, Throwable?) -> Unit = { _, _ -> },
+    /** How long a connection has to present its token before it is closed. */
+    private val handshakeTimeoutSeconds: Long = HANDSHAKE_TIMEOUT_SECONDS,
 ) {
 
     private val running = AtomicBoolean(false)
@@ -64,8 +72,16 @@ class McpBridgeServer(
     private val accepts = Executors.newSingleThreadExecutor { runnable ->
         Thread(runnable, "SpockAdb-MCP-bridge-accept").apply { isDaemon = true }
     }
-    private val connections = Executors.newCachedThreadPool { runnable ->
+
+    // Bounded, not cached: an unbounded pool lets anything that can reach the endpoint create
+    // threads without limit. Queued connections are still covered by the handshake deadline,
+    // so a burst of silent ones drains rather than blocking real clients out.
+    private val connections = Executors.newFixedThreadPool(MAX_CONCURRENT_SESSIONS) { runnable ->
         Thread(runnable, "SpockAdb-MCP-bridge").apply { isDaemon = true }
+    }
+
+    private val handshakes = Executors.newSingleThreadScheduledExecutor { runnable ->
+        Thread(runnable, "SpockAdb-MCP-bridge-handshake").apply { isDaemon = true }
     }
 
     @Volatile
@@ -118,6 +134,7 @@ class McpBridgeServer(
         stop()
         accepts.shutdownNow()
         connections.shutdownNow()
+        handshakes.shutdownNow()
         // Wait for them to actually go. The accept thread is not unblocked by an interrupt —
         // only by stop() closing the channel — so returning before it has noticed would leave
         // a thread running after the object that owns it is gone.
@@ -203,19 +220,31 @@ class McpBridgeServer(
     private fun acceptLoop() {
         while (running.get()) {
             val connection = acceptNext() ?: break
+            // Scheduled here rather than inside session() so that time spent waiting for a
+            // pool slot counts against the deadline too: the whole point is that a connection
+            // which never authenticates cannot occupy the server.
+            val deadline = handshakes.schedule(
+                {
+                    diagnostics("Closing an MCP stdio connection that never presented a token", null)
+                    runCatching { connection.close() }
+                },
+                handshakeTimeoutSeconds,
+                TimeUnit.SECONDS,
+            )
             connections.execute {
                 try {
-                    session(connection)
+                    session(connection, deadline)
                 } catch (e: Exception) {
                     diagnostics("MCP stdio session failed", e)
                 } finally {
+                    deadline.cancel(false)
                     runCatching { connection.close() }
                 }
             }
         }
     }
 
-    private fun session(connection: SocketChannel) {
+    private fun session(connection: SocketChannel, deadline: ScheduledFuture<*>) {
         val reader = BufferedReader(
             InputStreamReader(Channels.newInputStream(connection), StandardCharsets.UTF_8),
         )
@@ -224,7 +253,19 @@ class McpBridgeServer(
             StandardCharsets.UTF_8,
         )
 
-        val presented = reader.readLine()
+        val presented = try {
+            reader.readLine()
+        } catch (ignored: IOException) {
+            // The deadline fired and closed the connection out from under the read. That is
+            // the timeout working as designed, and it has already been logged, so there is
+            // nothing here worth a second line or a stack trace.
+            null
+        } finally {
+            // The session is authenticated or rejected from here on; either way the deadline
+            // has done its job and must not close a healthy connection later.
+            deadline.cancel(false)
+        }
+
         if (presented == null || !matchesToken(presented.trim())) {
             // Deliberately terse and unlogged in detail: do not tell an unauthorised caller
             // how to authorise.
@@ -309,6 +350,8 @@ class McpBridgeServer(
         /** Conservative limit for `sun_path`, which is 104 bytes on macOS and 108 on Linux. */
         private const val MAX_SOCKET_PATH_BYTES = 100
         private const val SHUTDOWN_GRACE_SECONDS = 5L
+        private const val MAX_CONCURRENT_SESSIONS = 8
+        private const val HANDSHAKE_TIMEOUT_SECONDS = 10L
         const val DESCRIPTOR_NAME = "mcp-stdio.properties"
     }
 }

--- a/src/main/kotlin/spock/adb/mcp/stdio/McpBridgeServer.kt
+++ b/src/main/kotlin/spock/adb/mcp/stdio/McpBridgeServer.kt
@@ -17,6 +17,7 @@ import java.nio.file.Path
 import java.security.MessageDigest
 import java.util.Properties
 import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
@@ -117,6 +118,11 @@ class McpBridgeServer(
         stop()
         accepts.shutdownNow()
         connections.shutdownNow()
+        // Wait for them to actually go. The accept thread is not unblocked by an interrupt —
+        // only by stop() closing the channel — so returning before it has noticed would leave
+        // a thread running after the object that owns it is gone.
+        runCatching { accepts.awaitTermination(SHUTDOWN_GRACE_SECONDS, TimeUnit.SECONDS) }
+        runCatching { connections.awaitTermination(SHUTDOWN_GRACE_SECONDS, TimeUnit.SECONDS) }
     }
 
     private fun closeChannel() {
@@ -293,6 +299,7 @@ class McpBridgeServer(
 
         /** Conservative limit for `sun_path`, which is 104 bytes on macOS and 108 on Linux. */
         private const val MAX_SOCKET_PATH_BYTES = 100
+        private const val SHUTDOWN_GRACE_SECONDS = 5L
         const val DESCRIPTOR_NAME = "mcp-stdio.properties"
     }
 }

--- a/src/main/kotlin/spock/adb/mcp/stdio/McpBridgeServer.kt
+++ b/src/main/kotlin/spock/adb/mcp/stdio/McpBridgeServer.kt
@@ -349,7 +349,11 @@ class McpBridgeServer(
 
         /** Conservative limit for `sun_path`, which is 104 bytes on macOS and 108 on Linux. */
         private const val MAX_SOCKET_PATH_BYTES = 100
-        private const val SHUTDOWN_GRACE_SECONDS = 5L
+
+        // A ceiling, not an expected wait: stop() has already closed every channel by the
+        // time these are awaited, so the threads are on their way out. It stays short because
+        // the tool window's Stop and Restart actions call this from the EDT.
+        private const val SHUTDOWN_GRACE_SECONDS = 2L
         private const val MAX_CONCURRENT_SESSIONS = 8
         private const val HANDSHAKE_TIMEOUT_SECONDS = 10L
         const val DESCRIPTOR_NAME = "mcp-stdio.properties"

--- a/src/main/kotlin/spock/adb/mcp/stdio/McpBridgeServer.kt
+++ b/src/main/kotlin/spock/adb/mcp/stdio/McpBridgeServer.kt
@@ -97,6 +97,9 @@ class McpBridgeServer(
      * @param directory where the socket and descriptor live. Created `700` if absent, so a
      *   Unix domain socket is unreachable by other users.
      */
+    // A failed start must leave nothing behind, so the cleanup path catches whatever the
+    // bind, the descriptor write or the executor threw and rethrows it after undoing them.
+    @Suppress("TooGenericExceptionCaught")
     @Synchronized
     fun start(directory: Path): Endpoint {
         stop()
@@ -104,13 +107,24 @@ class McpBridgeServer(
 
         val bound = bindUnixDomain(directory) ?: bindLoopback()
         channel = bound.first
-        val descriptor = writeDescriptor(directory, bound.second)
-        endpoint = descriptor
-        running.set(true)
 
-        accepts.execute { acceptLoop() }
-        diagnostics("MCP stdio bridge listening on ${descriptor.describe()}", null)
-        return descriptor
+        return try {
+            val descriptor = writeDescriptor(directory, bound.second)
+            endpoint = descriptor
+            running.set(true)
+
+            accepts.execute { acceptLoop() }
+            diagnostics("MCP stdio bridge listening on ${descriptor.describe()}", null)
+            descriptor
+        } catch (e: Exception) {
+            // Nothing half-built survives a failed start. A bound socket with no accept loop,
+            // or a descriptor naming one, both leave a client waiting on an endpoint that will
+            // never answer — and the descriptor is where the token lives.
+            running.set(false)
+            closeChannel()
+            runCatching { Files.deleteIfExists(directory.resolve(DESCRIPTOR_NAME)) }
+            throw e
+        }
     }
 
     @Synchronized
@@ -277,6 +291,16 @@ class McpBridgeServer(
 
         val session = Session(connection, McpStdioServer(handle, diagnostics))
         sessions += session
+        // stop() clears `running` before it drains the list, so a session published after that
+        // drain would otherwise be missed and outlive the server that accepted it. Publishing
+        // first and then re-checking closes the window in both directions: either stop() sees
+        // this session, or this sees that the server has stopped.
+        if (!running.get()) {
+            sessions -= session
+            session.server.shutdown()
+            return
+        }
+
         try {
             session.server.serve(reader, writer)
         } finally {

--- a/src/main/kotlin/spock/adb/mcp/stdio/McpBridgeServer.kt
+++ b/src/main/kotlin/spock/adb/mcp/stdio/McpBridgeServer.kt
@@ -1,0 +1,298 @@
+package spock.adb.mcp.stdio
+
+import java.io.BufferedReader
+import java.io.IOException
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.StandardProtocolFamily
+import java.net.UnixDomainSocketAddress
+import java.nio.channels.Channels
+import java.nio.channels.ServerSocketChannel
+import java.nio.channels.SocketChannel
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.security.MessageDigest
+import java.util.Properties
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * The IDE end of the stdio transport.
+ *
+ * An MCP client speaking stdio *spawns* its server and talks to the child's stdin and stdout.
+ * The tools cannot live in that child: they need this IDE's ADB bridge, its project model and
+ * its confirmation dialogs. So the child ([SpockAdbStdioLauncher]) is a byte relay with no
+ * knowledge of MCP at all, and this class is what it relays to — one local stream endpoint
+ * whose sessions are served by [McpStdioServer], which hands every message to the same
+ * [spock.adb.mcp.McpProtocol] instance the HTTP transport uses.
+ *
+ * The wire is identical to real stdio — newline-delimited JSON-RPC — so the relay never has to
+ * understand, reframe or rewrite anything passing through it.
+ *
+ * Security. A Unix domain socket is used where the platform has one: it lives in a directory
+ * only the developer can enter, so the filesystem does the authorisation and no credential
+ * needs to exist. Where it is unavailable the endpoint falls back to a loopback TCP port,
+ * which any local process can reach, so a token is required on both — one line, checked before
+ * the session starts. The token lives in a `600` file that the client config points at rather
+ * than embeds, so pasting a config into a client, or into a chat, does not paste a credential.
+ */
+class McpBridgeServer(
+    private val handle: (String) -> String?,
+    private val token: String,
+    private val diagnostics: (String, Throwable?) -> Unit = { _, _ -> },
+) {
+
+    private val running = AtomicBoolean(false)
+    private var channel: ServerSocketChannel? = null
+
+    /**
+     * Live sessions, so stopping the server actually ends them.
+     *
+     * The connection has to be closed as well as the session shut down: a session sits blocked
+     * reading its socket, and closing that socket is the only thing that unblocks it. Without
+     * it the relay process on the other end waits for input that will never come, and survives
+     * the server it was talking to.
+     */
+    private val sessions = java.util.Collections.synchronizedList(mutableListOf<Session>())
+
+    private class Session(val channel: SocketChannel, val server: McpStdioServer)
+
+    private val accepts = Executors.newSingleThreadExecutor { runnable ->
+        Thread(runnable, "SpockAdb-MCP-bridge-accept").apply { isDaemon = true }
+    }
+    private val connections = Executors.newCachedThreadPool { runnable ->
+        Thread(runnable, "SpockAdb-MCP-bridge").apply { isDaemon = true }
+    }
+
+    @Volatile
+    var endpoint: Endpoint? = null
+        private set
+
+    /**
+     * Binds the endpoint and writes [Endpoint.descriptorFile] describing it.
+     *
+     * @param directory where the socket and descriptor live. Created `700` if absent, so a
+     *   Unix domain socket is unreachable by other users.
+     */
+    @Synchronized
+    fun start(directory: Path): Endpoint {
+        stop()
+        Files.createDirectories(directory)
+        restrictToOwner(directory)
+
+        val bound = bindUnixDomain(directory) ?: bindLoopback()
+        channel = bound.first
+        val descriptor = writeDescriptor(directory, bound.second)
+        endpoint = descriptor
+        running.set(true)
+
+        accepts.execute { acceptLoop() }
+        diagnostics("MCP stdio bridge listening on ${descriptor.describe()}", null)
+        return descriptor
+    }
+
+    @Synchronized
+    fun stop() {
+        if (!running.compareAndSet(true, false)) {
+            // Still clean up a half-started bind.
+            closeChannel()
+            return
+        }
+        synchronized(sessions) { sessions.toList() }.forEach { session ->
+            session.server.shutdown()
+            runCatching { session.channel.close() }
+        }
+        sessions.clear()
+        closeChannel()
+        endpoint?.let { runCatching { Files.deleteIfExists(it.descriptorFile) } }
+        endpoint = null
+        diagnostics("MCP stdio bridge stopped", null)
+    }
+
+    /** Frees the executors. The server cannot be started again afterwards. */
+    fun dispose() {
+        stop()
+        accepts.shutdownNow()
+        connections.shutdownNow()
+    }
+
+    private fun closeChannel() {
+        channel?.let { open ->
+            // Read the address before closing: a closed channel throws ClosedChannelException
+            // rather than reporting what it used to be bound to.
+            val socketFile = runCatching { open.localAddress as? UnixDomainSocketAddress }
+                .getOrNull()?.path
+            runCatching { open.close() }
+            // A Unix domain socket is a file and does not remove itself.
+            socketFile?.let { runCatching { Files.deleteIfExists(it) } }
+        }
+        channel = null
+    }
+
+    private fun bindUnixDomain(directory: Path): Pair<ServerSocketChannel, Endpoint>? {
+        val socketPath = directory.resolve(SOCKET_NAME)
+        // sun_path is a fixed-size field in the kernel — a little over 100 bytes on every
+        // platform that has one. An IDE config directory nested deeply enough to overflow it
+        // is unusual but real, and binding would then fail for an obscure-looking reason.
+        if (socketPath.toString().toByteArray(StandardCharsets.UTF_8).size > MAX_SOCKET_PATH_BYTES) {
+            diagnostics("Socket path too long for a Unix domain socket, using loopback TCP", null)
+            return null
+        }
+
+        return try {
+            Files.deleteIfExists(socketPath)
+            val server = ServerSocketChannel.open(StandardProtocolFamily.UNIX)
+            server.bind(UnixDomainSocketAddress.of(socketPath))
+            server to Endpoint(
+                transport = Transport.UNIX,
+                socketPath = socketPath,
+                port = null,
+                token = token,
+                descriptorFile = directory.resolve(DESCRIPTOR_NAME),
+            )
+        } catch (e: UnsupportedOperationException) {
+            // Some platforms and some JDK builds have no AF_UNIX. Fall back rather than lose
+            // the transport, and say which path was taken so it is not a silent difference.
+            diagnostics("Unix domain sockets unavailable, using loopback TCP for the MCP stdio bridge", e)
+            null
+        } catch (e: IOException) {
+            diagnostics("Could not bind the MCP stdio Unix socket, using loopback TCP", e)
+            null
+        }
+    }
+
+    private fun bindLoopback(): Pair<ServerSocketChannel, Endpoint> {
+        val server = ServerSocketChannel.open()
+        server.bind(InetSocketAddress(InetAddress.getLoopbackAddress(), 0))
+        val port = (server.localAddress as InetSocketAddress).port
+        return server to Endpoint(
+            transport = Transport.TCP,
+            socketPath = null,
+            port = port,
+            token = token,
+            descriptorFile = Path.of(""),
+        )
+    }
+
+    // The accept loop must survive one bad connection: a client that dies mid-handshake is
+    // routine and must not take the endpoint down with it.
+    @Suppress("TooGenericExceptionCaught")
+    private fun acceptLoop() {
+        while (running.get()) {
+            val connection = try {
+                channel?.accept() ?: break
+            } catch (e: IOException) {
+                // Closing the channel to stop the server unblocks accept() by throwing.
+                if (running.get()) diagnostics("MCP stdio bridge accept failed", e)
+                break
+            }
+            connections.execute {
+                try {
+                    session(connection)
+                } catch (e: Exception) {
+                    diagnostics("MCP stdio session failed", e)
+                } finally {
+                    runCatching { connection.close() }
+                }
+            }
+        }
+    }
+
+    private fun session(connection: SocketChannel) {
+        val reader = BufferedReader(
+            InputStreamReader(Channels.newInputStream(connection), StandardCharsets.UTF_8),
+        )
+        val writer = OutputStreamWriter(
+            Channels.newOutputStream(connection), StandardCharsets.UTF_8,
+        )
+
+        val presented = reader.readLine()
+        if (presented == null || !matchesToken(presented.trim())) {
+            // Deliberately terse and unlogged in detail: do not tell an unauthorised caller
+            // how to authorise.
+            diagnostics("Rejected an MCP stdio connection with a bad token", null)
+            return
+        }
+
+        val session = Session(connection, McpStdioServer(handle, diagnostics))
+        sessions += session
+        try {
+            session.server.serve(reader, writer)
+        } finally {
+            sessions -= session
+            session.server.shutdown()
+        }
+    }
+
+    private fun matchesToken(presented: String): Boolean = presented.isNotEmpty() &&
+        MessageDigest.isEqual(
+            presented.toByteArray(StandardCharsets.UTF_8),
+            token.toByteArray(StandardCharsets.UTF_8),
+        )
+
+    private fun writeDescriptor(directory: Path, endpoint: Endpoint): Endpoint {
+        val file = directory.resolve(DESCRIPTOR_NAME)
+        val complete = endpoint.copy(descriptorFile = file)
+
+        val properties = Properties().apply {
+            setProperty("transport", complete.transport.name.lowercase())
+            complete.socketPath?.let { setProperty("socket", it.toString()) }
+            complete.port?.let { setProperty("port", it.toString()) }
+            setProperty("token", complete.token)
+        }
+        // Written before the permissions are tightened, so create it empty and restrict it
+        // first: a token must never exist, even briefly, as a world-readable file.
+        Files.deleteIfExists(file)
+        Files.createFile(file)
+        restrictToOwner(file)
+        Files.newOutputStream(file).use { properties.store(it, "Spock ADB MCP stdio endpoint") }
+        return complete
+    }
+
+    /**
+     * Best effort `700` / `600`.
+     *
+     * POSIX permissions are the real protection for the Unix socket. On Windows the ACL model
+     * is different and the token is what protects the loopback port, so a failure here is
+     * reported rather than fatal.
+     */
+    private fun restrictToOwner(path: Path) {
+        try {
+            val view = Files.getFileAttributeView(
+                path,
+                java.nio.file.attribute.PosixFileAttributeView::class.java,
+            ) ?: return
+            val permissions = if (Files.isDirectory(path)) "rwx------" else "rw-------"
+            view.setPermissions(java.nio.file.attribute.PosixFilePermissions.fromString(permissions))
+        } catch (e: IOException) {
+            diagnostics("Could not restrict permissions on $path", e)
+        }
+    }
+
+    enum class Transport { UNIX, TCP }
+
+    /** Where the bridge is listening, and the descriptor file that tells the launcher so. */
+    data class Endpoint(
+        val transport: Transport,
+        val socketPath: Path?,
+        val port: Int?,
+        val token: String,
+        val descriptorFile: Path,
+    ) {
+        fun describe(): String = when (transport) {
+            Transport.UNIX -> "unix:$socketPath"
+            Transport.TCP -> "127.0.0.1:$port"
+        }
+    }
+
+    companion object {
+        const val SOCKET_NAME = "mcp-stdio.sock"
+
+        /** Conservative limit for `sun_path`, which is 104 bytes on macOS and 108 on Linux. */
+        private const val MAX_SOCKET_PATH_BYTES = 100
+        const val DESCRIPTOR_NAME = "mcp-stdio.properties"
+    }
+}

--- a/src/main/kotlin/spock/adb/mcp/stdio/McpStdioServer.kt
+++ b/src/main/kotlin/spock/adb/mcp/stdio/McpStdioServer.kt
@@ -75,9 +75,10 @@ class McpStdioServer(
         running.set(true)
         try {
             while (running.get()) {
+                // End of stream is the only way out: the peer closed its end.
                 val line = reader.readLine() ?: break
-                if (line.isBlank()) continue
-                dispatch(line, writer)
+                // A blank line is not a message. Clients send them; they are not an error.
+                if (line.isNotBlank()) dispatch(line, writer)
             }
         } catch (e: java.io.IOException) {
             // A client that exits mid-read closes the pipe. That is how a stdio session ends,

--- a/src/main/kotlin/spock/adb/mcp/stdio/McpStdioServer.kt
+++ b/src/main/kotlin/spock/adb/mcp/stdio/McpStdioServer.kt
@@ -11,6 +11,7 @@ import java.io.Writer
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
+import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -126,6 +127,19 @@ class McpStdioServer(
 
         // Every request runs on a worker so reading continues while a tool executes: a
         // cancellation that arrived behind a slow call would otherwise never be read.
+        //
+        // A message arriving as the pool shuts down is rejected, which is the right outcome —
+        // there is nothing left to run it on — but it must be dropped rather than thrown out
+        // of the reading loop, where it would end the session as a failure during what is an
+        // ordinary shutdown race.
+        try {
+            submit(line, id, writer)
+        } catch (e: RejectedExecutionException) {
+            diagnostics("Dropped a message that arrived while the stdio session was closing", e)
+        }
+    }
+
+    private fun submit(line: String, id: String?, writer: Writer) {
         workers.execute {
             id?.let { inFlight[it] = Thread.currentThread() }
             try {

--- a/src/main/kotlin/spock/adb/mcp/stdio/McpStdioServer.kt
+++ b/src/main/kotlin/spock/adb/mcp/stdio/McpStdioServer.kt
@@ -88,9 +88,19 @@ class McpStdioServer(
         }
     }
 
-    /** Stops serving and stops accepting new work. Safe to call more than once. */
+    /**
+     * Stops serving and releases the worker pool. Safe to call more than once.
+     *
+     * Deliberately unconditional rather than guarded on [running]: a server that was shut down
+     * before it ever served, or that has already stopped, must still release its threads.
+     * Guarding this on the running flag leaked the pool in exactly those two cases.
+     *
+     * This does **not** unblock a [serve] call sitting in `readLine`. Nothing can, short of
+     * closing the stream — which is how a stdio session ends anyway, and what
+     * [McpBridgeServer] does to each live connection when it stops.
+     */
     fun shutdown() {
-        if (!running.compareAndSet(true, false)) return
+        running.set(false)
         // Interrupt anything still running: a tool call blocked on a device must not keep the
         // IDE's executor alive after the client has gone.
         inFlight.values.forEach { it.interrupt() }

--- a/src/main/kotlin/spock/adb/mcp/stdio/McpStdioServer.kt
+++ b/src/main/kotlin/spock/adb/mcp/stdio/McpStdioServer.kt
@@ -1,0 +1,181 @@
+package spock.adb.mcp.stdio
+
+import com.google.gson.JsonParser
+import java.io.BufferedReader
+import java.io.InputStream
+import java.io.InputStreamReader
+import java.io.OutputStream
+import java.io.OutputStreamWriter
+import java.io.Writer
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * MCP's stdio transport: newline-delimited JSON-RPC over a byte stream.
+ *
+ * It owns framing, concurrency and cancellation, and **nothing else**. Every message is
+ * handed verbatim to [handle] — which is [spock.adb.mcp.McpProtocol.handle] — so `initialize`,
+ * tool discovery, tool calls, unknown methods and malformed JSON are all answered by the same
+ * implementation that serves the HTTP transport. There is deliberately no second protocol
+ * here to drift from the first.
+ *
+ * It takes streams rather than touching `System.in` / `System.out`, so the same class serves
+ * a socket connection inside the IDE (see [McpBridgeServer]) and a real process stdio pair,
+ * and can be tested over a pipe.
+ *
+ * Framing is the MCP stdio spec's: one JSON message per line, UTF-8, no embedded newlines.
+ *
+ * **Nothing but protocol messages may reach [output].** Diagnostics go to [diagnostics], which
+ * in the IDE is the log and in the launcher process is stderr. A stray `println` on this
+ * stream corrupts the session for the client, which is why this class never prints.
+ */
+class McpStdioServer(
+    private val handle: (String) -> String?,
+    private val diagnostics: (String, Throwable?) -> Unit = { _, _ -> },
+) {
+
+    private val running = AtomicBoolean(false)
+
+    /**
+     * Requests being executed right now, by JSON-RPC id, so `notifications/cancelled` has
+     * something to act on. Entries are removed as each request finishes.
+     */
+    private val inFlight = ConcurrentHashMap<String, Thread>()
+
+    /** Ids cancelled by the client. A cancelled request's response is never written. */
+    private val cancelled = ConcurrentHashMap.newKeySet<String>()
+
+    private val workers = Executors.newFixedThreadPool(WORKERS) { runnable ->
+        Thread(runnable, "SpockAdb-MCP-stdio").apply { isDaemon = true }
+    }
+
+    /**
+     * Reads messages from [input] until end of stream, answering on [output].
+     *
+     * Blocks the calling thread. Returns when the peer closes its end (the client exited),
+     * when [shutdown] is called, or when the stream errors — all of which mean the session is
+     * over and are normal, not failures.
+     */
+    fun serve(input: InputStream, output: OutputStream) = serve(
+        BufferedReader(InputStreamReader(input, StandardCharsets.UTF_8)),
+        OutputStreamWriter(output, StandardCharsets.UTF_8),
+    )
+
+    /**
+     * Serves an already-wrapped reader and writer.
+     *
+     * [McpBridgeServer] needs this: it reads the token line off the connection before the
+     * session starts, and a second [BufferedReader] over the same socket would silently take
+     * the bytes the first one had already buffered.
+     */
+    fun serve(reader: BufferedReader, writer: Writer) {
+        running.set(true)
+        try {
+            while (running.get()) {
+                val line = reader.readLine() ?: break
+                if (line.isBlank()) continue
+                dispatch(line, writer)
+            }
+        } catch (e: java.io.IOException) {
+            // A client that exits mid-read closes the pipe. That is how a stdio session ends,
+            // not something to report as a failure.
+            diagnostics("stdio session ended: ${e.message}", null)
+        } finally {
+            shutdown()
+        }
+    }
+
+    /** Stops serving and stops accepting new work. Safe to call more than once. */
+    fun shutdown() {
+        if (!running.compareAndSet(true, false)) return
+        // Interrupt anything still running: a tool call blocked on a device must not keep the
+        // IDE's executor alive after the client has gone.
+        inFlight.values.forEach { it.interrupt() }
+        workers.shutdownNow()
+        runCatching { workers.awaitTermination(SHUTDOWN_GRACE_SECONDS, TimeUnit.SECONDS) }
+    }
+
+    private fun dispatch(line: String, writer: Writer) {
+        // Peek only. A message that will not parse is still forwarded verbatim, so the parse
+        // error comes back from the protocol implementation rather than from a second, subtly
+        // different one here.
+        val message = runCatching { JsonParser.parseString(line).asJsonObject }.getOrNull()
+        val method = runCatching { message?.get("method")?.asString }.getOrNull()
+
+        if (method == CANCEL_NOTIFICATION) {
+            cancel(message)
+            return
+        }
+
+        val id = message?.get("id")?.takeIf { !it.isJsonNull }?.toString()
+
+        // Every request runs on a worker so reading continues while a tool executes: a
+        // cancellation that arrived behind a slow call would otherwise never be read.
+        workers.execute {
+            id?.let { inFlight[it] = Thread.currentThread() }
+            try {
+                val response = handleSafely(line)
+                // A cancelled request gets no response, per the MCP spec: the client has
+                // already stopped waiting for one.
+                if (response != null && (id == null || !cancelled.contains(id))) {
+                    write(writer, response)
+                }
+            } finally {
+                id?.let {
+                    inFlight.remove(it)
+                    cancelled.remove(it)
+                }
+                // Clear the interrupt so the pooled thread is reusable after a cancellation.
+                Thread.interrupted()
+            }
+        }
+    }
+
+    // The protocol boundary must not be able to kill the session: an unexpected exception
+    // becomes an error response, never a dropped connection the client waits on forever.
+    @Suppress("TooGenericExceptionCaught")
+    private fun handleSafely(line: String): String? = try {
+        handle(line)
+    } catch (e: Exception) {
+        diagnostics("MCP request failed", e)
+        null
+    }
+
+    private fun cancel(message: com.google.gson.JsonObject?) {
+        val id = runCatching {
+            message?.getAsJsonObject("params")?.get("requestId")?.takeIf { !it.isJsonNull }?.toString()
+        }.getOrNull() ?: return
+
+        cancelled += id
+        inFlight[id]?.interrupt()
+        diagnostics("Cancelled in-flight request $id", null)
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun write(writer: Writer, response: String) {
+        // One message per line is the frame. A response containing a raw newline would be read
+        // by the client as two broken messages; Gson escapes newlines inside strings, so this
+        // only guards against a future change in how responses are produced.
+        val framed = response.replace("\n", "").replace("\r", "")
+        synchronized(writer) {
+            try {
+                writer.write(framed)
+                writer.write("\n")
+                writer.flush()
+            } catch (e: Exception) {
+                diagnostics("Could not write MCP response", e)
+                running.set(false)
+            }
+        }
+    }
+
+    companion object {
+        const val CANCEL_NOTIFICATION = "notifications/cancelled"
+
+        private const val WORKERS = 4
+        private const val SHUTDOWN_GRACE_SECONDS = 2L
+    }
+}

--- a/src/main/kotlin/spock/adb/mcp/stdio/McpStdioServer.kt
+++ b/src/main/kotlin/spock/adb/mcp/stdio/McpStdioServer.kt
@@ -1,5 +1,6 @@
 package spock.adb.mcp.stdio
 
+import com.google.gson.JsonObject
 import com.google.gson.JsonParser
 import java.io.BufferedReader
 import java.io.InputStream
@@ -128,7 +129,7 @@ class McpStdioServer(
         workers.execute {
             id?.let { inFlight[it] = Thread.currentThread() }
             try {
-                val response = handleSafely(line)
+                val response = handleSafely(line, id)
                 // A cancelled request gets no response, per the MCP spec: the client has
                 // already stopped waiting for one.
                 if (response != null && (id == null || !cancelled.contains(id))) {
@@ -145,17 +146,39 @@ class McpStdioServer(
         }
     }
 
-    // The protocol boundary must not be able to kill the session: an unexpected exception
-    // becomes an error response, never a dropped connection the client waits on forever.
+    /**
+     * Runs the handler, turning an unexpected exception into an error response.
+     *
+     * Returning null here instead would leave the client waiting forever on a request that is
+     * never answered — indistinguishable from a dropped one, and worse than the crash it was
+     * meant to contain. A notification ([id] null) still gets no response: by spec it never
+     * had one coming.
+     */
     @Suppress("TooGenericExceptionCaught")
-    private fun handleSafely(line: String): String? = try {
+    private fun handleSafely(line: String, id: String?): String? = try {
         handle(line)
     } catch (e: Exception) {
         diagnostics("MCP request failed", e)
-        null
+        id?.let { internalError(it, e) }
     }
 
-    private fun cancel(message: com.google.gson.JsonObject?) {
+    /**
+     * @param id the request id exactly as it arrived, already valid JSON — a number or a
+     *   quoted string — so it is echoed back in the form the client sent it.
+     */
+    private fun internalError(id: String, cause: Exception): String = JsonObject().apply {
+        addProperty("jsonrpc", "2.0")
+        add("id", JsonParser.parseString(id))
+        add(
+            "error",
+            JsonObject().apply {
+                addProperty("code", INTERNAL_ERROR)
+                addProperty("message", cause.message ?: cause.javaClass.simpleName)
+            },
+        )
+    }.toString()
+
+    private fun cancel(message: JsonObject?) {
         val id = runCatching {
             message?.getAsJsonObject("params")?.get("requestId")?.takeIf { !it.isJsonNull }?.toString()
         }.getOrNull() ?: return
@@ -185,6 +208,9 @@ class McpStdioServer(
 
     companion object {
         const val CANCEL_NOTIFICATION = "notifications/cancelled"
+
+        /** JSON-RPC 2.0 internal error. Defined here so the transport stays standalone. */
+        private const val INTERNAL_ERROR = -32603
 
         private const val WORKERS = 4
         private const val SHUTDOWN_GRACE_SECONDS = 2L

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -154,8 +154,12 @@
                     text="Restart MCP Server"/>
             <action id="spock.adb.mcp.CopyMcpConfigurationAction"
                     class="spock.adb.mcp.actions.CopyMcpConfigurationAction"
-                    text="Copy MCP Client Configuration"
+                    text="Copy MCP Client Configuration (HTTP)"
                     description="Copy a ready-to-paste MCP client configuration for this IDE"/>
+            <action id="spock.adb.mcp.CopyMcpStdioConfigurationAction"
+                    class="spock.adb.mcp.actions.CopyMcpStdioConfigurationAction"
+                    text="Copy MCP Client Configuration (stdio)"
+                    description="Copy a stdio MCP client configuration, which carries no token"/>
         </group>
     </actions>
 </idea-plugin>

--- a/src/test/kotlin/spock/adb/mcp/stdio/McpBridgeServerTest.kt
+++ b/src/test/kotlin/spock/adb/mcp/stdio/McpBridgeServerTest.kt
@@ -187,6 +187,18 @@ class McpBridgeServerTest {
             )
             // Everything after the response must have gone to stderr instead.
             assertNull(stdout.readLine(), "stdout carries protocol messages and nothing else")
+
+            // This is the ordinary way a session ends, so it is a success, and silent. Tearing
+            // the connection down from the stdin pump instead of half-closing it used to abort
+            // the read still in flight and report the clean shutdown as a lost connection.
+            assertEquals(0, process.exitValue(), "a client closing stdin is not a failure")
+            // Asserting the absence of the failure rather than an empty stderr: a JVM may
+            // print banners of its own there (JAVA_TOOL_OPTIONS, CDS warnings), and a test
+            // that breaks on those would be testing the environment, not the launcher.
+            assertFalse(
+                process.errorStream.readBytes().decodeToString().contains("lost the connection"),
+                "a clean shutdown must not be reported as a lost connection",
+            )
         } finally {
             process.destroyForcibly()
         }

--- a/src/test/kotlin/spock/adb/mcp/stdio/McpBridgeServerTest.kt
+++ b/src/test/kotlin/spock/adb/mcp/stdio/McpBridgeServerTest.kt
@@ -113,6 +113,23 @@ class McpBridgeServerTest {
     }
 
     @Test
+    fun `a connection that never presents a token is closed`(@TempDir directory: Path) {
+        // A connection that opens and then says nothing would otherwise hold a thread for as
+        // long as it liked, and enough of them would starve real clients of the pool — which
+        // any local process can attempt in the TCP fallback.
+        val server = McpBridgeServer(protocol::handle, token, handshakeTimeoutSeconds = 1)
+        bridge = server
+        val endpoint = server.start(directory)
+
+        connect(endpoint).use { channel ->
+            val responses = Channels.newInputStream(channel).bufferedReader()
+            // Deliberately send nothing at all. readLine returns null when the far end closes,
+            // so this blocks until the deadline does its job, or the test times out.
+            assertNull(responses.readLine(), "a silent connection should be closed, not held")
+        }
+    }
+
+    @Test
     fun `stopping removes the socket and the token file`(@TempDir directory: Path) {
         val endpoint = start(directory)
         bridge!!.stop()
@@ -133,16 +150,17 @@ class McpBridgeServerTest {
      * the generated client configuration resolves it, and it does not care whether the test
      * runner handed us a real classpath or a manifest-only one.
      */
-    private fun launch(descriptor: Path): Process {
+    private fun launch(descriptor: Path?): Process {
         val source = SpockAdbStdioLauncher::class.java.protectionDomain?.codeSource?.location
         assumeTrue(source != null, "cannot locate the launcher to spawn it")
-        return ProcessBuilder(
+        val command = listOfNotNull(
             Path.of(System.getProperty("java.home"), "bin", "java").toString(),
             "-cp",
             Path.of(source!!.toURI()).toString(),
             SpockAdbStdioLauncher::class.java.name,
-            descriptor.toString(),
-        ).start()
+            descriptor?.toString(),
+        )
+        return ProcessBuilder(command).start()
     }
 
     @Test
@@ -169,6 +187,24 @@ class McpBridgeServerTest {
             )
             // Everything after the response must have gone to stderr instead.
             assertNull(stdout.readLine(), "stdout carries protocol messages and nothing else")
+        } finally {
+            process.destroyForcibly()
+        }
+    }
+
+    @Test
+    fun `a launcher given no descriptor explains how to get one`() {
+        // The descriptor path is required: the IDE writes it under its own config directory,
+        // which differs per IDE, version and platform, so no default could name it correctly.
+        val process = launch(descriptor = null)
+        try {
+            assertTrue(process.waitFor(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+            assertFalse(process.exitValue() == 0)
+            assertTrue(process.inputStream.readBytes().isEmpty(), "nothing may go to stdout")
+            assertTrue(
+                process.errorStream.readBytes().decodeToString().contains("Copy MCP Client Configuration"),
+                "the message should say where to get a descriptor",
+            )
         } finally {
             process.destroyForcibly()
         }

--- a/src/test/kotlin/spock/adb/mcp/stdio/McpBridgeServerTest.kt
+++ b/src/test/kotlin/spock/adb/mcp/stdio/McpBridgeServerTest.kt
@@ -1,0 +1,210 @@
+package spock.adb.mcp.stdio
+
+import com.google.gson.JsonParser
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import spock.adb.mcp.FakeToolContext
+import spock.adb.mcp.McpProtocol
+import java.net.StandardProtocolFamily
+import java.net.UnixDomainSocketAddress
+import java.nio.channels.Channels
+import java.nio.channels.SocketChannel
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.attribute.PosixFilePermissions
+import java.util.Properties
+import java.util.concurrent.TimeUnit
+
+/**
+ * The bridge is what makes stdio reachable from outside the IDE, so its security properties
+ * are tested rather than asserted in a comment: the socket and the descriptor holding the
+ * token are unreadable by other users, and a connection that cannot present the token is
+ * closed before any protocol message is served.
+ *
+ * The launcher is exercised as a real spawned process, because the things most likely to be
+ * wrong about it — that it exits when told to, and that it never writes anything but protocol
+ * messages to stdout — are only true of an actual process.
+ */
+class McpBridgeServerTest {
+
+    private val token = "bridge-test-token"
+    private val protocol = McpProtocol(contextProvider = { FakeToolContext() })
+    private var bridge: McpBridgeServer? = null
+
+    private fun start(directory: Path): McpBridgeServer.Endpoint {
+        val server = McpBridgeServer(protocol::handle, token)
+        bridge = server
+        return server.start(directory)
+    }
+
+    @AfterEach
+    fun stop() {
+        bridge?.dispose()
+    }
+
+    private fun connect(endpoint: McpBridgeServer.Endpoint): SocketChannel {
+        assumeTrue(endpoint.transport == McpBridgeServer.Transport.UNIX, "no Unix domain sockets here")
+        val channel = SocketChannel.open(StandardProtocolFamily.UNIX)
+        channel.connect(UnixDomainSocketAddress.of(endpoint.socketPath!!))
+        return channel
+    }
+
+    @Test
+    fun `binds a socket and describes it in a descriptor file`(@TempDir directory: Path) {
+        val endpoint = start(directory)
+
+        assertTrue(Files.exists(endpoint.descriptorFile))
+        val properties = Properties().apply {
+            Files.newInputStream(endpoint.descriptorFile).use { load(it) }
+        }
+        assertEquals(token, properties.getProperty("token"))
+        assertTrue(properties.getProperty("transport") in setOf("unix", "tcp"))
+    }
+
+    @Test
+    fun `the token file is readable only by its owner`(@TempDir directory: Path) {
+        val endpoint = start(directory)
+        val permissions = runCatching { Files.getPosixFilePermissions(endpoint.descriptorFile) }.getOrNull()
+        assumeTrue(permissions != null, "not a POSIX filesystem")
+
+        // The whole point of keeping the token out of the client config is that the file it
+        // lives in is not readable by anything else on the machine.
+        assertEquals("rw-------", PosixFilePermissions.toString(permissions!!))
+        assertEquals("rwx------", PosixFilePermissions.toString(Files.getPosixFilePermissions(directory)))
+    }
+
+    @Test
+    fun `serves the shared protocol once the token is presented`(@TempDir directory: Path) {
+        val endpoint = start(directory)
+        connect(endpoint).use { channel ->
+            val out = Channels.newOutputStream(channel)
+            val responses = Channels.newInputStream(channel).bufferedReader()
+
+            out.write("$token\n".toByteArray())
+            out.write("""{"jsonrpc":"2.0","id":1,"method":"initialize"}""".toByteArray())
+            out.write('\n'.code)
+            out.flush()
+
+            val result = JsonParser.parseString(responses.readLine()).asJsonObject.getAsJsonObject("result")
+            assertEquals(McpProtocol.PROTOCOL_VERSION, result.get("protocolVersion").asString)
+        }
+    }
+
+    @Test
+    fun `closes a connection that presents the wrong token`(@TempDir directory: Path) {
+        val endpoint = start(directory)
+        connect(endpoint).use { channel ->
+            val out = Channels.newOutputStream(channel)
+            val responses = Channels.newInputStream(channel).bufferedReader()
+
+            out.write("not-the-token\n".toByteArray())
+            out.write("""{"jsonrpc":"2.0","id":1,"method":"initialize"}""".toByteArray())
+            out.write('\n'.code)
+            out.flush()
+
+            assertNull(responses.readLine(), "an unauthorised connection must be closed, not served")
+        }
+    }
+
+    @Test
+    fun `stopping removes the socket and the token file`(@TempDir directory: Path) {
+        val endpoint = start(directory)
+        bridge!!.stop()
+
+        // A stale descriptor would point a client at an endpoint that is no longer listening,
+        // and a leftover token file is a credential outliving the thing it authorises.
+        assertFalse(Files.exists(endpoint.descriptorFile))
+        endpoint.socketPath?.let { assertFalse(Files.exists(it)) }
+    }
+
+    // ---- the launcher, as a real process ----
+
+    private fun launch(descriptor: Path): Process {
+        val classpath = System.getProperty("java.class.path")
+        assumeTrue(!classpath.isNullOrBlank(), "no usable classpath to spawn the launcher with")
+        return ProcessBuilder(
+            Path.of(System.getProperty("java.home"), "bin", "java").toString(),
+            "-cp", classpath,
+            SpockAdbStdioLauncher::class.java.name,
+            descriptor.toString(),
+        ).start()
+    }
+
+    @Test
+    fun `a spawned launcher relays a session and exits when its stdin closes`(@TempDir directory: Path) {
+        val endpoint = start(directory)
+        assumeTrue(endpoint.transport == McpBridgeServer.Transport.UNIX, "no Unix domain sockets here")
+        val process = launch(endpoint.descriptorFile)
+        try {
+            val stdin = process.outputStream
+            val stdout = process.inputStream.bufferedReader()
+
+            stdin.write("""{"jsonrpc":"2.0","id":1,"method":"initialize"}""".toByteArray())
+            stdin.write('\n'.code)
+            stdin.flush()
+
+            val response = JsonParser.parseString(stdout.readLine()).asJsonObject
+            assertEquals(1, response.get("id").asInt)
+
+            // Closing stdin is how an MCP client ends a stdio session.
+            stdin.close()
+            assertTrue(
+                process.waitFor(TIMEOUT_SECONDS, TimeUnit.SECONDS),
+                "the launcher must exit when its client goes away, not linger",
+            )
+            // Everything after the response must have gone to stderr instead.
+            assertNull(stdout.readLine(), "stdout carries protocol messages and nothing else")
+        } finally {
+            process.destroyForcibly()
+        }
+    }
+
+    @Test
+    fun `a launcher with no endpoint fails on stderr and writes nothing to stdout`(@TempDir directory: Path) {
+        val process = launch(directory.resolve("absent.properties"))
+        try {
+            assertTrue(process.waitFor(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+            assertFalse(process.exitValue() == 0, "an unreachable IDE is a failure, and must be reported as one")
+            assertTrue(process.inputStream.readBytes().isEmpty(), "nothing may be written to the protocol stream")
+            assertTrue(
+                process.errorStream.readBytes().decodeToString().contains("Start MCP Server"),
+                "the developer should be told how to fix it",
+            )
+        } finally {
+            process.destroyForcibly()
+        }
+    }
+
+    @Test
+    fun `a launcher exits when the IDE stops the bridge`(@TempDir directory: Path) {
+        val endpoint = start(directory)
+        assumeTrue(endpoint.transport == McpBridgeServer.Transport.UNIX, "no Unix domain sockets here")
+        val process = launch(endpoint.descriptorFile)
+        try {
+            val stdin = process.outputStream
+            stdin.write("""{"jsonrpc":"2.0","id":1,"method":"ping"}""".toByteArray())
+            stdin.write('\n'.code)
+            stdin.flush()
+            process.inputStream.bufferedReader().readLine()
+
+            bridge!!.stop()
+
+            assertTrue(
+                process.waitFor(TIMEOUT_SECONDS, TimeUnit.SECONDS),
+                "stopping the server must end the client's session, not strand it",
+            )
+        } finally {
+            process.destroyForcibly()
+        }
+    }
+
+    private companion object {
+        const val TIMEOUT_SECONDS = 20L
+    }
+}

--- a/src/test/kotlin/spock/adb/mcp/stdio/McpBridgeServerTest.kt
+++ b/src/test/kotlin/spock/adb/mcp/stdio/McpBridgeServerTest.kt
@@ -125,12 +125,20 @@ class McpBridgeServerTest {
 
     // ---- the launcher, as a real process ----
 
+    /**
+     * Spawns the launcher from its own code source rather than from `java.class.path`.
+     *
+     * The launcher has no dependencies — that is the point of it being plain Java — so the jar
+     * or class directory holding it is the entire classpath it needs. It is also the same way
+     * the generated client configuration resolves it, and it does not care whether the test
+     * runner handed us a real classpath or a manifest-only one.
+     */
     private fun launch(descriptor: Path): Process {
-        val classpath = System.getProperty("java.class.path")
-        assumeTrue(!classpath.isNullOrBlank(), "no usable classpath to spawn the launcher with")
+        val source = SpockAdbStdioLauncher::class.java.protectionDomain?.codeSource?.location
+        assumeTrue(source != null, "cannot locate the launcher to spawn it")
         return ProcessBuilder(
             Path.of(System.getProperty("java.home"), "bin", "java").toString(),
-            "-cp", classpath,
+            "-cp", Path.of(source!!.toURI()).toString(),
             SpockAdbStdioLauncher::class.java.name,
             descriptor.toString(),
         ).start()

--- a/src/test/kotlin/spock/adb/mcp/stdio/McpBridgeServerTest.kt
+++ b/src/test/kotlin/spock/adb/mcp/stdio/McpBridgeServerTest.kt
@@ -205,6 +205,42 @@ class McpBridgeServerTest {
     }
 
     @Test
+    fun `a launcher whose token is stale fails loudly rather than exiting quietly`(@TempDir directory: Path) {
+        val endpoint = start(directory)
+        assumeTrue(endpoint.transport == McpBridgeServer.Transport.UNIX, "no Unix domain sockets here")
+
+        // A descriptor pointing at the real endpoint with the wrong token — what a client is
+        // left holding after the token is rotated. The bridge closes the connection without a
+        // word, so from the launcher this is indistinguishable from a stopped server, and both
+        // used to look like a clean, silent, successful exit.
+        val stale = directory.resolve("stale.properties")
+        Files.newOutputStream(stale).use { out ->
+            Properties().apply {
+                setProperty("transport", "unix")
+                setProperty("socket", endpoint.socketPath!!.toString())
+                setProperty("token", "not-the-token")
+            }.store(out, null)
+        }
+
+        val process = launch(stale)
+        try {
+            val stdin = process.outputStream
+            stdin.write("""{"jsonrpc":"2.0","id":1,"method":"initialize"}""".toByteArray())
+            stdin.write('\n'.code)
+            runCatching { stdin.flush() }
+
+            assertTrue(process.waitFor(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+            assertFalse(process.exitValue() == 0, "a rejected session is a failure, not a quiet success")
+            assertTrue(
+                process.errorStream.readBytes().decodeToString().contains("closed the connection"),
+                "the developer should be told the IDE hung up, not left guessing",
+            )
+        } finally {
+            process.destroyForcibly()
+        }
+    }
+
+    @Test
     fun `a launcher given no descriptor explains how to get one`() {
         // The descriptor path is required: the IDE writes it under its own config directory,
         // which differs per IDE, version and platform, so no default could name it correctly.
@@ -256,6 +292,10 @@ class McpBridgeServerTest {
                 process.waitFor(TIMEOUT_SECONDS, TimeUnit.SECONDS),
                 "stopping the server must end the client's session, not strand it",
             )
+            // The IDE hanging up while the client is still talking is a failure, however
+            // quietly it happens. Exiting 0 would tell the client the server started and then
+            // chose to do nothing.
+            assertFalse(process.exitValue() == 0, "a server that vanished mid-session is not success")
         } finally {
             process.destroyForcibly()
         }

--- a/src/test/kotlin/spock/adb/mcp/stdio/McpBridgeServerTest.kt
+++ b/src/test/kotlin/spock/adb/mcp/stdio/McpBridgeServerTest.kt
@@ -138,7 +138,8 @@ class McpBridgeServerTest {
         assumeTrue(source != null, "cannot locate the launcher to spawn it")
         return ProcessBuilder(
             Path.of(System.getProperty("java.home"), "bin", "java").toString(),
-            "-cp", Path.of(source!!.toURI()).toString(),
+            "-cp",
+            Path.of(source!!.toURI()).toString(),
             SpockAdbStdioLauncher::class.java.name,
             descriptor.toString(),
         ).start()

--- a/src/test/kotlin/spock/adb/mcp/stdio/McpStdioServerTest.kt
+++ b/src/test/kotlin/spock/adb/mcp/stdio/McpStdioServerTest.kt
@@ -241,16 +241,38 @@ class McpStdioServerTest {
     }
 
     @Test
-    fun `an exception escaping the protocol does not end the session`() {
+    fun `an exception escaping the protocol becomes an error response, not silence`() {
         start { raw -> if (raw.contains("boom")) error("boom") else """{"jsonrpc":"2.0","id":18,"result":{}}""" }
         send("""{"jsonrpc":"2.0","id":17,"method":"boom"}""")
-        send("""{"jsonrpc":"2.0","id":18,"method":"ping"}""")
 
+        // Answering nothing would leave the client waiting forever on a request that is never
+        // answered — indistinguishable from a dropped one, and worse than the crash it
+        // contains.
+        val failure = read()
+        assertEquals(17, failure.get("id").asInt)
+        val error = failure.getAsJsonObject("error")
+        assertEquals(JSON_RPC_INTERNAL_ERROR, error.get("code").asInt)
+        assertTrue(error.get("message").asString.contains("boom"))
+
+        // And the session is still usable afterwards.
+        send("""{"jsonrpc":"2.0","id":18,"method":"ping"}""")
         assertEquals(18, read().get("id").asInt)
+    }
+
+    @Test
+    fun `an exception on a notification is still not answered`() {
+        start { error("boom") }
+        send("""{"jsonrpc":"2.0","method":"notifications/initialized"}""")
+        send("""{"jsonrpc":"2.0","id":19,"method":"ping"}""")
+
+        // A notification has no response coming, failure included, so the next line on the
+        // wire is the ping's error rather than anything for the notification.
+        assertEquals(19, read().get("id").asInt)
     }
 
     private companion object {
         const val BUFFER = 1 shl 16
+        const val JSON_RPC_INTERNAL_ERROR = -32603
         const val TIMEOUT_SECONDS = 10L
         const val POLL_MS = 25L
     }

--- a/src/test/kotlin/spock/adb/mcp/stdio/McpStdioServerTest.kt
+++ b/src/test/kotlin/spock/adb/mcp/stdio/McpStdioServerTest.kt
@@ -40,7 +40,10 @@ class McpStdioServerTest {
         val output = PipedOutputStream(fromServer)
         responses = fromServer.bufferedReader()
         server = McpStdioServer(handle)
-        thread = Thread { server.serve(input, output) }.apply { isDaemon = true; start() }
+        thread = Thread { server.serve(input, output) }.apply {
+            isDaemon = true
+            start()
+        }
     }
 
     @AfterEach

--- a/src/test/kotlin/spock/adb/mcp/stdio/McpStdioServerTest.kt
+++ b/src/test/kotlin/spock/adb/mcp/stdio/McpStdioServerTest.kt
@@ -1,0 +1,247 @@
+package spock.adb.mcp.stdio
+
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import spock.adb.mcp.FakeToolContext
+import spock.adb.mcp.McpProtocol
+import spock.adb.mcp.tools.ToolRegistry
+import java.io.BufferedReader
+import java.io.PipedInputStream
+import java.io.PipedOutputStream
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * The stdio transport, exercised over a real pipe against the real [McpProtocol].
+ *
+ * The point of these tests is that nothing about the protocol is re-implemented for stdio:
+ * `initialize`, `tools/list`, `tools/call`, unknown tools and malformed JSON are answered by
+ * the same object that answers them over HTTP, and the answers arrive correctly framed.
+ */
+class McpStdioServerTest {
+
+    private val context = FakeToolContext()
+    private val protocol = McpProtocol(contextProvider = { context })
+
+    private val toServer = PipedOutputStream()
+    private val fromServer = PipedInputStream(BUFFER)
+    private lateinit var responses: BufferedReader
+    private lateinit var server: McpStdioServer
+    private lateinit var thread: Thread
+
+    private fun start(handle: (String) -> String? = protocol::handle) {
+        val input = PipedInputStream(toServer, BUFFER)
+        val output = PipedOutputStream(fromServer)
+        responses = fromServer.bufferedReader()
+        server = McpStdioServer(handle)
+        thread = Thread { server.serve(input, output) }.apply { isDaemon = true; start() }
+    }
+
+    @AfterEach
+    fun stop() {
+        if (::server.isInitialized) server.shutdown()
+    }
+
+    private fun send(line: String) {
+        toServer.write((line + "\n").toByteArray())
+        toServer.flush()
+    }
+
+    private fun read(): JsonObject =
+        JsonParser.parseString(responses.readLine()).asJsonObject
+
+    @Test
+    fun `initialize is answered by the shared protocol implementation`() {
+        start()
+        send("""{"jsonrpc":"2.0","id":1,"method":"initialize"}""")
+
+        val result = read().getAsJsonObject("result")
+        assertEquals(McpProtocol.PROTOCOL_VERSION, result.get("protocolVersion").asString)
+        assertEquals("spock-adb", result.getAsJsonObject("serverInfo").get("name").asString)
+    }
+
+    @Test
+    fun `tools list returns the same registry the HTTP transport serves`() {
+        start()
+        send("""{"jsonrpc":"2.0","id":2,"method":"tools/list"}""")
+
+        val tools = read().getAsJsonObject("result").getAsJsonArray("tools")
+        assertEquals(ToolRegistry.all().size, tools.size())
+    }
+
+    @Test
+    fun `a tool call runs the tool and returns its content`() {
+        start()
+        send(
+            """{"jsonrpc":"2.0","id":3,"method":"tools/call",
+               "params":{"name":"android_list_devices","arguments":{}}}""".replace("\n", " "),
+        )
+
+        val result = read().getAsJsonObject("result")
+        assertFalse(result.get("isError").asBoolean)
+        assertTrue(result.getAsJsonArray("content").toString().contains("emulator-5554"))
+    }
+
+    @Test
+    fun `an invalid request with no method is a JSON-RPC error`() {
+        start()
+        send("""{"jsonrpc":"2.0","id":4}""")
+
+        assertEquals(McpProtocol.INVALID_REQUEST, read().getAsJsonObject("error").get("code").asInt)
+    }
+
+    @Test
+    fun `malformed JSON is a parse error, produced by the protocol and not by the transport`() {
+        start()
+        send("""{"jsonrpc": "2.0", "id": 5, "method":""")
+
+        assertEquals(McpProtocol.PARSE_ERROR, read().getAsJsonObject("error").get("code").asInt)
+    }
+
+    @Test
+    fun `an unknown tool is a tool error the agent can read`() {
+        start()
+        send("""{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"android_nope"}}""")
+
+        val result = read().getAsJsonObject("result")
+        assertTrue(result.get("isError").asBoolean)
+        assertTrue(result.getAsJsonArray("content").toString().contains("Unknown tool"))
+    }
+
+    @Test
+    fun `a failing tool reports the failure as a tool error, not a dropped session`() {
+        start()
+        send(
+            """{"jsonrpc":"2.0","id":7,"method":"tools/call",
+               "params":{"name":"android_select_device","arguments":{"deviceSerial":"missing"}}}"""
+                .replace("\n", " "),
+        )
+
+        assertTrue(read().getAsJsonObject("result").get("isError").asBoolean)
+
+        // The session survives it: the next request is answered normally.
+        send("""{"jsonrpc":"2.0","id":8,"method":"ping"}""")
+        assertEquals(8, read().get("id").asInt)
+    }
+
+    @Test
+    fun `a notification is not answered`() {
+        start()
+        send("""{"jsonrpc":"2.0","method":"notifications/initialized"}""")
+        send("""{"jsonrpc":"2.0","id":9,"method":"ping"}""")
+
+        // The first line on the stream is the ping's response, so nothing was written for the
+        // notification.
+        assertEquals(9, read().get("id").asInt)
+    }
+
+    @Test
+    fun `responses are one per line, so a client can frame them`() {
+        start()
+        send("""{"jsonrpc":"2.0","id":10,"method":"initialize"}""")
+
+        val line = responses.readLine()
+        assertFalse(line.contains('\n'))
+        // instructions and change notes contain prose; none of it may break the frame.
+        JsonParser.parseString(line).asJsonObject
+    }
+
+    // ---- cancellation and lifecycle ----
+    //
+    // These use a controllable handler rather than the real protocol: no registered tool
+    // blocks long enough to be cancelled on purpose, and a test that raced a real ADB call
+    // would be flaky rather than meaningful. Cancellation is a transport concern in any case —
+    // the protocol never sees it.
+
+    private val started = CountDownLatch(1)
+    private val interrupted = AtomicBoolean(false)
+
+    private fun slowHandler(raw: String): String? {
+        val request = JsonParser.parseString(raw).asJsonObject
+        val id = request.get("id")
+        if (request.get("method").asString == "slow") {
+            started.countDown()
+            try {
+                Thread.sleep(TimeUnit.SECONDS.toMillis(30))
+            } catch (e: InterruptedException) {
+                interrupted.set(true)
+                Thread.currentThread().interrupt()
+            }
+        }
+        return """{"jsonrpc":"2.0","id":$id,"result":{}}"""
+    }
+
+    @Test
+    fun `a cancelled request is interrupted and never answered`() {
+        start(::slowHandler)
+        send("""{"jsonrpc":"2.0","id":11,"method":"slow"}""")
+        assertTrue(started.await(TIMEOUT_SECONDS, TimeUnit.SECONDS), "the slow call should have started")
+
+        send("""{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":11}}""")
+        send("""{"jsonrpc":"2.0","id":12,"method":"ping"}""")
+
+        // Id 12 is the next line on the wire: the cancelled request produced no response,
+        // which is what the MCP spec requires — the client has stopped waiting for one.
+        assertEquals(12, read().get("id").asInt)
+        assertTrue(interrupted.get(), "a cancelled call must actually be interrupted")
+    }
+
+    @Test
+    fun `reading continues while a slow call is running`() {
+        start(::slowHandler)
+        send("""{"jsonrpc":"2.0","id":13,"method":"slow"}""")
+        assertTrue(started.await(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+
+        // If requests were served on the reading thread, a cancellation arriving behind a slow
+        // call could never be read, and cancellation would not work at all.
+        send("""{"jsonrpc":"2.0","id":14,"method":"ping"}""")
+        assertEquals(14, read().get("id").asInt)
+    }
+
+    @Test
+    fun `the session ends when the client closes the stream`() {
+        start()
+        send("""{"jsonrpc":"2.0","id":15,"method":"ping"}""")
+        read()
+
+        toServer.close()
+
+        thread.join(TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS))
+        assertFalse(thread.isAlive, "serving should stop at end of stream, not spin")
+    }
+
+    @Test
+    fun `shutdown interrupts work still in flight`() {
+        start(::slowHandler)
+        send("""{"jsonrpc":"2.0","id":16,"method":"slow"}""")
+        assertTrue(started.await(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+
+        server.shutdown()
+
+        // A tool call blocked on a device must not keep threads alive after the client has gone.
+        val deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS)
+        while (!interrupted.get() && System.currentTimeMillis() < deadline) Thread.sleep(POLL_MS)
+        assertTrue(interrupted.get(), "shutdown must interrupt in-flight work")
+    }
+
+    @Test
+    fun `an exception escaping the protocol does not end the session`() {
+        start { raw -> if (raw.contains("boom")) error("boom") else """{"jsonrpc":"2.0","id":18,"result":{}}""" }
+        send("""{"jsonrpc":"2.0","id":17,"method":"boom"}""")
+        send("""{"jsonrpc":"2.0","id":18,"method":"ping"}""")
+
+        assertEquals(18, read().get("id").asInt)
+    }
+
+    private companion object {
+        const val BUFFER = 1 shl 16
+        const val TIMEOUT_SECONDS = 10L
+        const val POLL_MS = 25L
+    }
+}

--- a/src/test/kotlin/spock/adb/mcp/stdio/McpStdioServerTest.kt
+++ b/src/test/kotlin/spock/adb/mcp/stdio/McpStdioServerTest.kt
@@ -45,7 +45,14 @@ class McpStdioServerTest {
 
     @AfterEach
     fun stop() {
+        // Closing the client's end is how a stdio session ends, and the only thing that
+        // unblocks serve() from readLine(). Without it the serving thread lives past the test,
+        // which the IDE test framework's thread-leak tracker fails the test for — correctly,
+        // since a real session leaking a thread per connection would be a defect.
+        runCatching { toServer.close() }
         if (::server.isInitialized) server.shutdown()
+        if (::thread.isInitialized) thread.join(TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS))
+        runCatching { fromServer.close() }
     }
 
     private fun send(line: String) {


### PR DESCRIPTION
The MCP server only spoke HTTP, so clients that only spawn stdio servers could not use it. stdio is now a second transport into the **same `McpProtocol` instance**: one protocol implementation, one `ToolRegistry`, one safety model, one audit trail. A `tools/call` arriving over stdio is confirmed, recorded in the activity panel and written to `idea.log` exactly as the same call over HTTP, because it is the same call.

```
MCP client --+-> McpHttpServer  --+
             |                    |
             +-> McpStdioServer --+->  McpProtocol  ->  ToolRegistry -> ADB
```

## The awkward part

A stdio client *spawns* its server, and the tools cannot live in that child process — they need the running IDE's ADB bridge, project model and confirmation dialogs. So the pieces split three ways:

- **`McpStdioServer`** — the transport. Newline-delimited JSON-RPC per the MCP stdio spec, over `InputStream`/`OutputStream` rather than `System.in`/`out`, so it serves a socket inside the IDE and can be tested over a pipe. It owns framing, concurrency and cancellation and re-implements no protocol: every message goes to `McpProtocol.handle` verbatim, so malformed JSON, unknown methods and unknown tools are answered by the implementation that already answers them over HTTP.
- **`McpBridgeServer`** — the IDE endpoint. A Unix domain socket in a `700` directory, falling back to loopback TCP where `AF_UNIX` is missing or the path is too long for `sun_path`.
- **`SpockAdbStdioLauncher`** — the spawned process. A byte relay with no knowledge of MCP at all. Keeping it ignorant is the point: a relay that understood the protocol would be a second implementation of it, and the second one would drift. Written in Java with no dependencies, because the plugin uses the IDE's Kotlin stdlib rather than bundling one, so a Kotlin launcher could not start from a plain `java -cp`.

## Details worth knowing

**Cancellation.** Requests run on a worker pool rather than the reading thread, so a `notifications/cancelled` queued behind a slow tool call can still be read — otherwise cancellation could not work at all. Cancelling interrupts the call and suppresses its response, per spec. Stopping the server closes live sessions, which ends the relay processes instead of stranding them.

**Credentials.** The stdio config carries none — it points the client at an endpoint descriptor, and the token stays in that `600` file, so the config is safe to paste into a chat or a bug report. It is the same token the HTTP transport uses; rotating it rotates both.

**Stdout purity.** Stdout is the protocol stream, so the launcher claims the real stdout on its first statement and redirects `System.out` to stderr. Nothing that later prints, in this code or any library, can corrupt a session.

## Testing

`src/test/kotlin/spock/adb/mcp/stdio/` — protocol-level tests driven over a real pipe against the real `McpProtocol` with `FakeToolContext`: `initialize`, `tools/list`, `tools/call`, invalid request, malformed JSON, unknown tool, tool error, cancellation, shutdown, plus notification handling and one-message-per-line framing. The launcher is tested as an **actually spawned process**, because the two things most likely to be wrong about it are only true of a real one: that it exits when its client closes stdin or the IDE stops the server, and that it writes nothing but protocol messages to stdout. The bridge's security properties are tested rather than asserted in a comment — `600`/`700` permissions, and a wrong token closed before any protocol message is served.

Gradle cannot resolve the Android Studio artifact in the environment I developed this in, so I ran the transport, the bridge and the launcher in a standalone harness (gson + JDK only) against the real `McpProtocol`: 35 tests green, including both test files in this PR verbatim. Two genuine bugs came out of that and are fixed here — `closeChannel()` read the socket address after closing it (`ClosedChannelException` on every stop), and `stop()` closed the listening socket but not accepted connections, so the relay process outlived the server it was talking to.

**Not compiled locally:** `McpServerService`, `McpServerPanel`, `McpActions` and `plugin.xml` — the IDE-bound wiring. Imports, detekt thresholds and line lengths were checked by hand; CI is the first real compile of those four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018W7aaYZfisooQqhECaFoQ1

---
_Generated by [Claude Code](https://claude.ai/code/session_018W7aaYZfisooQqhECaFoQ1)_