### PR TITLE
MCP: debug context, file transfer, screen recording, and two defect fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,39 @@
 
 ### Added
 
+- **`android_get_debug_context`** — the whole triage bundle in one call: current activity, the
+  UI semantics tree with its framework identified, recent logcat, and optionally a screenshot.
+  Assembling those separately cost three or four round trips, and by the time the last landed
+  the screen could have moved on, so the bundle described no single moment. A failing section
+  reports its failure in place and the rest still come back — a screenshot blocked by
+  `FLAG_SECURE` must not cost you the crash sitting beside it in logcat
+- **`android_push_file` and `android_pull_file`.** Device paths are restricted to `/sdcard`,
+  `/storage` and `/data/local/tmp`, which is deliberately stricter than `adb`: it will hand over
+  anything the shell user can read, and an agent that can be talked into pulling another app's
+  database is an exfiltration path wearing a debugging tool's clothes. The local destination of
+  a pull is **not** a parameter — a tool that writes where its caller asks lets anything holding
+  the MCP token drop a file anywhere on the filesystem — so pulls land in one known directory
+  and the tool reports where. Transfers are capped at 50 MB
+- **`android_start_screen_recording` and `android_stop_screen_recording`**, one session per
+  device, capped at three minutes. Recording stops with `SIGINT` rather than `SIGKILL` so
+  `screenrecord` writes the MP4 index on the way out — a killed recording leaves a file no
+  player will open — and the remote file is deleted only once the pull has succeeded
 - `android_select_project` — says which open project later calls are about, so the ambiguity
   above names a fix the agent can actually perform. Unnecessary with a single project open
+
+### Internal
+
+- `StubbedIDeviceApiTest` fails the build when anything calls one of the nineteen `IDevice`
+  methods Android Studio leaves unimplemented. Each throws "This method is not used in Android
+  Studio" at runtime while compiling and unit-testing cleanly, because a test that builds its
+  own `AndroidDebugBridge` gets stock ddmlib where they all work. It scans compiled bytecode
+  rather than source, since Kotlin's property syntax hides the call — `device.screenshot` is a
+  call to `getScreenshot()` that no text search would find. This is the bug that shipped in
+  `android_take_screenshot`
+- `McpSmokeTest` calls every read-only tool against a real device through a running server.
+  The live checks are opt-in via `SPOCK_MCP_URL` and `SPOCK_MCP_TOKEN`, so an ordinary
+  `./gradlew test` skips them, but its coverage assertion always runs — a read-only tool cannot
+  be added without deciding how it is smoke-tested
 
 ## [4.0.2] - 2026-09-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,8 +54,8 @@
 
 ### Internal
 
-- `StubbedIDeviceApiTest` fails the build when anything calls one of the nineteen `IDevice`
-  methods Android Studio leaves unimplemented. Each throws "This method is not used in Android
+- `StubbedIDeviceApiTest` fails the build when anything calls an `IDevice` method Android
+  Studio leaves unimplemented. Each throws "This method is not used in Android
   Studio" at runtime while compiling and unit-testing cleanly, because a test that builds its
   own `AndroidDebugBridge` gets stock ddmlib where they all work. It scans compiled bytecode
   rather than source, since Kotlin's property syntax hides the call — `device.screenshot` is a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## [Unreleased]
 
+### Added
+
+- **The assistant core** — the machinery behind the in-IDE AI assistant, with no UI yet.
+  `AgentLoop` runs the model ⇄ tool cycle against the same `ToolRegistry` the MCP transports
+  use, so there is one definition of what an agent may do and one safety model: destructive
+  tools still ask the developer per call and still default to denied, and a declined call is
+  reported back to the model in words rather than ending the conversation. Every call is
+  recorded to the same activity history as `spock-assistant`, so one place answers "what
+  touched my device". The loop is capped at 25 iterations, which is the only guard against a
+  surprise bill in this version
+- `AnthropicClient` and `OpenAiCompatibleClient` on `java.net.http` and Gson — no SDK, no new
+  dependency, and no change to the supported IDE range. Provider errors are surfaced verbatim
+  and never retried: retrying a rejected request spends money to be rejected again
+- The API key lives in `PasswordSafe` and nowhere else — never in the settings XML, the audit
+  history or the log
+
 ### Fixed
 
 - **`android_take_screenshot` never worked inside Android Studio.** It called

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,9 @@
   database is an exfiltration path wearing a debugging tool's clothes. The local destination of
   a pull is **not** a parameter — a tool that writes where its caller asks lets anything holding
   the MCP token drop a file anywhere on the filesystem — so pulls land in one known directory
-  and the tool reports where. Transfers are capped at 50 MB
+  and the tool reports where. The source of a push is restricted to the open project or
+  that same directory, so the pair cannot be composed into a read of any file on the
+  machine. Transfers are capped at 50 MB in both directions
 - **`android_start_screen_recording` and `android_stop_screen_recording`**, one session per
   device, capped at three minutes. Recording stops with `SIGINT` rather than `SIGKILL` so
   `screenrecord` writes the MP4 index on the way out — a killed recording leaves a file no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,29 @@
   encoded because ddmlib's shell channel decodes its output as text and would otherwise corrupt
   the PNG, and the result is checked for a PNG signature so a `FLAG_SECURE` screen is reported
   as such rather than returned as a broken image
+- **Every project-dependent MCP tool failed whenever two projects were open.** The tool
+  context resolved the project with `openProjects.singleOrNull { !it.isDisposed }`, so a
+  second open project turned `android_get_current_activity`, `android_get_activity_stack`,
+  `android_get_current_fragments` and the default logcat package filter into "No project is
+  open" — a message that was both wrong and unactionable. Resolution now follows the same
+  rule as device resolution: use the selected project, or the only one open, and otherwise
+  **refuse to guess** and name the candidates. Picking the focused window instead would be
+  wrong exactly when it matters most, with an agent working while the developer looks
+  elsewhere
+- **Starting and stopping the MCP server ran on the EDT.** Starting binds two sockets and
+  writes the stdio endpoint descriptor; stopping waits for live stdio sessions to end before
+  releasing their threads. Stopping the server from the MCP panel with a client attached
+  therefore froze the tool window until that wait expired. Both transitions now run on a
+  pooled thread, the controls show the transition and are disabled while it runs, and
+  Restart chains stop → start rather than issuing them together
+- `McpServerService.start()` is idempotent: starting an already-running server returns the
+  bound port instead of replacing the HTTP server and stranding the previous stdio bridge's
+  threads
+
+### Added
+
+- `android_select_project` — says which open project later calls are about, so the ambiguity
+  above names a fix the agent can actually perform. Unnecessary with a single project open
 
 ## [4.0.2] - 2026-09-04
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Full control of your Android device directly from your IDE — no terminal neede
 
 Spock ADB puts the most common ADB workflows into a single tool window: navigate to the active Activity or Fragment in your editor, manage app lifecycle, stream logcat, run ADB commands, and inspect the UI of Views <em>and</em> Jetpack Compose screens.
 
-It also ships an <b>Android MCP server</b>: give Claude Code, Claude Desktop, Cursor or any MCP client safe, structured access to a connected device. 36 strongly typed tools rather than a raw shell, and anything destructive asks you first, every time.
+It also ships an <b>Android MCP server</b>: give Claude Code, Claude Desktop, Cursor or any MCP client safe, structured access to a connected device. 42 strongly typed tools rather than a raw shell, and anything destructive asks you first, every time.
 
 Works in Android Studio and IntelliJ IDEA.
 <!-- Plugin description end -->
@@ -103,7 +103,7 @@ accessibility tree where Compose publishes its semantics rather than assuming a 
 Give an AI agent — Claude Code, Claude Desktop, Cursor — safe, structured access to a connected
 device. **Off by default**; you start it deliberately.
 
-- **36 strongly typed tools** instead of a raw shell, so an agent can reason about what an
+- **42 strongly typed tools** instead of a raw shell, so an agent can reason about what an
   operation *means* and you can audit it
 - **Live activity monitor**: every call with a safety marker, outcome and duration. Expand one to
   see arguments, result, client, target device — and whether you approved or denied it

--- a/detekt-config.yml
+++ b/detekt-config.yml
@@ -12,8 +12,9 @@ complexity:
   TooManyFunctions:
     # Swing panels decompose into many small private methods, which is the readable shape
     # for UI code — collapsing them into fewer, larger ones would be worse. Parsers split
-    # into small named steps for the same reason.
-    thresholdInClasses: 24
+    # into small named steps for the same reason, and a service that fronts several
+    # collaborators (transports, history, settings) is mostly thin, named delegation.
+    thresholdInClasses: 28
     thresholdInObjects: 14
 
 style:

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -386,7 +386,7 @@ Recorded honestly so the gaps are not mistaken for features:
 ## Testing
 
 Two guards exist because of bugs that reached users. `StubbedIDeviceApiTest` fails the build
-when anything calls one of the nineteen `IDevice` methods Android Studio leaves unimplemented —
+when anything calls one of the `IDevice` methods Android Studio leaves unimplemented —
 each throws "This method is not used in Android Studio" at runtime while compiling and
 unit-testing cleanly, because a test that builds its own `AndroidDebugBridge` gets stock ddmlib
 where they all work. It reads compiled bytecode rather than source, since Kotlin's property

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -175,11 +175,13 @@ dependencies, and identical behaviour in Android Studio and IntelliJ IDEA.
 
 Every tool declares a level, as a property of the tool rather than a flag a client can set.
 
+42 tools, in three levels.
+
 | Level | Behaviour | Tools |
 |---|---|---|
-| **Read-only** | Runs automatically. Cannot change device or app state. | `android_list_devices`, `android_get_device_info`, `android_list_packages`, `android_get_package_info`, `android_get_current_activity`, `android_get_activity_stack`, `android_get_current_fragments`, `android_get_logcat`, `android_get_processes`, `android_get_battery_info`, `android_get_network_info`, `android_take_screenshot`, `android_get_ui_hierarchy` |
-| **Safe action** | Runs automatically. Changes state only in ways you routinely do by hand and can undo by repeating a normal action. | `android_select_device`, `android_launch_app`, `android_stop_app`, `android_restart_app`, `android_grant_permission`, `android_open_deep_link`, `android_input_text`, `android_tap`, `android_swipe`, `android_press_key` |
-| **Destructive** | **Always** asks you first, per call. Never auto-approved. | `android_clear_app_data`, `android_revoke_permission`, `android_run_adb_command` |
+| **Read-only** (19) | Runs automatically. Cannot change device or app state. | `android_list_devices`, `android_get_device_info`, `android_list_packages`, `android_get_package_info`, `android_get_current_activity`, `android_get_activity_stack`, `android_get_current_fragments`, `android_get_logcat`, `android_get_processes`, `android_get_battery_info`, `android_get_network_info`, `android_get_debug_context`, `android_take_screenshot`, `android_get_ui_tree`, `android_find_ui_element`, `android_accessibility_audit`, `android_assert_visible`, `android_assert_enabled`, `android_assert_text` |
+| **Safe action** (19) | Runs automatically. Changes state only in ways you routinely do by hand and can undo by repeating a normal action. | `android_select_device`, `android_select_project`, `android_launch_app`, `android_stop_app`, `android_restart_app`, `android_grant_permission`, `android_tap_element`, `android_long_press_element`, `android_scroll_to_element`, `android_input_text_into_element`, `android_open_deep_link`, `android_input_text`, `android_tap`, `android_swipe`, `android_press_key`, `android_push_file`, `android_pull_file`, `android_start_screen_recording`, `android_stop_screen_recording` |
+| **Destructive** (4) | **Always** asks you first, per call. Never auto-approved. | `android_clear_app_data`, `android_uninstall_app`, `android_revoke_permission`, `android_run_adb_command` |
 
 Rules that hold regardless of what a client asks for:
 
@@ -290,17 +292,77 @@ the View-level fix does not exist there.
 
 ## UI automation
 
-`android_get_ui_hierarchy` returns uiautomator's XML: view class, resource id, text, content
-description, bounds, and whether each node is clickable, enabled and selected. Agents should
-drive `android_tap` from those bounds rather than guessing coordinates off a screenshot —
-guessed coordinates are the main cause of flaky UI automation.
+`android_get_ui_tree` returns the semantics tree as a structure rather than raw XML: class,
+test tag, text, content description, bounds, and whether each node is clickable, enabled,
+scrollable, checked or selected. Pass `interactiveOnly` to see only what can be acted on.
 
-Screenshots are first-class MCP image content, so an agent can actually look at the screen.
+Agents should not drive `android_tap` from those bounds by hand. Prefer the element-addressed
+tools — `android_tap_element`, `android_long_press_element`, `android_scroll_to_element`,
+`android_input_text_into_element` — which resolve the element from semantics and derive the tap
+point from the matched node themselves. `android_tap` remains the fallback for a screen that
+offers no semantic identifier at all, and its own description says so.
+
+`android_assert_visible`, `android_assert_enabled` and `android_assert_text` let an agent verify
+the result of an action rather than infer it from pixels.
+
+Screenshots are first-class MCP image content, so an agent can also look at the screen.
+
+## Triage, files and screen recording
+
+### `android_get_debug_context`
+
+The call to reach for first when something is wrong. It returns the current activity, the UI
+semantics tree with its framework identified, recent logcat, and optionally a screenshot — in
+one round trip, all describing **the same moment**. Assembling those separately costs three or
+four turns, and by the time the last one lands the screen may have moved on, so the bundle it
+produces describes no single moment at all.
+
+Sections are chosen with `include` (`activity`, `ui`, `logcat`, `screenshot`); the first three
+are the default. The screenshot is opt-in because it is by far the most expensive section.
+
+**A failing section does not fail the call.** A screenshot blocked by `FLAG_SECURE` must not
+cost you the crash sitting beside it in logcat, so each section reports its own failure in place
+and the rest still come back.
+
+### `android_push_file` and `android_pull_file`
+
+Deliberately narrower than `adb` itself, in two ways.
+
+**Device paths are restricted** to `/sdcard`, `/storage` and `/data/local/tmp`. `adb` will hand
+over anything the shell user can read, and an agent that can be talked into pulling another
+app's database is an exfiltration path wearing a debugging tool's clothes. A path outside the
+allow-list is *refused*, not confirmed: one conditional gate that sometimes prompts would be a
+second implementation of the safety model, and `android_run_adb_command` already exists as the
+confirmed escape hatch.
+
+**The local destination of a pull is not a parameter.** A tool that writes where its caller asks
+lets anything holding the MCP token drop a file anywhere on your filesystem, and no debugging
+workflow needs that. Pulls land in the IDE's own pull directory and the tool reports the path;
+small text files come back inline as well, so reading one costs no second call. A transfer that
+fails part-way cannot leave a half-written file under a previous good name — the pull stages to
+a neighbour and moves into place.
+
+Transfers are capped at 50 MB.
+
+### `android_start_screen_recording` and `android_stop_screen_recording`
+
+One session per device, capped at three minutes. Recording stops with `SIGINT` rather than
+`SIGKILL` so `screenrecord` writes the MP4 index on the way out — a killed recording leaves a
+file no player will open — and the remote file is deleted only once the pull has succeeded.
+
+### `android_select_project`
+
+Needed only when the IDE has more than one project open. The application ID, the sources an
+Activity resolves against and the default logcat filter all come from a project, so with several
+open the plugin refuses to guess and names the candidates, exactly as it does for several
+attached devices. With one project open, every tool already targets it and this call is
+unnecessary.
 
 ## Example workflows
 
-**Debug a crash.** `android_list_devices` → `android_get_current_activity` →
-`android_get_logcat(minLevel: "E")` → `android_take_screenshot` → analyse.
+**Debug a crash.** `android_get_debug_context(include: ["activity", "ui", "logcat"], minLevel:
+"E")` → analyse. That is one call where it used to be four, and every section describes the same
+moment.
 
 **Test a deep link.** `android_open_deep_link(uri)` → `android_get_current_activity` →
 `android_take_screenshot` → report which screen opened.
@@ -312,15 +374,29 @@ Screenshots are first-class MCP image content, so an agent can actually look at 
 
 Recorded honestly so the gaps are not mistaken for features:
 
-- **Screen recording** (`android_start_screen_recording` / `android_stop_screen_recording`).
-  `screenrecord` needs a file pulled off the device afterwards and has a hard duration limit;
-  it needs a file-transfer story first.
-- **MCP activity panel.** Calls are recorded (`McpServerService.recentCalls()`) and
-  destructive ones are logged, but there is no tool window tab showing them live yet.
-- **Per-tool allow-lists** so a developer can disable individual tools.
-- **File push/pull.**
+- **Per-tool allow-lists** so a developer can expose, say, the read-only tools and nothing
+  else. The per-call confirmation on destructive tools is the real boundary today, and there is
+  no way to remove a tool from the catalogue short of not starting the server.
+- **Prompts.** `prompts/list` answers with an empty array. The debugging workflows in this
+  document are prose an agent cannot call.
+- **Cancellation over HTTP.** stdio honours `notifications/cancelled` by interrupting the
+  request; the HTTP transport is stateless by design and has nothing to cancel against, so a
+  slow tool call there runs to its timeout.
 
 ## Testing
+
+Two guards exist because of bugs that reached users. `StubbedIDeviceApiTest` fails the build
+when anything calls one of the nineteen `IDevice` methods Android Studio leaves unimplemented —
+each throws "This method is not used in Android Studio" at runtime while compiling and
+unit-testing cleanly, because a test that builds its own `AndroidDebugBridge` gets stock ddmlib
+where they all work. It reads compiled bytecode rather than source, since Kotlin's property
+syntax hides the call: `device.screenshot` is a call to `getScreenshot()` that no text search
+would find. This is exactly how `android_take_screenshot` shipped broken.
+
+`McpSmokeTest` calls every read-only tool against a real device through a running server, which
+is the only place that class of failure appears. The live checks are opt-in via `SPOCK_MCP_URL`
+and `SPOCK_MCP_TOKEN`, so an ordinary `./gradlew test` skips them — but its coverage assertion
+always runs, so a read-only tool cannot be added without deciding how it is smoke-tested.
 
 The protocol, the safety model and both transports are all tested without a device:
 `FakeToolContext` stands in for the IDE and ADB. The tests that matter most assert that

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -342,7 +342,11 @@ small text files come back inline as well, so reading one costs no second call. 
 fails part-way cannot leave a half-written file under a previous good name — the pull stages to
 a neighbour and moves into place.
 
-Transfers are capped at 50 MB.
+Transfers are capped at 50 MB in both directions, and the cap on a pull is enforced
+before the bytes are kept, not just claimed. The **source** of a push is restricted too —
+the open project, or the IDE's pull directory — because push and pull compose: an
+unrestricted source means an agent can push any file on the machine to a device and pull
+it straight back, which is an arbitrary local read wearing a debugging tool's clothes.
 
 ### `android_start_screen_recording` and `android_stop_screen_recording`
 

--- a/docs/PLAN-5.0.md
+++ b/docs/PLAN-5.0.md
@@ -1,0 +1,216 @@
+# Spock ADB 5.0 — AI-native Android debugging
+
+Working plan. Phases are executed **one at a time**, in order; each is a reviewable commit
+with tests green before the next begins. Tick the boxes as they land.
+
+## Starting point (verified against the tree at 4.0.3)
+
+Eight of the ten headline capabilities already ship. The MCP server (HTTP + stdio, 36 typed
+tools, bearer token, three-level safety model), the MCP Server panel (status, Tools catalogue,
+live Activity monitor, bounded filterable history), Compose inspection via the uiautomator
+semantics tree, screenshots as MCP image content, and Keymap-native actions are all present
+and tested. `ToolRegistry` reserves itself in its own header for "the plugin's own AI layer".
+
+So this is **not** a greenfield build, and the release must not be messaged as "introducing
+MCP". It is: close the documented gaps, bring the AI agent inside the IDE, and polish.
+
+## Decisions taken
+
+| Question | Decision | Why |
+|---|---|---|
+| LLM providers in v1 | **Anthropic + a generic OpenAI-compatible client** | Two implementations behind `LlmClient` cover Anthropic, OpenAI, local Ollama and corporate proxies via a configurable base URL. |
+| History persistence | **On by default, 500-entry cap, Settings toggle to disable and clear** | The audit trail's value is surviving the restart that loses in-memory state. Local file in the same trust boundary as the `idea.log` entries destructive calls already write. Off-by-default would disable it exactly when it is needed. |
+| `android_pull_file` scope | Allow-list `/sdcard/**` and `/data/local/tmp/**`; anything else is `DESTRUCTIVE` and prompts | Pulling arbitrary device paths is a data-exfiltration vector. Being stricter than raw `adb` here is a deliberate product choice. |
+| Chat UI toolkit | **Swing**, not JCEF | Matches every other panel; JCEF is heavy and version-sensitive across AS 231+. Revisit only if markdown fidelity becomes a requirement. |
+| Messaging | "Extending the MCP toolkit and bringing the AI agent into the IDE" | 4.x already shipped MCP. |
+
+## Architecture
+
+No new parallel systems. The assistant reuses `ToolRegistry` exactly as `McpProtocol` does —
+per the registry's own stated intent — so the safety-enforcing code has one implementation.
+
+```
+Spock ADB tool window
+ ├── Devices / Logcat / Commands / UI Inspector / MCP Server   (existing)
+ └── AI Assistant                                              (new, Swing)
+          ↓
+     AssistantService (app service)
+          ├── ConversationStore (bounded, in-memory)
+          ├── LlmClient ──→ AnthropicClient | OpenAiCompatibleClient
+          └── AgentLoop  ─┐
+                          │
+MCP client → McpHttpServer / McpStdioServer → McpProtocol ─┼→ ToolRegistry → ToolContext → DeviceLister/Commands → ddmlib → device
+                                                           │       ▲
+                                                           │   new tools register here only
+                                                           └── one allow-list, one audit trail,
+                                                               one destructive-confirm dialog
+```
+
+Invariants that must survive every phase:
+
+- The MCP layer owns no ADB logic; the assistant owns no tool logic.
+- `ToolContext.confirmDestructive` is the **only** destructive gate, and defaults to deny —
+  including when the caller is the in-plugin assistant. An AI loop can never clear app data
+  unasked.
+- Assistant tool calls land in the same `McpRequestHistory` (client `spock-assistant`), so the
+  Activity tab shows everything an agent did, whatever drove it.
+- Zero new external dependencies; no change to `sinceBuild=231` or the open `untilBuild`.
+
+## Compatibility rules for all new code
+
+From `docs/COMPATIBILITY.md`, non-negotiable:
+
+- No `sequence {}`, `iterator {}`, or `suspend` — coroutine state machines reference stdlib
+  symbols absent on 2023.1 IDEs. The agent loop is therefore synchronous, on pooled threads.
+- `-Xjvm-default=all` stays global.
+- Explicit `getService(...)`; no reified service accessors.
+- `java.net.http`, `HttpServer`, `PasswordSafe` and Gson are all present on platform 231.
+- `verifyPlugin` must stay green on AS 231/242/251 and IDEA 231/251.
+
+---
+
+## Phase 1 — `android_get_debug_context` (P0)
+
+One call returning the triage bundle an agent currently needs three or four calls to assemble.
+
+- [x] Extract a shared `LogcatReader` from `GetLogcatTool` in `mcp/tools/InspectionTools.kt`
+      (PID resolution + `logcat -d -v threadtime` construction) so the new tool does not
+      duplicate the pidof-not-grep logic.
+- [x] `mcp/tools/DebugContextTool.kt` — `READ_ONLY`. Args: `include` (array of
+      `activity|logcat|ui|screenshot`, default all but screenshot), `maxLogcatLines`
+      (default 200, cap 2000), `maxUiDepth`, `packageName`, `deviceSerial`.
+- [x] Always emit `UiTree.frameworkNote()` in the UI section, so an assistant never misses the
+      `testTagsAsResourceId` caveat on a Compose screen.
+- [x] Per-section caps and a 60s overall budget — this is the heaviest tool in the registry.
+- [x] Register in `ToolRegistry`.
+- [x] `DebugContextToolTest` — section matrix, caps honoured, no-device message is actionable.
+
+### Landed in Phase 1
+
+`LogcatReader` extracted; `Schema.stringArray` + `optionalStringList` added;
+`UiTreeReader.render` gained a counted `maxDepth`; `DebugContextTool` registered, with 11 tests.
+
+Two guards worth knowing about before writing another tool, both of which failed first:
+
+- `McpSmokeTest` refuses to pass unless every `READ_ONLY` tool appears in its `PROBES` or
+  `QUERIES` table, so a new read-only tool must be classified there.
+- `ToolSafetyTest` pins the exact membership of each safety level.
+
+## Phase 2 — File transfer and screen recording (P1)
+
+- [ ] `mcp/tools/FileTools.kt` — `PushFileTool`, `PullFileTool` over `IDevice.pushFile/pullFile`.
+      Path validation rejects `..` and other apps' `/data/data`; 50 MB cap; pulls outside the
+      allow-list are `DESTRUCTIVE` and prompt.
+- [ ] `mcp/tools/ScreenRecordTools.kt` — `StartScreenRecordTool` / `StopScreenRecordTool`,
+      `SAFE_ACTION`, single tracked session, 180s auto-stop (platform hard cap), pull to a
+      local path then `rm` the remote file.
+      **Constraint found in Phase 1:** `IDevice.startScreenRecorder` is on
+      `StubbedIDeviceApiTest.UNIMPLEMENTED_IN_ANDROID_STUDIO` — Android Studio's
+      `AdblibIDeviceWrapper` throws "This method is not used in Android Studio" for it. Recording
+      must go through `executeShellCommand("screenrecord …")`, and the guard test will fail the
+      build if it does not. `getSyncService` is likewise unimplemented, so pushes and pulls must
+      use `IDevice.pushFile`/`pullFile` directly rather than opening a sync service.
+- [ ] Tool descriptions state plainly that a recording captures whatever is on screen.
+- [ ] `FileToolsTest` (path validation, size caps), `ScreenRecordToolsTest` (state machine:
+      start twice → error, stop without start → error).
+
+## Phase 3 — Assistant core (P0)
+
+- [ ] `assistant/LlmClient.kt` — synchronous interface called from pooled threads, streaming
+      via callback, explicit cancellation predicate. No coroutines.
+- [ ] `AdbTool.toToolSpec(provider)` — one mapping from the existing `inputSchema`, so tool
+      definitions are never written twice.
+- [ ] `assistant/AnthropicClient.kt` and `assistant/OpenAiCompatibleClient.kt` on
+      `java.net.http.HttpClient` + Gson. Configurable base URL. Errors surfaced verbatim; no
+      retries in v1.
+- [ ] `assistant/AgentLoop.kt` — model ⇄ tool-call cycle through `ToolRegistry`, hard cap 25
+      iterations, every call recorded to `McpRequestHistory` as `spock-assistant`.
+- [ ] `assistant/AssistantToolContext.kt` — same `DeviceLister`/`DebugBridgeProvider`, reusing
+      the `McpToolContext` confirmation dialog.
+- [ ] API key in `PasswordSafe` only — never in `PersistentStateComponent` XML, logs or history.
+- [ ] `AgentLoopTest` (scripted fake `LlmClient`: tool cycle, iteration cap, denied
+      confirmation fed back to the model, cancellation), `ToolSpecMappingTest`.
+
+## Phase 4 — Assistant UI (P0)
+
+- [ ] `assistant/AssistantPanel.kt` — Swing: transcript, input, Send, Stop, "attach debugging
+      context" toggle that injects a `android_get_debug_context` result into the first message.
+- [ ] Tab in `spock/AdbDrawerViewer.kt`, disposer registered like its siblings.
+- [ ] `OpenAssistantAction`, following `OpenMcpPanelAction`. No default keyboard shortcut —
+      established project policy, users bind via Keymap.
+- [ ] Settings section: provider dropdown, model, base URL, write-only API key field.
+- [ ] States: empty (no key → link to Settings), loading (Send disabled, Stop enabled), error
+      (rendered as a transcript line with the HTTP status, not a modal). Destructive
+      confirmation stays the existing IDE modal — never an inline chat approval.
+- [ ] Streaming appends throttled to the EDT on the Logcat panel's 100ms flush pattern.
+- [ ] Transcript bounded (~500 messages), `JBColor`/`JBUI` only, Ctrl+Enter sends, Esc stops.
+
+## Phase 5 — Safety and control (P0)
+
+- [ ] `McpSettings.disabledTools: MutableSet<String>`; predicate consulted in
+      `McpProtocol.dispatch` **and** the assistant loop. The shared registry is never mutated.
+- [ ] A disabled tool returns a clear "disabled by user" error and is still recorded.
+- [ ] Settings UI: checkbox list grouped by safety level.
+- [ ] History persistence: append-only NDJSON under `<config>/spock-adb/`, capped by
+      `historySize`, batched writes off the EDT, loaded on start.
+- [ ] Tests: disabled-tool error path, NDJSON round-trip and cap, and a regression asserting
+      no new tool can perform a destructive action unconfirmed (extend `ToolSafetyTest`).
+
+## Phase 6 — UI/UX polish (P2)
+
+- [ ] Devices tab: show which device MCP clients are targeting — `McpServerService.selectedSerial`
+      and the tool-window selection are independent today, which is a real "agent hit the wrong
+      phone" trap.
+- [ ] MCP panel: stdio session count in the header, reporting only what `McpBridgeServer` can
+      actually observe.
+- [ ] UI Inspector: promote `TestTagSupport.UNAVAILABLE` from a note to a banner carrying the
+      exact `testTagsAsResourceId = true` snippet.
+- [ ] `McpServerPanel`: collapse the 72/28 details split below ~500px using the existing
+      `CollapsibleSection`.
+
+## Phase 7 — Compatibility gate (P0)
+
+- [ ] `./gradlew detekt test`
+- [ ] `./gradlew verifyPlugin` green on all five IDEs; any new finding fixed or justified in
+      `verifier-ignored-problems.txt`.
+- [ ] `verify-marketplace-descriptor.sh`.
+- [ ] Settings migration: state XML written by 4.0.3 loads without the new fields.
+
+## Phase 8 — Documentation (P1)
+
+- [ ] `docs/MCP.md` — new tools, per-tool allow-list; remove them from "Not yet implemented".
+- [ ] `docs/AI.md` — new, with the privacy section first: **every chat message and every tool
+      result, including screenshots, logcat and package lists, leaves the machine for the
+      configured provider.** Context attachment is opt-in per conversation; the plugin adds no
+      telemetry of its own.
+- [ ] README plugin-description block; `CHANGELOG.md` under `[Unreleased]`.
+- [ ] Bump `pluginVersion` to 5.0.0.
+
+---
+
+## Security and privacy ledger
+
+| Risk | Mitigation |
+|---|---|
+| Chat + tool results sent to an LLM provider | Stated plainly in Settings and `docs/AI.md`; context attachment opt-in; no plugin telemetry. |
+| API key | `PasswordSafe` only. |
+| `android_pull_file` exfiltration | Path allow-list; prompt outside it. |
+| Assistant tool loop | Same default-deny modal, 25-iteration cap, Stop button, shared audit trail. |
+| Screen recording | Captures whatever is on screen — said in the tool description; remote file deleted after pull. |
+| New network surface | None inbound. The LLM client is outbound-only. |
+
+## Explicitly out of scope
+
+Screen recording beyond the 3-minute platform cap; MCP prompts/resource subscriptions;
+per-client session presence (the stateless HTTP transport genuinely cannot observe it);
+persistent or multiple named conversations; Layout-Inspector-grade Compose internals such as
+recomposition counts (rejected by design — undocumented JVMTI protocol, debuggable builds
+only); remote/non-loopback binding; multi-device fan-out; implementing the unrelated
+`connectDeviceOverIp` stub.
+
+## Open risks
+
+- Agent-loop correctness under cancellation and partial streaming is the single riskiest item.
+- No usage metering in v1; the 25-iteration cap is the only guard against a surprise bill.
+- The real-device smoke matrix (API levels, `FLAG_SECURE` screens, offline/unauthorized
+  states) stays manual — there is no emulator CI today.

--- a/docs/PLAN-5.0.md
+++ b/docs/PLAN-5.0.md
@@ -130,20 +130,45 @@ Two deliberate narrowings of the plan, both tightening rather than loosening it:
 
 ## Phase 3 — Assistant core (P0)
 
-- [ ] `assistant/LlmClient.kt` — synchronous interface called from pooled threads, streaming
+- [x] `assistant/LlmClient.kt` — synchronous interface called from pooled threads, streaming
       via callback, explicit cancellation predicate. No coroutines.
-- [ ] `AdbTool.toToolSpec(provider)` — one mapping from the existing `inputSchema`, so tool
-      definitions are never written twice.
-- [ ] `assistant/AnthropicClient.kt` and `assistant/OpenAiCompatibleClient.kt` on
+- [x] `AdbTool.toToolSpec()` — one mapping from the existing `inputSchema`, so tool definitions
+      are never written twice. **No `provider` parameter**: a tool is a name, a description and
+      a JSON Schema for both providers, and only the envelope differs — that belongs to the
+      client writing the request body. Passing the provider in would have put two providers'
+      knowledge in the mapping *and* still left each client shaping its own request.
+- [x] `assistant/AnthropicClient.kt` and `assistant/OpenAiCompatibleClient.kt` on
       `java.net.http.HttpClient` + Gson. Configurable base URL. Errors surfaced verbatim; no
-      retries in v1.
-- [ ] `assistant/AgentLoop.kt` — model ⇄ tool-call cycle through `ToolRegistry`, hard cap 25
-      iterations, every call recorded to `McpRequestHistory` as `spock-assistant`.
-- [ ] `assistant/AssistantToolContext.kt` — same `DeviceLister`/`DebugBridgeProvider`, reusing
-      the `McpToolContext` confirmation dialog.
-- [ ] API key in `PasswordSafe` only — never in `PersistentStateComponent` XML, logs or history.
-- [ ] `AgentLoopTest` (scripted fake `LlmClient`: tool cycle, iteration cap, denied
-      confirmation fed back to the model, cancellation), `ToolSpecMappingTest`.
+      retries in v1. Model `claude-opus-5`; `thinking` is deliberately unset (on by default on
+      that family, and the older `budget_tokens` form is a 400, not a knob).
+- [x] `assistant/AgentLoop.kt` — model ⇄ tool-call cycle, hard cap 25 iterations, every call
+      recorded to `McpRequestHistory` as `spock-assistant`. Reaches the registry through an
+      `AgentTools` seam so the loop is testable without an IDE, a device or 42 real tools;
+      `RegistryAgentTools` is the adapter and holds no tool logic of its own.
+- [x] API key in `PasswordSafe` only — never in `PersistentStateComponent` XML, logs or history
+      (`assistant/AssistantKeyStore.kt`, read on demand so a rotated key applies to the next
+      request rather than the next restart).
+- [x] `AgentLoopTest` (scripted fake `LlmClient`: tool cycle, iteration cap, denied
+      confirmation fed back to the model, cancellation), `ToolSpecMappingTest`,
+      `AnthropicStreamTest` and `OpenAiStreamTest` (fragmented tool arguments, parallel calls
+      by index, a half-streamed call dropped rather than run, mid-stream error, refusal).
+- [x] ~~`assistant/AssistantToolContext.kt`~~ — **not written, deliberately.** `McpToolContext`
+      already *is* "the same `DeviceLister`/`DebugBridgeProvider`, reusing the confirmation
+      dialog". A subclass would add a name and no behaviour, and would be a second place for the
+      safety model to drift to. The assistant is handed the same context the transports get.
+
+### Landed in Phase 3
+
+`LlmClient`, `LlmMessage`/`LlmToolCall`/`LlmToolResult`/`ToolSpec` (one neutral shape, since a
+loop written against either provider's own would have to be rewritten for the other),
+`AnthropicClient` + `AnthropicStream`, `OpenAiCompatibleClient` + `OpenAiStream`, `AgentLoop`,
+`AgentTools`/`RegistryAgentTools`, `AssistantKeyStore`, `toToolSpec`.
+
+Each provider's SSE parsing is split from its HTTP call, which is what makes the frame handling
+testable from a canned stream: 22 tests run without a network, an IDE or a key.
+
+Still open before Phase 4 can use this: nothing in the loop, but no `AssistantService` owns a
+conversation yet — that arrives with the UI it exists to serve.
 
 ## Phase 4 — Assistant UI (P0)
 

--- a/docs/PLAN-5.0.md
+++ b/docs/PLAN-5.0.md
@@ -98,10 +98,10 @@ Two guards worth knowing about before writing another tool, both of which failed
 
 ## Phase 2 — File transfer and screen recording (P1)
 
-- [ ] `mcp/tools/FileTools.kt` — `PushFileTool`, `PullFileTool` over `IDevice.pushFile/pullFile`.
+- [x] `mcp/tools/FileTools.kt` — `PushFileTool`, `PullFileTool` over `IDevice.pushFile/pullFile`.
       Path validation rejects `..` and other apps' `/data/data`; 50 MB cap; pulls outside the
       allow-list are `DESTRUCTIVE` and prompt.
-- [ ] `mcp/tools/ScreenRecordTools.kt` — `StartScreenRecordTool` / `StopScreenRecordTool`,
+- [x] `mcp/tools/ScreenRecordTools.kt` — `StartScreenRecordTool` / `StopScreenRecordTool`,
       `SAFE_ACTION`, single tracked session, 180s auto-stop (platform hard cap), pull to a
       local path then `rm` the remote file.
       **Constraint found in Phase 1:** `IDevice.startScreenRecorder` is on
@@ -110,9 +110,23 @@ Two guards worth knowing about before writing another tool, both of which failed
       must go through `executeShellCommand("screenrecord …")`, and the guard test will fail the
       build if it does not. `getSyncService` is likewise unimplemented, so pushes and pulls must
       use `IDevice.pushFile`/`pullFile` directly rather than opening a sync service.
-- [ ] Tool descriptions state plainly that a recording captures whatever is on screen.
-- [ ] `FileToolsTest` (path validation, size caps), `ScreenRecordToolsTest` (state machine:
+- [x] Tool descriptions state plainly that a recording captures whatever is on screen.
+- [x] `FileToolsTest` (path validation, size caps), `ScreenRecordToolsTest` (state machine:
       start twice → error, stop without start → error).
+
+### Landed in Phase 2
+
+`DevicePaths` allow-list, `PushFileTool`, `PullFileTool`, `ScreenRecorder` +
+`Start`/`StopScreenRecordTool`, with 18 tests.
+
+Two deliberate narrowings of the plan, both tightening rather than loosening it:
+
+- A pull outside the allow-list is **refused**, not confirmed. One conditional gate that
+  sometimes prompts would be a second implementation of the safety model; refusing and pointing
+  at `android_run_adb_command` (already `DESTRUCTIVE`, already confirmed per call) keeps exactly
+  one.
+- The local destination of a pull is **not a parameter**. Letting a caller choose it hands
+  anything with the MCP token an arbitrary filesystem write.
 
 ## Phase 3 — Assistant core (P0)
 

--- a/docs/PLAN-5.0.md
+++ b/docs/PLAN-5.0.md
@@ -20,7 +20,7 @@ MCP". It is: close the documented gaps, bring the AI agent inside the IDE, and p
 |---|---|---|
 | LLM providers in v1 | **Anthropic + a generic OpenAI-compatible client** | Two implementations behind `LlmClient` cover Anthropic, OpenAI, local Ollama and corporate proxies via a configurable base URL. |
 | History persistence | **On by default, 500-entry cap, Settings toggle to disable and clear** | The audit trail's value is surviving the restart that loses in-memory state. Local file in the same trust boundary as the `idea.log` entries destructive calls already write. Off-by-default would disable it exactly when it is needed. |
-| `android_pull_file` scope | Allow-list `/sdcard/**` and `/data/local/tmp/**`; anything else is `DESTRUCTIVE` and prompts | Pulling arbitrary device paths is a data-exfiltration vector. Being stricter than raw `adb` here is a deliberate product choice. |
+| `android_pull_file` scope | Allow-list `/sdcard`, `/storage` and `/data/local/tmp`; anything else is **refused**, naming `android_run_adb_command` as the escape hatch | Pulling arbitrary device paths is a data-exfiltration vector. Being stricter than raw `adb` here is a deliberate product choice. Refusing beats prompting: a prompt puts the judgement on a developer mid-flow, where the safe answer is the one the agent already has a documented, confirmed route to. |
 | Chat UI toolkit | **Swing**, not JCEF | Matches every other panel; JCEF is heavy and version-sensitive across AS 231+. Revisit only if markdown fidelity becomes a requirement. |
 | Messaging | "Extending the MCP toolkit and bringing the AI agent into the IDE" | 4.x already shipped MCP. |
 

--- a/src/main/kotlin/spock/adb/assistant/AgentLoop.kt
+++ b/src/main/kotlin/spock/adb/assistant/AgentLoop.kt
@@ -1,0 +1,120 @@
+package spock.adb.assistant
+
+/**
+ * The tools the loop may call, and the one place they are run.
+ *
+ * An interface rather than `ToolRegistry` directly, so the loop can be tested without an IDE,
+ * a device or a registry of 42 real tools. The production implementation is a thin adapter:
+ * the registry stays the single definition of what an agent may do, and the safety model stays
+ * where it already is.
+ */
+interface AgentTools {
+
+    fun specs(): List<ToolSpec>
+
+    /**
+     * Runs one call and returns what the model should see.
+     *
+     * Must not throw. A tool that failed, was refused by the developer, or does not exist is
+     * information the model needs in order to do something else; an exception thrown here
+     * would end the conversation instead, at the moment it became interesting.
+     */
+    fun invoke(call: LlmToolCall): LlmToolResult
+}
+
+/** Why the loop stopped. The caller shows a different thing for each. */
+sealed interface AgentOutcome {
+
+    /** The model finished its turn. */
+    data class Answered(val text: String) : AgentOutcome
+
+    /** The developer pressed Stop. Whatever had streamed is already on screen. */
+    data class Cancelled(val text: String) : AgentOutcome
+
+    /**
+     * The loop hit its ceiling with the model still calling tools.
+     *
+     * Reported rather than silently truncated: an agent going round in circles is a bug or a
+     * bill, and either way the developer should be told which.
+     */
+    data class ReachedIterationCap(val text: String, val cap: Int) : AgentOutcome
+
+    /** The provider declined the request. Retrying it would spend money to be declined again. */
+    data class Refused(val text: String) : AgentOutcome
+
+    /** The provider failed. Carries its own words. */
+    data class Failed(val message: String) : AgentOutcome
+}
+
+/**
+ * The model ⇄ tool cycle.
+ *
+ * Synchronous, on a pooled thread, with cancellation as a polled predicate rather than a
+ * thread interrupt — `docs/COMPATIBILITY.md` rules out coroutines, and interrupting a thread
+ * mid-request tears down the HTTP connection instead of ending the turn cleanly.
+ */
+class AgentLoop(
+    private val client: LlmClient,
+    private val tools: AgentTools,
+    private val maxIterations: Int = MAX_ITERATIONS,
+) {
+
+    /**
+     * @param conversation appended to in place, so the caller keeps the transcript across
+     *   turns and a cancelled turn still leaves the history consistent.
+     */
+    // Six exits, each naming a different outcome the caller renders differently. Folding them
+    // into one result variable would trade six clear names for one mutable one.
+    @Suppress("ReturnCount")
+    fun run(
+        system: String,
+        userMessage: String,
+        conversation: MutableList<LlmMessage>,
+        onTextDelta: (String) -> Unit,
+        isCancelled: () -> Boolean,
+    ): AgentOutcome {
+        conversation += LlmMessage(LlmMessage.Role.USER, text = userMessage)
+        val specs = tools.specs()
+        var lastText = ""
+
+        repeat(maxIterations) {
+            if (isCancelled()) return AgentOutcome.Cancelled(lastText)
+
+            val response = try {
+                client.send(system, conversation.toList(), specs, onTextDelta, isCancelled)
+            } catch (e: LlmException) {
+                return AgentOutcome.Failed(e.message ?: "The provider failed without saying why.")
+            }
+
+            lastText = response.text
+            conversation += LlmMessage(
+                role = LlmMessage.Role.ASSISTANT,
+                text = response.text,
+                toolCalls = response.toolCalls,
+            )
+
+            if (response.wasRefused) return AgentOutcome.Refused(response.text)
+            if (response.toolCalls.isEmpty()) return AgentOutcome.Answered(response.text)
+            // Cancelled while the model was asking for tools: stop before running any of them.
+            // The alternative — clearing app data and then noticing Stop was pressed — is not
+            // a race worth having.
+            if (isCancelled()) return AgentOutcome.Cancelled(lastText)
+
+            // Every result for this turn goes back in one message, in the order asked for.
+            conversation += LlmMessage(
+                role = LlmMessage.Role.USER,
+                toolResults = response.toolCalls.map { tools.invoke(it) },
+            )
+        }
+
+        return AgentOutcome.ReachedIterationCap(lastText, maxIterations)
+    }
+
+    companion object {
+        /**
+         * The only guard against a surprise bill in v1, so it is deliberately not generous.
+         * A debugging task that genuinely needs more than this is one to drive by hand.
+         */
+        const val MAX_ITERATIONS = 25
+    }
+}

--- a/src/main/kotlin/spock/adb/assistant/AnthropicClient.kt
+++ b/src/main/kotlin/spock/adb/assistant/AnthropicClient.kt
@@ -1,0 +1,259 @@
+package spock.adb.assistant
+
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.time.Duration
+
+/**
+ * Anthropic's Messages API over `java.net.http`.
+ *
+ * No SDK: this plugin ships with one dependency and must keep `verifyPlugin` green on five
+ * IDEs, so a transitive HTTP and JSON stack is not a trade worth making for one endpoint that
+ * is a POST and a stream of server-sent events.
+ */
+class AnthropicClient(
+    private val apiKey: () -> String,
+    private val model: String = DEFAULT_MODEL,
+    private val baseUrl: String = DEFAULT_BASE_URL,
+    private val http: HttpClient = defaultHttpClient(),
+) : LlmClient {
+
+    override fun send(
+        system: String,
+        messages: List<LlmMessage>,
+        tools: List<ToolSpec>,
+        onTextDelta: (String) -> Unit,
+        isCancelled: () -> Boolean,
+    ): LlmResponse {
+        val key = apiKey()
+        if (key.isBlank()) {
+            throw LlmException("No Anthropic API key is set. Add one in Settings > Tools > Spock ADB.")
+        }
+
+        val request = HttpRequest.newBuilder(URI.create("$baseUrl$MESSAGES_PATH"))
+            .header("content-type", "application/json")
+            .header("x-api-key", key)
+            .header("anthropic-version", ANTHROPIC_VERSION)
+            .timeout(REQUEST_TIMEOUT)
+            .POST(HttpRequest.BodyPublishers.ofString(body(system, messages, tools).toString()))
+            .build()
+
+        val response = try {
+            http.send(request, HttpResponse.BodyHandlers.ofLines())
+        } catch (e: java.io.IOException) {
+            throw LlmException("Could not reach $baseUrl: ${e.message}", e)
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            throw LlmException("The request was interrupted.", e)
+        }
+
+        if (response.statusCode() !in SUCCESS) {
+            // Verbatim, including the provider's own error body: a paraphrase drops the part
+            // that says which field was wrong.
+            val detail = runCatching { response.body().limit(ERROR_LINES).toList().joinToString("\n") }
+                .getOrDefault("")
+            throw LlmException("Anthropic returned HTTP ${response.statusCode()}. $detail".trim())
+        }
+
+        return response.body().use { lines ->
+            AnthropicStream.parse(lines.iterator(), onTextDelta, isCancelled)
+        }
+    }
+
+    private fun body(system: String, messages: List<LlmMessage>, tools: List<ToolSpec>) =
+        JsonObject().apply {
+            addProperty("model", model)
+            addProperty("max_tokens", MAX_TOKENS)
+            addProperty("stream", true)
+            if (system.isNotBlank()) addProperty("system", system)
+            // `thinking` is deliberately absent. It is on by default on this model family, and
+            // the older `budget_tokens` form is rejected outright — sending either would be a
+            // 400 rather than a tuning knob.
+            if (tools.isNotEmpty()) {
+                add(
+                    "tools",
+                    JsonArray().apply {
+                        tools.forEach { spec ->
+                            add(
+                                JsonObject().apply {
+                                    addProperty("name", spec.name)
+                                    addProperty("description", spec.description)
+                                    add("input_schema", spec.inputSchema)
+                                },
+                            )
+                        }
+                    },
+                )
+            }
+            add("messages", JsonArray().apply { messages.forEach { add(wire(it)) } })
+        }
+
+    /** One conversation turn as Anthropic content blocks. */
+    private fun wire(message: LlmMessage): JsonObject = JsonObject().apply {
+        addProperty("role", if (message.role == LlmMessage.Role.ASSISTANT) "assistant" else "user")
+        add(
+            "content",
+            JsonArray().apply {
+                message.text?.takeIf { it.isNotBlank() }?.let { text ->
+                    add(
+                        JsonObject().apply {
+                            addProperty("type", "text")
+                            addProperty("text", text)
+                        },
+                    )
+                }
+                message.toolCalls.forEach { call ->
+                    add(
+                        JsonObject().apply {
+                            addProperty("type", "tool_use")
+                            addProperty("id", call.id)
+                            addProperty("name", call.name)
+                            add("input", call.arguments)
+                        },
+                    )
+                }
+                // Every result for a turn goes in this one message. Splitting them across
+                // several teaches the model to stop asking for parallel calls.
+                message.toolResults.forEach { result ->
+                    add(
+                        JsonObject().apply {
+                            addProperty("type", "tool_result")
+                            addProperty("tool_use_id", result.id)
+                            addProperty("content", result.content)
+                            // A failed tool is reported as a failure, never dropped: the model
+                            // cannot route around an error it was not told about.
+                            if (result.isError) addProperty("is_error", true)
+                        },
+                    )
+                }
+            },
+        )
+    }
+
+    companion object {
+        /** The current default. Never date-suffixed — the plain id is the whole id. */
+        const val DEFAULT_MODEL = "claude-opus-5"
+        const val DEFAULT_BASE_URL = "https://api.anthropic.com"
+        const val ANTHROPIC_VERSION = "2023-06-01"
+        const val MESSAGES_PATH = "/v1/messages"
+
+        /** Generous because the response is streamed; a long turn is not a stuck one. */
+        private const val MAX_TOKENS = 64_000
+        private val REQUEST_TIMEOUT: Duration = Duration.ofMinutes(10)
+        private val SUCCESS = 200..299
+        private const val ERROR_LINES = 20L
+        private val CONNECT_TIMEOUT: Duration = Duration.ofSeconds(30)
+
+        private fun defaultHttpClient(): HttpClient = HttpClient.newBuilder()
+            .connectTimeout(CONNECT_TIMEOUT)
+            .build()
+    }
+}
+
+/**
+ * The server-sent event stream, turned into one [LlmResponse].
+ *
+ * Split from the HTTP call so it can be driven from a canned stream: the frame handling —
+ * accumulating a tool call's arguments across `input_json_delta` fragments, and stopping
+ * cleanly part-way through — is the part worth testing, and it needs no network to test.
+ */
+internal object AnthropicStream {
+
+    fun parse(
+        lines: Iterator<String>,
+        onTextDelta: (String) -> Unit,
+        isCancelled: () -> Boolean,
+    ): LlmResponse {
+        val state = State()
+        while (lines.hasNext() && !isCancelled()) {
+            val event = eventOf(lines.next()) ?: continue
+            handle(event, state, onTextDelta)
+        }
+        return state.build()
+    }
+
+    /** Null for keepalives, event-name lines and anything that is not a JSON data frame. */
+    private fun eventOf(line: String): JsonObject? {
+        if (!line.startsWith(DATA_PREFIX)) return null
+        val payload = line.removePrefix(DATA_PREFIX).trim()
+        if (payload.isEmpty() || payload == DONE) return null
+        return runCatching { JsonParser.parseString(payload).asJsonObject }.getOrNull()
+    }
+
+    private fun handle(event: JsonObject, state: State, onTextDelta: (String) -> Unit) {
+        when (event.get("type")?.asString) {
+            "content_block_start" -> state.startBlock(event)
+            "content_block_delta" -> state.delta(event, onTextDelta)
+            "message_delta" -> state.stopReason = event.getAsJsonObject("delta")
+                ?.get("stop_reason")?.takeIf { !it.isJsonNull }?.asString ?: state.stopReason
+            "error" -> throw LlmException(
+                event.getAsJsonObject("error")?.get("message")?.asString
+                    ?: "The provider reported an error mid-stream.",
+            )
+        }
+    }
+
+    private class State {
+        private val text = StringBuilder()
+        private val toolCalls = mutableListOf<PartialCall>()
+        var stopReason: String? = null
+
+        fun startBlock(event: JsonObject) {
+            val block = event.getAsJsonObject("content_block") ?: return
+            if (block.get("type")?.asString != "tool_use") return
+            toolCalls += PartialCall(
+                index = event.get("index")?.asInt ?: toolCalls.size,
+                id = block.get("id")?.asString.orEmpty(),
+                name = block.get("name")?.asString.orEmpty(),
+            )
+        }
+
+        fun delta(event: JsonObject, onTextDelta: (String) -> Unit) {
+            val delta = event.getAsJsonObject("delta") ?: return
+            when (delta.get("type")?.asString) {
+                "text_delta" -> delta.get("text")?.asString?.let {
+                    text.append(it)
+                    onTextDelta(it)
+                }
+                // Tool arguments arrive as JSON fragments that are not valid JSON on their
+                // own, so they are concatenated and parsed once at the end.
+                "input_json_delta" -> delta.get("partial_json")?.asString?.let { fragment ->
+                    val index = event.get("index")?.asInt
+                    toolCalls.firstOrNull { it.index == index }?.arguments?.append(fragment)
+                }
+            }
+        }
+
+        fun build() = LlmResponse(
+            text = text.toString(),
+            toolCalls = toolCalls.mapNotNull { it.build() },
+            stopReason = stopReason,
+        )
+    }
+
+    private class PartialCall(val index: Int, val id: String, val name: String) {
+        val arguments = StringBuilder()
+
+        /**
+         * Null when the call never completed — a stream cut short by cancellation leaves
+         * arguments that do not parse, and half a tool call must not be run.
+         */
+        fun build(): LlmToolCall? {
+            if (id.isBlank() || name.isBlank()) return null
+            val parsed = if (arguments.isEmpty()) {
+                JsonObject()
+            } else {
+                runCatching { JsonParser.parseString(arguments.toString()).asJsonObject }.getOrNull()
+            }
+            return parsed?.let { LlmToolCall(id, name, it) }
+        }
+    }
+
+    private const val DATA_PREFIX = "data:"
+    private const val DONE = "[DONE]"
+}

--- a/src/main/kotlin/spock/adb/assistant/AssistantKeyStore.kt
+++ b/src/main/kotlin/spock/adb/assistant/AssistantKeyStore.kt
@@ -1,0 +1,42 @@
+package spock.adb.assistant
+
+import com.intellij.credentialStore.CredentialAttributes
+import com.intellij.credentialStore.Credentials
+import com.intellij.credentialStore.generateServiceName
+import com.intellij.ide.passwordSafe.PasswordSafe
+
+/**
+ * The LLM API key, in `PasswordSafe` and nowhere else.
+ *
+ * Never in the settings XML, the audit history or the log. A `PersistentStateComponent` field
+ * would put the developer's key in a plain file that syncs with their IDE settings, and the
+ * plugin already writes MCP call history and `idea.log` entries that a key must never reach.
+ *
+ * Read on demand rather than cached: rotating a key in Settings should take effect on the next
+ * request, not the next restart.
+ */
+object AssistantKeyStore {
+
+    fun apiKey(provider: Provider): String =
+        PasswordSafe.instance.getPassword(attributesFor(provider)).orEmpty()
+
+    fun store(provider: Provider, key: String) {
+        val attributes = attributesFor(provider)
+        // A blank key clears the entry rather than storing an empty secret, so "no key" is one
+        // state instead of two that behave the same but read differently.
+        if (key.isBlank()) {
+            PasswordSafe.instance.set(attributes, null)
+        } else {
+            PasswordSafe.instance.set(attributes, Credentials(provider.name, key))
+        }
+    }
+
+    fun hasKey(provider: Provider): Boolean = apiKey(provider).isNotBlank()
+
+    private fun attributesFor(provider: Provider) =
+        CredentialAttributes(generateServiceName(SERVICE, provider.name), provider.name)
+
+    enum class Provider { ANTHROPIC, OPENAI_COMPATIBLE }
+
+    private const val SERVICE = "Spock ADB assistant"
+}

--- a/src/main/kotlin/spock/adb/assistant/LlmClient.kt
+++ b/src/main/kotlin/spock/adb/assistant/LlmClient.kt
@@ -1,0 +1,81 @@
+package spock.adb.assistant
+
+import com.google.gson.JsonObject
+
+/**
+ * One turn of a conversation, in the shape both providers can carry.
+ *
+ * Deliberately not the provider's own wire format: Anthropic nests tool calls as content
+ * blocks and OpenAI hangs them off the message, and a loop written against either shape would
+ * have to be rewritten for the other.
+ */
+data class LlmMessage(
+    val role: Role,
+    val text: String? = null,
+    /** Tool calls the model asked for, on an [Role.ASSISTANT] turn. */
+    val toolCalls: List<LlmToolCall> = emptyList(),
+    /** Results being handed back, on a [Role.USER] turn. */
+    val toolResults: List<LlmToolResult> = emptyList(),
+) {
+    enum class Role { USER, ASSISTANT }
+}
+
+/** @param id the provider's own id for the call, echoed back with the result. */
+data class LlmToolCall(val id: String, val name: String, val arguments: JsonObject)
+
+data class LlmToolResult(val id: String, val content: String, val isError: Boolean)
+
+/** A tool as the provider wants it described. Built from [AdbTool] and never written twice. */
+data class ToolSpec(val name: String, val description: String, val inputSchema: JsonObject)
+
+/**
+ * What the model did with a turn.
+ *
+ * [toolCalls] being non-empty is the loop's signal to run them and go round again; empty means
+ * the turn is finished and [text] is the answer.
+ */
+data class LlmResponse(
+    val text: String,
+    val toolCalls: List<LlmToolCall> = emptyList(),
+    val stopReason: String? = null,
+) {
+    /**
+     * True when the provider declined the request outright rather than answering it.
+     *
+     * Worth distinguishing from an empty answer: retrying it or feeding it back to the loop
+     * would burn iterations on a request that is not going to be served.
+     */
+    val wasRefused: Boolean get() = stopReason == "refusal"
+}
+
+/**
+ * A synchronous chat completion, called from a pooled thread.
+ *
+ * Synchronous and callback-streamed on purpose. `docs/COMPATIBILITY.md` rules out coroutines
+ * in this plugin — a `suspend` function compiles to a state machine that references stdlib
+ * symbols missing from the Kotlin runtime bundled with 2023.1 IDEs, and the failure appears
+ * only in the IDE, never in a unit test.
+ */
+interface LlmClient {
+
+    /**
+     * @param onTextDelta called on the calling thread as text arrives, for streaming into the
+     *   transcript. Never called after [send] returns.
+     * @param isCancelled polled between events; when it goes true, [send] stops reading and
+     *   returns what it has. A predicate rather than a `Thread.interrupt`, so a cancelled turn
+     *   ends at a message boundary instead of tearing the HTTP connection down mid-frame.
+     * @throws LlmException with the provider's own message when the call fails. No retries:
+     *   an agent loop that silently retries a 400 spends the developer's money on the same
+     *   rejected request several times over.
+     */
+    fun send(
+        system: String,
+        messages: List<LlmMessage>,
+        tools: List<ToolSpec>,
+        onTextDelta: (String) -> Unit,
+        isCancelled: () -> Boolean,
+    ): LlmResponse
+}
+
+/** Carries the provider's message verbatim: a paraphrase loses the part that explains it. */
+class LlmException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)

--- a/src/main/kotlin/spock/adb/assistant/OpenAiCompatibleClient.kt
+++ b/src/main/kotlin/spock/adb/assistant/OpenAiCompatibleClient.kt
@@ -1,0 +1,242 @@
+package spock.adb.assistant
+
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.time.Duration
+
+/**
+ * Any endpoint that speaks OpenAI's `/chat/completions`.
+ *
+ * One class rather than several because the base URL is the only thing that differs between
+ * OpenAI itself, a local Ollama, and a corporate proxy — and a plugin that made the developer
+ * pick from a list of three would be wrong the day a fourth appeared.
+ */
+class OpenAiCompatibleClient(
+    private val apiKey: () -> String,
+    private val model: String,
+    private val baseUrl: String,
+    private val http: HttpClient = HttpClient.newBuilder()
+        .connectTimeout(CONNECT_TIMEOUT).build(),
+) : LlmClient {
+
+    override fun send(
+        system: String,
+        messages: List<LlmMessage>,
+        tools: List<ToolSpec>,
+        onTextDelta: (String) -> Unit,
+        isCancelled: () -> Boolean,
+    ): LlmResponse {
+        val request = HttpRequest.newBuilder(URI.create(baseUrl.trimEnd('/') + COMPLETIONS_PATH))
+            .header("content-type", "application/json")
+            .apply { apiKey().takeIf { it.isNotBlank() }?.let { header("authorization", "Bearer $it") } }
+            .timeout(REQUEST_TIMEOUT)
+            .POST(HttpRequest.BodyPublishers.ofString(body(system, messages, tools).toString()))
+            .build()
+
+        val response = try {
+            http.send(request, HttpResponse.BodyHandlers.ofLines())
+        } catch (e: java.io.IOException) {
+            throw LlmException("Could not reach $baseUrl: ${e.message}", e)
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            throw LlmException("The request was interrupted.", e)
+        }
+
+        if (response.statusCode() !in SUCCESS) {
+            val detail = runCatching { response.body().limit(ERROR_LINES).toList().joinToString("\n") }.getOrDefault("")
+            throw LlmException("$baseUrl returned HTTP ${response.statusCode()}. $detail".trim())
+        }
+
+        return response.body().use { OpenAiStream.parse(it.iterator(), onTextDelta, isCancelled) }
+    }
+
+    private fun body(system: String, messages: List<LlmMessage>, tools: List<ToolSpec>) = JsonObject().apply {
+        addProperty("model", model)
+        addProperty("stream", true)
+        if (tools.isNotEmpty()) {
+            add(
+                "tools",
+                JsonArray().apply {
+                    tools.forEach { spec ->
+                        add(
+                            JsonObject().apply {
+                                addProperty("type", "function")
+                                add(
+                                    "function",
+                                    JsonObject().apply {
+                                        addProperty("name", spec.name)
+                                        addProperty("description", spec.description)
+                                        add("parameters", spec.inputSchema)
+                                    },
+                                )
+                            },
+                        )
+                    }
+                },
+            )
+        }
+        add(
+            "messages",
+            JsonArray().apply {
+                if (system.isNotBlank()) {
+                    add(
+                        JsonObject().apply {
+                            addProperty("role", "system")
+                            addProperty("content", system)
+                        },
+                    )
+                }
+                messages.forEach { message -> wire(message).forEach { add(it) } }
+            },
+        )
+    }
+
+    /**
+     * One neutral turn as one or more OpenAI messages.
+     *
+     * Not one-to-one: OpenAI carries each tool result as its own `role: "tool"` message, where
+     * Anthropic carries them all as blocks inside a single user turn. The neutral [LlmMessage]
+     * is the Anthropic shape, so a turn holding several results fans out here.
+     */
+    private fun wire(message: LlmMessage): List<JsonObject> = when {
+        message.toolResults.isNotEmpty() -> message.toolResults.map { result ->
+            JsonObject().apply {
+                addProperty("role", "tool")
+                addProperty("tool_call_id", result.id)
+                // No is_error field exists here, so the failure has to be said in words or the
+                // model cannot tell a refusal from a result.
+                addProperty("content", if (result.isError) "ERROR: ${result.content}" else result.content)
+            }
+        }
+        message.role == LlmMessage.Role.ASSISTANT -> listOf(
+            JsonObject().apply {
+                addProperty("role", "assistant")
+                addProperty("content", message.text.orEmpty())
+                if (message.toolCalls.isNotEmpty()) {
+                    add(
+                        "tool_calls",
+                        JsonArray().apply {
+                            message.toolCalls.forEach { call ->
+                                add(
+                                    JsonObject().apply {
+                                        addProperty("id", call.id)
+                                        addProperty("type", "function")
+                                        add(
+                                            "function",
+                                            JsonObject().apply {
+                                                addProperty("name", call.name)
+                                                addProperty("arguments", call.arguments.toString())
+                                            },
+                                        )
+                                    },
+                                )
+                            }
+                        },
+                    )
+                }
+            },
+        )
+        else -> listOf(
+            JsonObject().apply {
+                addProperty("role", "user")
+                addProperty("content", message.text.orEmpty())
+            },
+        )
+    }
+
+    private companion object {
+        const val COMPLETIONS_PATH = "/chat/completions"
+        const val ERROR_LINES = 20L
+        val SUCCESS = 200..299
+        val CONNECT_TIMEOUT: Duration = Duration.ofSeconds(30)
+        val REQUEST_TIMEOUT: Duration = Duration.ofMinutes(10)
+    }
+}
+
+/** The `chat.completion.chunk` stream, turned into one [LlmResponse]. */
+internal object OpenAiStream {
+
+    fun parse(
+        lines: Iterator<String>,
+        onTextDelta: (String) -> Unit,
+        isCancelled: () -> Boolean,
+    ): LlmResponse {
+        val state = State()
+        while (lines.hasNext() && !isCancelled()) {
+            val choice = choiceOf(lines.next()) ?: continue
+            state.consume(choice, onTextDelta)
+        }
+        return state.build()
+    }
+
+    private fun choiceOf(line: String): JsonObject? {
+        if (!line.startsWith(DATA_PREFIX)) return null
+        val payload = line.removePrefix(DATA_PREFIX).trim()
+        if (payload.isEmpty() || payload == DONE) return null
+        return runCatching {
+            JsonParser.parseString(payload).asJsonObject
+                .getAsJsonArray("choices")?.firstOrNull()?.asJsonObject
+        }.getOrNull()
+    }
+
+    private class State {
+        private val text = StringBuilder()
+        private val calls = linkedMapOf<Int, PartialCall>()
+        private var finishReason: String? = null
+
+        fun consume(choice: JsonObject, onTextDelta: (String) -> Unit) {
+            choice.get("finish_reason")?.takeIf { !it.isJsonNull }?.let { finishReason = it.asString }
+            val delta = choice.getAsJsonObject("delta") ?: return
+            delta.get("content")?.takeIf { !it.isJsonNull }?.asString?.let {
+                text.append(it)
+                onTextDelta(it)
+            }
+            delta.getAsJsonArray("tool_calls")?.forEach { element -> accumulate(element.asJsonObject) }
+        }
+
+        /** Arguments arrive as string fragments keyed by index, invalid JSON until the last. */
+        private fun accumulate(call: JsonObject) {
+            val partial = calls.getOrPut(call.get("index")?.asInt ?: 0) { PartialCall() }
+            call.get("id")?.takeIf { !it.isJsonNull }?.asString?.let { partial.id = it }
+            val function = call.getAsJsonObject("function") ?: return
+            function.get("name")?.takeIf { !it.isJsonNull }?.asString?.let { partial.name = it }
+            function.get("arguments")?.takeIf { !it.isJsonNull }?.asString
+                ?.let { partial.arguments.append(it) }
+        }
+
+        fun build() = LlmResponse(
+            text = text.toString(),
+            toolCalls = calls.values.mapNotNull { it.build() },
+            // Mapped to the neutral vocabulary so the loop has one set of reasons to read.
+            stopReason = when (finishReason) {
+                "tool_calls" -> "tool_use"
+                "content_filter" -> "refusal"
+                else -> finishReason
+            },
+        )
+    }
+
+    private class PartialCall {
+        var id: String = ""
+        var name: String = ""
+        val arguments = StringBuilder()
+
+        fun build(): LlmToolCall? {
+            if (id.isBlank() || name.isBlank()) return null
+            val parsed = if (arguments.isEmpty()) {
+                JsonObject()
+            } else {
+                runCatching { JsonParser.parseString(arguments.toString()).asJsonObject }.getOrNull()
+            }
+            return parsed?.let { LlmToolCall(id, name, it) }
+        }
+    }
+
+    private const val DATA_PREFIX = "data:"
+    private const val DONE = "[DONE]"
+}

--- a/src/main/kotlin/spock/adb/assistant/RegistryAgentTools.kt
+++ b/src/main/kotlin/spock/adb/assistant/RegistryAgentTools.kt
@@ -1,0 +1,82 @@
+package spock.adb.assistant
+
+import spock.adb.mcp.McpCall
+import spock.adb.mcp.tools.ToolContent
+import spock.adb.mcp.tools.ToolContext
+import spock.adb.mcp.tools.ToolRegistry
+import spock.adb.mcp.tools.ToolResult
+
+/**
+ * The assistant's tools: the MCP registry, unchanged.
+ *
+ * There is no `AssistantToolContext` class, though the plan named one. [ToolContext] is already
+ * "the same `DeviceLister` and `DebugBridgeProvider`, reusing the confirmation dialog" — that
+ * is `McpToolContext`'s entire job — so a subclass of it would add a name and no behaviour, and
+ * would be a second place for the safety model to drift to. The assistant is handed the same
+ * context the MCP transports are handed, which is the invariant the plan asks for rather than
+ * merely a way to satisfy it.
+ *
+ * @param audit every call, recorded with the client set to [ASSISTANT_CLIENT] so the Activity
+ *   tab shows what the assistant did next to what an external agent did. One trail, one place
+ *   to look when the question is "what touched my device".
+ */
+class RegistryAgentTools(
+    private val contextProvider: () -> ToolContext,
+    private val audit: (McpCall) -> Unit = {},
+) : AgentTools {
+
+    override fun specs(): List<ToolSpec> = ToolRegistry.all().toToolSpecs()
+
+    // A tool boundary must not be able to end the conversation: whatever went wrong is a
+    // result the model can read and act on, and an exception here would instead be a stack
+    // trace where the developer expected an answer.
+    @Suppress("TooGenericExceptionCaught")
+    override fun invoke(call: LlmToolCall): LlmToolResult {
+        val tool = ToolRegistry.find(call.name)
+            ?: return LlmToolResult(
+                call.id,
+                "There is no tool called '${call.name}'. Use one of the tools you were given.",
+                isError = true,
+            )
+
+        val startedAt = System.currentTimeMillis()
+        val result = try {
+            tool.execute(call.arguments, contextProvider())
+        } catch (e: Exception) {
+            // Includes a declined confirmation, which reaches here as a thrown refusal. The
+            // model needs to be told "no" in words; silence would look like a tool that hung.
+            ToolResult.error(e.message ?: "${e.javaClass.simpleName} while running ${call.name}")
+        }
+
+        val text = result.content.joinToString("\n") { item ->
+            when (item) {
+                is ToolContent.Text -> item.text
+                // An image is described, not inlined: a base64 screenshot would blow the
+                // context window and cost real money to send back on every later turn.
+                is ToolContent.Image -> "[${item.mimeType}, ${item.base64Data.length} base64 chars]"
+            }
+        }
+
+        audit(
+            McpCall(
+                toolName = call.name,
+                safety = tool.safety,
+                arguments = call.arguments.toString(),
+                result = text.take(RESULT_PREVIEW_CHARS),
+                durationMs = System.currentTimeMillis() - startedAt,
+                isError = result.isError,
+                client = ASSISTANT_CLIENT,
+                deviceSerial = call.arguments.get("deviceSerial")
+                    ?.takeIf { !it.isJsonNull }?.asString,
+            ),
+        )
+
+        return LlmToolResult(call.id, text, result.isError)
+    }
+
+    companion object {
+        /** What the Activity tab shows in the client column for an in-IDE assistant call. */
+        const val ASSISTANT_CLIENT = "spock-assistant"
+        private const val RESULT_PREVIEW_CHARS = 4_000
+    }
+}

--- a/src/main/kotlin/spock/adb/assistant/ToolSpecs.kt
+++ b/src/main/kotlin/spock/adb/assistant/ToolSpecs.kt
@@ -1,0 +1,20 @@
+package spock.adb.assistant
+
+import spock.adb.mcp.tools.AdbTool
+
+/**
+ * The one mapping from a registered tool to the shape a model is told about.
+ *
+ * There is no `provider` parameter, deliberately, though the plan named one. A tool is a name,
+ * a description and a JSON Schema in both providers' APIs; only the envelope around it differs,
+ * and that envelope belongs to the client that writes the request body. Passing the provider in
+ * here would put two providers' knowledge in the mapping and still leave each client shaping
+ * its own request — the definition would be written twice, which is the thing this avoids.
+ */
+fun AdbTool.toToolSpec(): ToolSpec = ToolSpec(
+    name = name,
+    description = description,
+    inputSchema = inputSchema,
+)
+
+fun Iterable<AdbTool>.toToolSpecs(): List<ToolSpec> = map { it.toToolSpec() }

--- a/src/main/kotlin/spock/adb/mcp/McpResources.kt
+++ b/src/main/kotlin/spock/adb/mcp/McpResources.kt
@@ -38,6 +38,10 @@ object McpResources {
             name = "Project application ID",
             description = "Application ID of the app module in the open project.",
         ) { context ->
+            // Resolve the project first: "several projects are open" and "no application ID"
+            // are different problems, and reporting the second for the first sends the agent
+            // after a Gradle sync that was never the issue.
+            context.requireProject()
             context.projectApplicationId()
                 ?: "No application ID could be resolved. Open an Android project and let Gradle sync finish."
         },

--- a/src/main/kotlin/spock/adb/mcp/McpServerPanel.kt
+++ b/src/main/kotlin/spock/adb/mcp/McpServerPanel.kt
@@ -78,6 +78,10 @@ class McpServerPanel(
 
     private val callListener: (McpCall) -> Unit = { refreshActivityLater() }
 
+    /** Set on dispose, so a transition still in flight cannot update a dead panel. */
+    @Volatile
+    private var disposed = false
+
     init {
         setToolbar(header())
         setContent(body())
@@ -289,10 +293,7 @@ class McpServerPanel(
 
     private fun wire() {
         startStopButton.addActionListener { if (service.isRunning) stopServer() else startServer() }
-        restartButton.addActionListener {
-            stopServer()
-            startServer()
-        }
+        restartButton.addActionListener { restartServer() }
         copyConfigButton.addActionListener {
             copy(service.clientConfiguration())
             detailLabel.text = "Configuration copied — it contains an access token for your devices."
@@ -307,18 +308,57 @@ class McpServerPanel(
     }
 
     private fun startServer() {
-        service.start()
-            .onSuccess { refreshStatus() }
-            .onFailure {
-                statusLabel.text = "Could not start: ${it.message}"
-                statusLabel.foreground = ERROR
-            }
+        beginTransition("Starting the MCP server…")
+        service.startAsync { result -> onEdt { finishTransition(result.exceptionOrNull()) } }
     }
 
     private fun stopServer() {
-        service.stop()
-        refreshStatus()
+        beginTransition("Stopping the MCP server…")
+        service.stopAsync { onEdt { finishTransition() } }
     }
+
+    /**
+     * Stop and start are chained, not issued together: the second must not begin until the
+     * first has released the sockets — which is the whole reason they are asynchronous.
+     */
+    private fun restartServer() {
+        beginTransition("Restarting the MCP server…")
+        service.stopAsync {
+            service.startAsync { result -> onEdt { finishTransition(result.exceptionOrNull()) } }
+        }
+    }
+
+    /**
+     * The controls go quiet while a transition runs.
+     *
+     * Starting binds two sockets and stopping waits for live stdio sessions to end, so both
+     * take long enough to notice — this used to happen on the EDT and froze the tool window.
+     * Disabling the buttons also stops a second click starting a server that is already
+     * starting.
+     */
+    private fun beginTransition(message: String) {
+        statusLabel.text = "◌ $message"
+        statusLabel.foreground = JBColor.GRAY
+        detailLabel.text = " "
+        startStopButton.isEnabled = false
+        restartButton.isEnabled = false
+        copyConfigButton.isEnabled = false
+    }
+
+    /** [failure] is reported after the refresh, which would otherwise overwrite it. */
+    private fun finishTransition(failure: Throwable? = null) {
+        startStopButton.isEnabled = true
+        refreshStatus()
+
+        if (failure != null) {
+            statusLabel.text = "Could not start: ${failure.message}"
+            statusLabel.foreground = ERROR
+        }
+    }
+
+    /** Back to the EDT, dropping the update when the panel or the project has gone. */
+    private fun onEdt(block: () -> Unit) =
+        ApplicationManager.getApplication().invokeLater({ block() }) { disposed || project.isDisposed }
 
     private fun refreshStatus() {
         val running = service.isRunning
@@ -377,8 +417,7 @@ class McpServerPanel(
 
     // ------------------------------------------------------------------ activity
 
-    private fun refreshActivityLater() =
-        ApplicationManager.getApplication().invokeLater({ refreshActivity() }) { project.isDisposed }
+    private fun refreshActivityLater() = onEdt { refreshActivity() }
 
     private fun refreshActivity() {
         val filter = McpHistoryFilter(
@@ -455,7 +494,10 @@ class McpServerPanel(
     private fun openSettings() =
         ShowSettingsUtil.getInstance().showSettingsDialog(project, SpockAdbConfigurable::class.java)
 
-    override fun dispose() = service.removeCallListener(callListener)
+    override fun dispose() {
+        disposed = true
+        service.removeCallListener(callListener)
+    }
 
     // ------------------------------------------------------------------ rendering
 

--- a/src/main/kotlin/spock/adb/mcp/McpServerService.kt
+++ b/src/main/kotlin/spock/adb/mcp/McpServerService.kt
@@ -37,6 +37,7 @@ class McpServerService : PersistentStateComponent<McpSettings>, Disposable {
 
     private var settings = McpSettings()
     private val selectedSerial = AtomicReference<String?>(null)
+    private val selectedProject = AtomicReference<String?>(null)
     private val history = McpRequestHistory()
 
     private var server: McpHttpServer? = null
@@ -62,10 +63,16 @@ class McpServerService : PersistentStateComponent<McpSettings>, Disposable {
 
     @Synchronized
     fun start(): Result<Int> = runCatching {
+        // Already listening. Starting again would replace the HTTP server and strand the
+        // previous stdio bridge's threads, so a double click, or a start racing an
+        // auto-start, is answered with the port that is already bound. Restarting is
+        // Restart's job.
+        server?.port?.let { return@runCatching it }
+
         if (settings.token.isBlank()) settings.token = generateToken()
 
         val mcpProtocol = McpProtocol(
-            contextProvider = { McpToolContext(selectedSerial) },
+            contextProvider = { McpToolContext(selectedSerial, selectedProject) },
             auditLog = ::record,
         )
         protocol = mcpProtocol
@@ -92,6 +99,35 @@ class McpServerService : PersistentStateComponent<McpSettings>, Disposable {
         bridge = null
         protocol = null
         settings.enabled = false
+    }
+
+    /**
+     * [start], off the calling thread.
+     *
+     * Both transitions do real blocking work — [start] binds two sockets and writes the
+     * stdio endpoint descriptor, and [stop] waits for live stdio sessions to end before
+     * releasing their threads — so neither belongs on the EDT, where stopping the server
+     * with a client attached froze the tool window until the wait expired.
+     *
+     * [onResult] runs on the pooled thread, not the EDT. Callers marshal it themselves, as
+     * every other background call in the plugin does, so each can also carry its own "is my
+     * component still alive" condition.
+     */
+    fun startAsync(onResult: (Result<Int>) -> Unit) {
+        ApplicationManager.getApplication().executeOnPooledThread { onResult(start()) }
+    }
+
+    /** [stop], off the calling thread. [onDone] runs on the pooled thread. See [startAsync]. */
+    fun stopAsync(onDone: () -> Unit = {}) {
+        ApplicationManager.getApplication().executeOnPooledThread {
+            // finally, not a plain sequence: the caller re-enables its controls in [onDone],
+            // and a stop that failed part-way must not leave them disabled for good.
+            try {
+                stop()
+            } finally {
+                onDone()
+            }
+        }
     }
 
     /**

--- a/src/main/kotlin/spock/adb/mcp/McpToolContext.kt
+++ b/src/main/kotlin/spock/adb/mcp/McpToolContext.kt
@@ -22,10 +22,13 @@ import java.util.concurrent.atomic.AtomicReference
  */
 class McpToolContext(
     private val selectedSerial: AtomicReference<String?>,
-    private val projectProvider: () -> Project? = { defaultProject() },
+    /** The agent's project choice, when it has made one. Session state, like the device. */
+    private val selectedProject: AtomicReference<String?> = AtomicReference(null),
+    private val openProjects: () -> List<Project> = { allOpenProjects() },
 ) : ToolContext {
 
-    override val project: Project? get() = projectProvider()
+    override val project: Project?
+        get() = (resolveProject() as? ProjectResolution.Outcome.Resolved)?.project
 
     private val lister: DeviceLister
         get() {
@@ -75,6 +78,48 @@ class McpToolContext(
         return device
     }
 
+    /**
+     * Fails with the reason rather than a null.
+     *
+     * "Nothing is open" and "several are open, say which" need different things from the
+     * agent, and returning null for both taught it the wrong fix for one of them.
+     */
+    override fun requireProject(): Project = when (val outcome = resolveProject()) {
+        is ProjectResolution.Outcome.Resolved -> outcome.project
+
+        ProjectResolution.Outcome.None -> error(
+            "No project is open, which this tool needs to run. Open the Android project in " +
+                "the IDE and let Gradle sync finish.",
+        )
+
+        is ProjectResolution.Outcome.Ambiguous -> error(
+            "Several projects are open, so it is ambiguous which app this call is about: " +
+                outcome.names.joinToString() +
+                ". Call android_select_project with one of those names first.",
+        )
+    }
+
+    override fun selectProject(name: String): String {
+        val open = openProjects()
+        check(open.isNotEmpty()) { "No project is open." }
+
+        val match = open.firstOrNull { candidate ->
+            keysOf(candidate).any { it.isNotBlank() && it.equals(name, ignoreCase = true) }
+        } ?: error(
+            "No open project is called '$name'. Open: " + open.joinToString { it.name } + ".",
+        )
+
+        selectedProject.set(match.name)
+        return match.name
+    }
+
+    private fun resolveProject(): ProjectResolution.Outcome<Project> = ProjectResolution.resolve(
+        candidates = openProjects(),
+        selectedKey = selectedProject.get(),
+        keysOf = { keysOf(it) },
+        nameOf = { it.name },
+    )
+
     override fun projectApplicationId(): String? =
         project?.let { runCatching { GetApplicationIDCommand.resolve(it) }.getOrNull() }
 
@@ -89,7 +134,10 @@ class McpToolContext(
         summary: String,
         device: ConnectedDevice,
     ): Boolean {
-        val currentProject = project ?: return false
+        // Any open frame will do: this dialog is about a device operation, not about a
+        // project, so refusing to ask merely because two projects are open would deny a call
+        // the developer would have approved.
+        val currentProject = project ?: openProjects().firstOrNull() ?: return false
         if (currentProject.isDisposed) return false
 
         var approved = false
@@ -115,8 +163,11 @@ class McpToolContext(
     }
 
     private companion object {
-        /** The single open project, when there is exactly one; otherwise nothing to guess at. */
-        fun defaultProject(): Project? =
-            ProjectManager.getInstance().openProjects.singleOrNull { !it.isDisposed }
+        /** Disposed projects are gone, not candidates. */
+        fun allOpenProjects(): List<Project> =
+            ProjectManager.getInstance().openProjects.filterNot { it.isDisposed }
+
+        /** Everything a project answers to, so a selection can name either. */
+        fun keysOf(project: Project): List<String> = listOfNotNull(project.name, project.basePath)
     }
 }

--- a/src/main/kotlin/spock/adb/mcp/McpToolContext.kt
+++ b/src/main/kotlin/spock/adb/mcp/McpToolContext.kt
@@ -95,7 +95,8 @@ class McpToolContext(
         is ProjectResolution.Outcome.Ambiguous -> error(
             "Several projects are open, so it is ambiguous which app this call is about: " +
                 outcome.names.joinToString() +
-                ". Call android_select_project with one of those names first.",
+                ". Call android_select_project first, naming one of those — where a path is " +
+                "shown, two projects share a name and only the path tells them apart.",
         )
     }
 
@@ -106,18 +107,28 @@ class McpToolContext(
         val match = open.firstOrNull { candidate ->
             keysOf(candidate).any { it.isNotBlank() && it.equals(name, ignoreCase = true) }
         } ?: error(
-            "No open project is called '$name'. Open: " + open.joinToString { it.name } + ".",
+            "No open project is called '$name'. Open: " +
+                open.joinToString { labellerFor(open)(it) } +
+                ". A project may be named by its name or by its path.",
         )
 
-        selectedProject.set(match.name)
-        return match.name
+        // Remembered by path, not by name. Two checkouts of one repository are both called
+        // "app", and a selection stored as "app" resolves back to whichever the IDE lists
+        // first — so selecting the fork by its path would silently keep targeting the
+        // original, and every project-dependent tool would answer about the wrong app.
+        selectedProject.set(match.basePath ?: match.name)
+        return labellerFor(open)(match)
     }
+
+    /** Labels that separate two open projects sharing a name. */
+    private fun labellerFor(candidates: List<Project>): (Project) -> String =
+        ProjectResolution.labeller(candidates, nameOf = { it.name }, pathOf = { it.basePath })
 
     private fun resolveProject(): ProjectResolution.Outcome<Project> = ProjectResolution.resolve(
         candidates = openProjects(),
         selectedKey = selectedProject.get(),
         keysOf = { keysOf(it) },
-        nameOf = { it.name },
+        labelOf = labellerFor(openProjects()),
     )
 
     override fun projectApplicationId(): String? =

--- a/src/main/kotlin/spock/adb/mcp/McpToolContext.kt
+++ b/src/main/kotlin/spock/adb/mcp/McpToolContext.kt
@@ -95,21 +95,19 @@ class McpToolContext(
         is ProjectResolution.Outcome.Ambiguous -> error(
             "Several projects are open, so it is ambiguous which app this call is about: " +
                 outcome.names.joinToString() +
-                ". Call android_select_project first, naming one of those — where a path is " +
-                "shown, two projects share a name and only the path tells them apart.",
+                ". Call android_select_project first, passing one of those exactly as written.",
         )
     }
 
     override fun selectProject(name: String): String {
         val open = openProjects()
         check(open.isNotEmpty()) { "No project is open." }
+        val label = labellerFor(open)
 
-        val match = open.firstOrNull { candidate ->
-            keysOf(candidate).any { it.isNotBlank() && it.equals(name, ignoreCase = true) }
-        } ?: error(
+        val match = ProjectResolution.select(open, name, ::keysOf, label) ?: error(
             "No open project is called '$name'. Open: " +
-                open.joinToString { labellerFor(open)(it) } +
-                ". A project may be named by its name or by its path.",
+                open.joinToString { label(it) } +
+                ". A project may be named by its name, its path, or exactly as listed here.",
         )
 
         // Remembered by path, not by name. Two checkouts of one repository are both called
@@ -117,19 +115,25 @@ class McpToolContext(
         // first — so selecting the fork by its path would silently keep targeting the
         // original, and every project-dependent tool would answer about the wrong app.
         selectedProject.set(match.basePath ?: match.name)
-        return labellerFor(open)(match)
+        return label(match)
     }
 
     /** Labels that separate two open projects sharing a name. */
     private fun labellerFor(candidates: List<Project>): (Project) -> String =
         ProjectResolution.labeller(candidates, nameOf = { it.name }, pathOf = { it.basePath })
 
-    private fun resolveProject(): ProjectResolution.Outcome<Project> = ProjectResolution.resolve(
-        candidates = openProjects(),
-        selectedKey = selectedProject.get(),
-        keysOf = { keysOf(it) },
-        labelOf = labellerFor(openProjects()),
-    )
+    private fun resolveProject(): ProjectResolution.Outcome<Project> {
+        // One snapshot: a project opened or closed between the two reads would label the
+        // candidates against a different set than the one being resolved, and the labels are
+        // what the caller is then told to choose from.
+        val open = openProjects()
+        return ProjectResolution.resolve(
+            candidates = open,
+            selectedKey = selectedProject.get(),
+            keysOf = { keysOf(it) },
+            labelOf = labellerFor(open),
+        )
+    }
 
     override fun projectApplicationId(): String? =
         project?.let { runCatching { GetApplicationIDCommand.resolve(it) }.getOrNull() }

--- a/src/main/kotlin/spock/adb/mcp/ProjectResolution.kt
+++ b/src/main/kotlin/spock/adb/mcp/ProjectResolution.kt
@@ -71,6 +71,24 @@ object ProjectResolution {
     }
 
     /**
+     * The candidate a caller named, or null.
+     *
+     * Matches the label as well as [keysOf], because the label is what an ambiguity error
+     * *shows*: a caller that passes back exactly what it was told to choose from would
+     * otherwise be answered "no open project is called 'app (/home/dev/app)'", which reads as
+     * the project having closed rather than as the wrong string having been sent.
+     */
+    fun <T> select(
+        candidates: List<T>,
+        key: String,
+        keysOf: (T) -> List<String>,
+        labelOf: (T) -> String,
+    ): T? = candidates.firstOrNull { candidate ->
+        (keysOf(candidate) + labelOf(candidate))
+            .any { it.isNotBlank() && it.equals(key, ignoreCase = true) }
+    }
+
+    /**
      * Describes each candidate, adding its path only where the name alone would not identify it.
      *
      * Two checkouts of one repository are both called `app`, which is ordinary rather than

--- a/src/main/kotlin/spock/adb/mcp/ProjectResolution.kt
+++ b/src/main/kotlin/spock/adb/mcp/ProjectResolution.kt
@@ -1,0 +1,67 @@
+package spock.adb.mcp
+
+/**
+ * Chooses which of the IDE's open projects an MCP call is about.
+ *
+ * An MCP client connects to the IDE, not to a project, so with more than one project open
+ * there is a real ambiguity: the application ID, the sources an Activity is resolved
+ * against and the default logcat filter all come from a project, and picking the wrong one
+ * hands the agent confident answers about the wrong app.
+ *
+ * The rule deliberately mirrors device resolution: resolve when there is one right answer,
+ * and **refuse to guess** when there is not, naming the candidates so the caller can choose.
+ * Picking the focused window instead would be wrong exactly when it matters most — an agent
+ * working while the developer is looking at something else.
+ *
+ * Generic and free of IntelliJ types, so the rules are unit tested directly rather than only
+ * inside a running IDE.
+ */
+object ProjectResolution {
+
+    sealed interface Outcome<out T> {
+
+        /** Nothing is open, so there is nothing to choose between. */
+        object None : Outcome<Nothing>
+
+        data class Resolved<T>(val project: T, val source: Source) : Outcome<T>
+
+        /** Several are open and none was chosen. [names] is what may be selected from. */
+        data class Ambiguous(val names: List<String>) : Outcome<Nothing>
+    }
+
+    /** Why a project was chosen, so a caller can say so rather than appear to have guessed. */
+    enum class Source {
+        /** Named by an earlier `android_select_project`. */
+        SELECTED,
+
+        /** The only one open, so there was nothing to choose. */
+        ONLY_OPEN,
+    }
+
+    /**
+     * @param candidates the open projects.
+     * @param selectedKey what was last selected, matched against [keysOf] case-insensitively.
+     * @param keysOf every identifier a candidate answers to — its name and its path.
+     * @param nameOf the human name, used only to describe an ambiguity.
+     */
+    fun <T> resolve(
+        candidates: List<T>,
+        selectedKey: String?,
+        keysOf: (T) -> List<String>,
+        nameOf: (T) -> String,
+    ): Outcome<T> {
+        if (candidates.isEmpty()) return Outcome.None
+
+        // A stale selection — the project it named has since been closed — falls through
+        // rather than failing: a choice should not outlive the project it was about.
+        if (!selectedKey.isNullOrBlank()) {
+            candidates.firstOrNull { candidate ->
+                keysOf(candidate).any { it.isNotBlank() && it.equals(selectedKey, ignoreCase = true) }
+            }?.let { return Outcome.Resolved(it, Source.SELECTED) }
+        }
+
+        candidates.singleOrNull()?.let { return Outcome.Resolved(it, Source.ONLY_OPEN) }
+
+        return Outcome.Ambiguous(candidates.map(nameOf).sorted())
+    }
+}

--- a/src/main/kotlin/spock/adb/mcp/ProjectResolution.kt
+++ b/src/main/kotlin/spock/adb/mcp/ProjectResolution.kt
@@ -25,7 +25,11 @@ object ProjectResolution {
 
         data class Resolved<T>(val project: T, val source: Source) : Outcome<T>
 
-        /** Several are open and none was chosen. [names] is what may be selected from. */
+        /**
+         * Several are open and none was chosen. [names] is what may be selected from, and is
+         * built by [labeller] so that two projects sharing a name are still told apart — a
+         * list reading "app, app" names no choice the caller can actually make.
+         */
         data class Ambiguous(val names: List<String>) : Outcome<Nothing>
     }
 
@@ -42,13 +46,14 @@ object ProjectResolution {
      * @param candidates the open projects.
      * @param selectedKey what was last selected, matched against [keysOf] case-insensitively.
      * @param keysOf every identifier a candidate answers to — its name and its path.
-     * @param nameOf the human name, used only to describe an ambiguity.
+     * @param labelOf how to describe a candidate in an ambiguity. Build it with [labeller]
+     *   so duplicated names carry the detail that separates them.
      */
     fun <T> resolve(
         candidates: List<T>,
         selectedKey: String?,
         keysOf: (T) -> List<String>,
-        nameOf: (T) -> String,
+        labelOf: (T) -> String,
     ): Outcome<T> {
         if (candidates.isEmpty()) return Outcome.None
 
@@ -62,6 +67,29 @@ object ProjectResolution {
 
         candidates.singleOrNull()?.let { return Outcome.Resolved(it, Source.ONLY_OPEN) }
 
-        return Outcome.Ambiguous(candidates.map(nameOf).sorted())
+        return Outcome.Ambiguous(candidates.map(labelOf).sorted())
+    }
+
+    /**
+     * Describes each candidate, adding its path only where the name alone would not identify it.
+     *
+     * Two checkouts of one repository are both called `app`, which is ordinary rather than
+     * exotic. Naming them both "app" in an ambiguity error asks the caller to choose between
+     * two identical strings; qualifying every project with its path all the time would make
+     * the common single-name case needlessly noisy. So the path appears exactly when it is
+     * what distinguishes them.
+     */
+    fun <T> labeller(
+        candidates: List<T>,
+        nameOf: (T) -> String,
+        pathOf: (T) -> String?,
+    ): (T) -> String {
+        val duplicated = candidates.groupingBy(nameOf).eachCount()
+            .filterValues { it > 1 }
+            .keys
+        return { candidate ->
+            val name = nameOf(candidate)
+            if (name in duplicated) "$name (${pathOf(candidate) ?: "no path"})" else name
+        }
     }
 }

--- a/src/main/kotlin/spock/adb/mcp/actions/McpActions.kt
+++ b/src/main/kotlin/spock/adb/mcp/actions/McpActions.kt
@@ -4,10 +4,27 @@ import com.intellij.notification.NotificationType
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.ide.CopyPasteManager
+import com.intellij.openapi.project.Project
 import spock.adb.mcp.McpServerService
 import spock.adb.notification.CommonNotifier
 import java.awt.datatransfer.StringSelection
+
+/**
+ * Reports the outcome of work that finished on a pooled thread.
+ *
+ * Starting and stopping the server both block — binding sockets, and waiting for live stdio
+ * sessions to end — so they no longer run on the EDT and their results arrive on a
+ * background thread. See [McpServerService.startAsync].
+ */
+private fun notifyLater(
+    project: Project,
+    content: String,
+    type: NotificationType = NotificationType.INFORMATION,
+) = ApplicationManager.getApplication().invokeLater(
+    { CommonNotifier.showNotifier(project = project, content = content, type = type) },
+) { project.isDisposed }
 
 /**
  * Starts or stops the MCP server.
@@ -31,30 +48,33 @@ class ToggleMcpServerAction : AnAction() {
         val service = McpServerService.getInstance()
 
         if (service.isRunning) {
-            service.stop()
-            CommonNotifier.showNotifier(
-                project = project,
-                content = "MCP server stopped. Connected AI agents can no longer reach your devices.",
-            )
+            service.stopAsync {
+                notifyLater(
+                    project = project,
+                    content = "MCP server stopped. Connected AI agents can no longer reach your devices.",
+                )
+            }
             return
         }
 
-        service.start()
-            .onSuccess { port ->
-                CommonNotifier.showNotifier(
-                    project = project,
-                    content = "MCP server listening on 127.0.0.1:$port. " +
-                        "Use 'Spock: Copy MCP Client Configuration (stdio)' — or (HTTP) — to " +
-                        "connect a client.",
-                )
-            }
-            .onFailure { error ->
-                CommonNotifier.showNotifier(
-                    project = project,
-                    content = "Could not start the MCP server: ${error.message}",
-                    type = NotificationType.ERROR,
-                )
-            }
+        service.startAsync { result ->
+            result
+                .onSuccess { port ->
+                    notifyLater(
+                        project = project,
+                        content = "MCP server listening on 127.0.0.1:$port. " +
+                            "Use 'Spock: Copy MCP Client Configuration (stdio)' — or (HTTP) — to " +
+                            "connect a client.",
+                    )
+                }
+                .onFailure { error ->
+                    notifyLater(
+                        project = project,
+                        content = "Could not start the MCP server: ${error.message}",
+                        type = NotificationType.ERROR,
+                    )
+                }
+        }
     }
 }
 
@@ -147,17 +167,23 @@ class RestartMcpServerAction : AnAction() {
     override fun actionPerformed(event: AnActionEvent) {
         val project = event.project ?: return
         val service = McpServerService.getInstance()
-        service.stop()
-        service.start()
-            .onSuccess {
-                CommonNotifier.showNotifier(project = project, content = "MCP server restarted on 127.0.0.1:$it.")
+
+        // Chained, not issued together: the start must not begin until the stop has released
+        // the sockets.
+        service.stopAsync {
+            service.startAsync { result ->
+                result
+                    .onSuccess {
+                        notifyLater(project = project, content = "MCP server restarted on 127.0.0.1:$it.")
+                    }
+                    .onFailure {
+                        notifyLater(
+                            project = project,
+                            content = "Could not restart the MCP server: ${it.message}",
+                            type = NotificationType.ERROR,
+                        )
+                    }
             }
-            .onFailure {
-                CommonNotifier.showNotifier(
-                    project = project,
-                    content = "Could not restart the MCP server: ${it.message}",
-                    type = NotificationType.ERROR,
-                )
-            }
+        }
     }
 }

--- a/src/main/kotlin/spock/adb/mcp/tools/ComposeUiTools.kt
+++ b/src/main/kotlin/spock/adb/mcp/tools/ComposeUiTools.kt
@@ -62,7 +62,12 @@ internal object UiTreeReader {
         }
     }
 
-    fun UiNode.render(depth: Int = 0): String = buildString {
+    /**
+     * @param maxDepth how deep to descend before summarising. A whole tree is often thousands
+     *   of nodes, and an agent pays for every one of them, so callers assembling a bundle can
+     *   trade depth for tokens. Hidden subtrees are counted rather than dropped silently.
+     */
+    fun UiNode.render(depth: Int = 0, maxDepth: Int = Int.MAX_VALUE): String = buildString {
         append("  ".repeat(depth))
         append(shortClassName())
         testTag?.let { append(" testTag=").append(it) }
@@ -74,7 +79,17 @@ internal object UiTreeReader {
         if (!enabled) append(" DISABLED")
         if (selected) append(" selected")
         append(' ').append(bounds)
-        children.forEach { append('\n').append(it.render(depth + 1)) }
+
+        when {
+            children.isEmpty() -> Unit
+            depth < maxDepth -> children.forEach { append('\n').append(it.render(depth + 1, maxDepth)) }
+            else -> {
+                val hidden = children.sumOf { it.asSequence().count() }
+                append('\n').append("  ".repeat(depth + 1))
+                append("[").append(hidden).append(" more node(s) below this one, hidden by maxUiDepth=")
+                append(maxDepth).append(". Raise it, or call android_get_ui_tree for the full tree.]")
+            }
+        }
     }
 
     private fun UiNode.shortClassName(): String = className.substringAfterLast('.')

--- a/src/main/kotlin/spock/adb/mcp/tools/DebugContextTool.kt
+++ b/src/main/kotlin/spock/adb/mcp/tools/DebugContextTool.kt
@@ -1,0 +1,193 @@
+package spock.adb.mcp.tools
+
+import com.google.gson.JsonObject
+
+/**
+ * `android_get_debug_context` — the whole triage bundle in one call.
+ *
+ * Answering "why does this screen look wrong" previously cost an agent three or four
+ * round-trips: current activity, UI tree, logcat, screenshot. Each is a separate turn, and by
+ * the time the last one lands the screen may have moved on — so the bundle it assembled
+ * describes no single moment. Capturing them together is both cheaper and more truthful.
+ *
+ * A failing section does not fail the call. A screenshot blocked by `FLAG_SECURE` must not
+ * cost the developer the crash sitting next to it in logcat, so each section reports its own
+ * failure in place and the rest still come back.
+ */
+class DebugContextTool : AdbTool {
+
+    override val name = "android_get_debug_context"
+
+    override val description =
+        "Everything needed to triage what is on screen right now, in one call: the current " +
+            "activity, the UI semantics tree with its framework identified, recent logcat, and " +
+            "optionally a screenshot. Prefer this over calling android_get_current_activity, " +
+            "android_get_ui_tree and android_get_logcat separately — it is one round-trip and " +
+            "every section describes the same moment. Start here when asked why a screen looks " +
+            "wrong, why an app crashed, or what state the app is in."
+
+    override val safety = ToolSafety.READ_ONLY
+
+    override val inputSchema: JsonObject = Schema.obj {
+        stringArray(
+            "include",
+            "Which sections to capture. Defaults to activity, ui and logcat. Add \"screenshot\" " +
+                "only when you need to see the screen rather than read its structure — it is by " +
+                "far the most expensive section.",
+            values = Section.ALL.map { it.id },
+        )
+        string(
+            "packageName",
+            "Package for the logcat section. Defaults to the open project's application ID. " +
+                "Pass an empty string to read the whole log.",
+        )
+        enumeration(
+            "minLevel",
+            "Minimum logcat level. Defaults to V; use E when hunting a crash.",
+            listOf("V", "D", "I", "W", "E", "F"),
+        )
+        integer("maxLogcatLines", "Logcat lines to include. Defaults to 200, capped at 2000.")
+        integer("maxUiDepth", "How deep to render the UI tree. Defaults to 25.")
+        deviceSerial()
+    }
+
+    override fun execute(arguments: JsonObject, context: ToolContext): ToolResult {
+        val device = context.requireDevice(arguments.optionalString("deviceSerial"))
+        val sections = resolveSections(arguments)
+        if (sections.isEmpty()) {
+            return ToolResult.error(
+                "No known section was requested. 'include' accepts any of: " +
+                    Section.ALL.joinToString { it.id } + ".",
+            )
+        }
+
+        val deadline = System.nanoTime() + BUDGET_SECONDS * NANOS_PER_SECOND
+        val report = StringBuilder("Debug context for ").appendLine(device.info.describe())
+        var screenshot: ToolContent.Image? = null
+
+        sections.forEach { section ->
+            report.append('\n').append("## ").appendLine(section.heading)
+
+            if (System.nanoTime() > deadline) {
+                report.appendLine(
+                    "Skipped: the ${BUDGET_SECONDS}s budget for this call was already spent. " +
+                        "Request fewer sections, or call the individual tool for this one.",
+                )
+                return@forEach
+            }
+
+            val captured = runCatching { capture(section, arguments, context, device) }
+                .getOrElse { failure ->
+                    // An agent can act on "the screen is off"; it cannot act on a stack trace.
+                    Captured(
+                        "Could not capture this section: " +
+                            (failure.message ?: failure::class.java.simpleName),
+                    )
+                }
+            captured.image?.let { screenshot = it }
+            report.appendLine(captured.text)
+        }
+
+        val text = with(McpShell) { report.toString().trimEnd().truncateForAgent(MAX_CHARS) }
+        val content = mutableListOf<ToolContent>(ToolContent.Text(text))
+        screenshot?.let { content += it }
+        return ToolResult(content)
+    }
+
+    private fun capture(
+        section: Section,
+        arguments: JsonObject,
+        context: ToolContext,
+        device: spock.adb.device.ConnectedDevice,
+    ): Captured = when (section) {
+        Section.ACTIVITY -> Captured(textOf(GetCurrentActivityTool().execute(arguments, context)))
+
+        Section.UI -> Captured(renderUi(arguments, device))
+
+        Section.LOGCAT -> {
+            val read = with(LogcatReader) {
+                LogcatReader.read(
+                    device = device.device,
+                    packageName = arguments.logcatPackage(context),
+                    minLevel = arguments.logcatLevel(),
+                    // Deliberately not LogcatReader.logcatMaxLines: that helper reads the
+                    // `maxLines` argument android_get_logcat declares, and this tool's
+                    // argument is `maxLogcatLines` — sharing it would silently ignore the cap.
+                    maxLines = arguments.optionalInt("maxLogcatLines", DEFAULT_LOGCAT_LINES)
+                        .coerceIn(1, MAX_LOGCAT_LINES),
+                )
+            }
+            Captured(read.textOrExplanation())
+        }
+
+        Section.SCREENSHOT -> {
+            val result = TakeScreenshotTool().execute(arguments, context)
+            val image = result.content.filterIsInstance<ToolContent.Image>().firstOrNull()
+            when (image) {
+                null -> Captured(textOf(result).ifBlank { "The screenshot could not be captured." })
+                else -> Captured("Attached as an image alongside this text.", image)
+            }
+        }
+    }
+
+    /**
+     * The framework note is always emitted, never only on failure: an agent that does not know
+     * this screen is Compose without `testTagsAsResourceId` will keep matching on test tags
+     * that cannot exist, and blame the app rather than the opt-in it is missing.
+     */
+    private fun renderUi(arguments: JsonObject, device: spock.adb.device.ConnectedDevice): String {
+        val depth = arguments.optionalInt("maxUiDepth", DEFAULT_UI_DEPTH).coerceIn(1, MAX_UI_DEPTH)
+        val tree = UiTreeReader.read(device.device)
+        return with(UiTreeReader) {
+            val root = tree.root ?: return@with tree.frameworkNote() + "\n\nThe dump contained no UI nodes."
+            tree.frameworkNote() + "\n\n" + root.render(maxDepth = depth)
+        }
+    }
+
+    /** Unknown names are ignored rather than fatal, so a newer client cannot break an older plugin. */
+    private fun resolveSections(arguments: JsonObject): List<Section> {
+        val requested = arguments.optionalStringList("include") ?: return DEFAULT_SECTIONS
+        if (requested.isEmpty()) return DEFAULT_SECTIONS
+        val wanted = requested.map { it.trim().lowercase() }.toSet()
+        return Section.ALL.filter { it.id in wanted }
+    }
+
+    private fun textOf(result: ToolResult): String =
+        result.content.filterIsInstance<ToolContent.Text>()
+            .joinToString("\n") { it.text }
+            .ifBlank { "Nothing was reported." }
+
+    private data class Captured(val text: String, val image: ToolContent.Image? = null)
+
+    /** Ordered as a developer reads a bug report: where am I, what is drawn, what went wrong. */
+    private enum class Section(val id: String, val heading: String) {
+        ACTIVITY("activity", "Current activity"),
+        UI("ui", "UI semantics tree"),
+        LOGCAT("logcat", "Recent logcat"),
+        SCREENSHOT("screenshot", "Screenshot"),
+        ;
+
+        companion object {
+            /**
+             * Listed explicitly rather than via `entries`, whose backing stdlib class is newer
+             * than the one bundled with the oldest supported IDE. See docs/COMPATIBILITY.md.
+             */
+            val ALL: List<Section> = listOf(ACTIVITY, UI, LOGCAT, SCREENSHOT)
+        }
+    }
+
+    private companion object {
+        val DEFAULT_SECTIONS = listOf(Section.ACTIVITY, Section.UI, Section.LOGCAT)
+
+        const val BUDGET_SECONDS = 60L
+        const val NANOS_PER_SECOND = 1_000_000_000L
+
+        const val DEFAULT_LOGCAT_LINES = 200
+        const val MAX_LOGCAT_LINES = 2_000
+        const val DEFAULT_UI_DEPTH = 25
+        const val MAX_UI_DEPTH = 200
+
+        /** This is the heaviest tool in the registry; the bundle still has to fit a context window. */
+        const val MAX_CHARS = 120_000
+    }
+}

--- a/src/main/kotlin/spock/adb/mcp/tools/FileTools.kt
+++ b/src/main/kotlin/spock/adb/mcp/tools/FileTools.kt
@@ -3,6 +3,7 @@ package spock.adb.mcp.tools
 import com.android.ddmlib.IDevice
 import com.google.gson.JsonObject
 import com.intellij.openapi.application.PathManager
+import spock.adb.ShellQuote
 import java.nio.charset.CharacterCodingException
 import java.nio.charset.CodingErrorAction
 import java.nio.charset.StandardCharsets
@@ -42,6 +43,42 @@ internal object DevicePaths {
     }
 }
 
+/**
+ * Which files on the *developer's machine* an agent may read.
+ *
+ * [DevicePaths] guards the device side, and this is its mirror. Without it the two transfer
+ * tools compose into an arbitrary local read: push `~/.ssh/id_rsa` to `/sdcard`, pull it back,
+ * and a file the agent could never open directly arrives in its context — neither call asking
+ * the developer anything, because neither is destructive on its own.
+ *
+ * `PullFileTool` already refuses a caller-chosen *destination* for exactly this reason. Leaving
+ * the source unrestricted granted the read half of the same power the write half was denied.
+ */
+internal object LocalPaths {
+
+    /**
+     * @param roots directories the file may live under. Resolved to real paths before
+     *   comparison, so a symlink or a `..` inside an allowed root cannot point outside it —
+     *   a textual prefix check is not enough here, unlike on the device where paths are opaque.
+     * @throws IllegalArgumentException naming the directories that are allowed.
+     */
+    fun validate(path: Path, roots: List<Path>): Path {
+        val real = runCatching { path.toRealPath() }.getOrElse {
+            throw IllegalArgumentException("'$path' could not be resolved on this machine.")
+        }
+        val realRoots = roots.mapNotNull { runCatching { it.toRealPath() }.getOrNull() }
+        require(realRoots.any { real.startsWith(it) }) {
+            "'$path' is outside the directories this tool may read (" +
+                (realRoots.joinToString().ifBlank { "none are available" }) + "). Reading any " +
+                "file on the developer's machine is not a debugging operation: pushed to a " +
+                "device it can be pulled straight back, so this would hand over private keys " +
+                "and credentials as readily as a test fixture. Move the file into one of those " +
+                "directories, or use android_run_adb_command, which asks the developer first."
+        }
+        return real
+    }
+}
+
 /** Files pulled off a device land here, never at a path the caller chose. */
 internal fun defaultPullDirectory(): Path = runCatching {
     Path.of(PathManager.getConfigPath(), "spock-adb", "pulls")
@@ -50,20 +87,34 @@ internal fun defaultPullDirectory(): Path = runCatching {
 /** Shared cap. Big enough for a database or a three-minute recording, small enough to notice. */
 internal const val MAX_TRANSFER_BYTES = 50L * 1024 * 1024
 
-/** `android_push_file` — put a local file onto the device. */
-class PushFileTool : AdbTool {
+/**
+ * `android_push_file` — put a local file onto the device.
+ *
+ * @param transferDirectory injectable for the same reason [PullFileTool] takes one: the
+ *   allowed source roots are part of what this tool refuses to do, and a test that cannot
+ *   choose them cannot check the refusal.
+ */
+class PushFileTool(
+    private val transferDirectory: () -> Path = ::defaultPullDirectory,
+) : AdbTool {
 
     override val name = "android_push_file"
 
     override val description =
         "Copy a file from this machine onto the device, for example a test fixture, a " +
             "seeded database or a config file. The destination must be under /sdcard, " +
-            "/storage or /data/local/tmp."
+            "/storage or /data/local/tmp, and the source must be inside the open project or " +
+            "the IDE's Spock ADB pull directory."
 
     override val safety = ToolSafety.SAFE_ACTION
 
     override val inputSchema: JsonObject = Schema.obj {
-        string("localPath", "Absolute path of the file on this machine.", required = true)
+        string(
+            "localPath",
+            "Absolute path of the file on this machine, inside the open project or the " +
+                "IDE's Spock ADB pull directory.",
+            required = true,
+        )
         string(
             "remotePath",
             "Absolute destination on the device, under /sdcard, /storage or /data/local/tmp.",
@@ -75,11 +126,12 @@ class PushFileTool : AdbTool {
     override fun execute(arguments: JsonObject, context: ToolContext): ToolResult {
         val device = context.requireIDevice(arguments.optionalString("deviceSerial"))
         val remotePath = DevicePaths.validate(arguments.requiredString("remotePath"))
-        val local = Path.of(arguments.requiredString("localPath"))
+        val given = Path.of(arguments.requiredString("localPath"))
 
-        if (!Files.isRegularFile(local)) {
-            return ToolResult.error("'$local' is not a file on this machine.")
+        if (!Files.isRegularFile(given)) {
+            return ToolResult.error("'$given' is not a file on this machine.")
         }
+        val local = LocalPaths.validate(given, allowedSourceRoots(context))
         val size = Files.size(local)
         if (size > MAX_TRANSFER_BYTES) {
             return ToolResult.error(
@@ -90,6 +142,19 @@ class PushFileTool : AdbTool {
         device.pushFile(local.toAbsolutePath().toString(), remotePath)
         return ToolResult.text("Pushed $size bytes to $remotePath.")
     }
+
+    /**
+     * The open project, and the directory pulls land in.
+     *
+     * The project is where fixtures actually live, and the pull directory makes
+     * pull-edit-push work and doubles as the drop-box for anything else. Both are places the
+     * developer has already put material in front of the IDE; the rest of the filesystem has
+     * not been.
+     */
+    private fun allowedSourceRoots(context: ToolContext): List<Path> = listOfNotNull(
+        runCatching { transferDirectory() }.getOrNull(),
+        context.project?.basePath?.let { runCatching { Path.of(it) }.getOrNull() },
+    )
 }
 
 /**
@@ -150,15 +215,35 @@ class PullFileTool(
         // Resolved, not created: createTempFile would make the file itself, and then the
         // "did the device actually send anything" check below could never fail.
         val staging = directory.resolve("pull-" + java.util.UUID.randomUUID() + ".part")
+        // Asked before transferring, so an oversized file is refused rather than written and
+        // then deleted. Best effort: a device without `stat` leaves this null, and the check
+        // after the transfer is what actually guarantees the cap.
+        remoteSizeOf(device, remotePath)?.let { remote -> requireWithinCap(remotePath, remote) }
+
         try {
             device.pullFile(remotePath, staging.toString())
             check(Files.exists(staging)) { "The device returned no file for '$remotePath'." }
+            requireWithinCap(remotePath, Files.size(staging))
             Files.move(staging, destination, StandardCopyOption.REPLACE_EXISTING)
         } finally {
+            // Also removes an oversized transfer: the check above throws while staging still
+            // holds it, and nothing over the cap is kept.
             Files.deleteIfExists(staging)
         }
         return destination
     }
+
+    private fun requireWithinCap(remotePath: String, size: Long) {
+        require(size <= MAX_TRANSFER_BYTES) {
+            "'$remotePath' is $size bytes, over the ${MAX_TRANSFER_BYTES}-byte transfer limit. " +
+                "Narrow it on the device first — for a recording, a shorter --time-limit."
+        }
+    }
+
+    /** The device's own answer, or null when it cannot give one. */
+    private fun remoteSizeOf(device: IDevice, remotePath: String): Long? = runCatching {
+        McpShell.run(device, "stat -c %s " + ShellQuote.quote(remotePath)).trim().toLong()
+    }.getOrNull()
 
     /** Keeps the remote basename when it is safe, so a pulled file is recognisable. */
     private fun localNameFor(remotePath: String): String {

--- a/src/main/kotlin/spock/adb/mcp/tools/FileTools.kt
+++ b/src/main/kotlin/spock/adb/mcp/tools/FileTools.kt
@@ -1,0 +1,193 @@
+package spock.adb.mcp.tools
+
+import com.android.ddmlib.IDevice
+import com.google.gson.JsonObject
+import com.intellij.openapi.application.PathManager
+import java.nio.charset.CharacterCodingException
+import java.nio.charset.CodingErrorAction
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+
+/**
+ * Where on the device an agent may read and write.
+ *
+ * Deliberately stricter than `adb` itself. `adb pull` will happily hand over anything the
+ * shell user can read, and an agent that can be talked into pulling `/data/data/<someone
+ * else>/databases` is an exfiltration path wearing a debugging tool's clothes. The three
+ * prefixes below are where developer artefacts actually live — screen recordings, exported
+ * databases, test fixtures — and `android_run_adb_command` remains as the escape hatch for
+ * anything else, where it is gated behind a per-call confirmation.
+ */
+internal object DevicePaths {
+
+    private val ALLOWED_PREFIXES = listOf("/sdcard/", "/storage/", "/data/local/tmp/")
+
+    /** @throws IllegalArgumentException with a message naming what *is* allowed. */
+    fun validate(path: String): String {
+        require(path.startsWith("/")) {
+            "'$path' must be an absolute device path, starting with '/'."
+        }
+        require(".." !in path.split("/")) {
+            "'$path' must not contain '..'. Give the full path instead."
+        }
+        require(ALLOWED_PREFIXES.any { path.startsWith(it) }) {
+            "'$path' is outside the paths this tool may touch (" +
+                ALLOWED_PREFIXES.joinToString() + "). This is deliberately stricter than adb: " +
+                "other apps' private storage is not a debugging artefact. If you genuinely need " +
+                "it, use android_run_adb_command, which asks the developer first."
+        }
+        return path
+    }
+}
+
+/** Files pulled off a device land here, never at a path the caller chose. */
+internal fun defaultPullDirectory(): Path = runCatching {
+    Path.of(PathManager.getConfigPath(), "spock-adb", "pulls")
+}.getOrElse { Path.of(System.getProperty("java.io.tmpdir"), "spock-adb-pulls") }
+
+/** Shared cap. Big enough for a database or a three-minute recording, small enough to notice. */
+internal const val MAX_TRANSFER_BYTES = 50L * 1024 * 1024
+
+/** `android_push_file` — put a local file onto the device. */
+class PushFileTool : AdbTool {
+
+    override val name = "android_push_file"
+
+    override val description =
+        "Copy a file from this machine onto the device, for example a test fixture, a " +
+            "seeded database or a config file. The destination must be under /sdcard, " +
+            "/storage or /data/local/tmp."
+
+    override val safety = ToolSafety.SAFE_ACTION
+
+    override val inputSchema: JsonObject = Schema.obj {
+        string("localPath", "Absolute path of the file on this machine.", required = true)
+        string(
+            "remotePath",
+            "Absolute destination on the device, under /sdcard, /storage or /data/local/tmp.",
+            required = true,
+        )
+        deviceSerial()
+    }
+
+    override fun execute(arguments: JsonObject, context: ToolContext): ToolResult {
+        val device = context.requireIDevice(arguments.optionalString("deviceSerial"))
+        val remotePath = DevicePaths.validate(arguments.requiredString("remotePath"))
+        val local = Path.of(arguments.requiredString("localPath"))
+
+        if (!Files.isRegularFile(local)) {
+            return ToolResult.error("'$local' is not a file on this machine.")
+        }
+        val size = Files.size(local)
+        if (size > MAX_TRANSFER_BYTES) {
+            return ToolResult.error(
+                "'$local' is $size bytes, over the ${MAX_TRANSFER_BYTES}-byte transfer limit.",
+            )
+        }
+
+        device.pushFile(local.toAbsolutePath().toString(), remotePath)
+        return ToolResult.text("Pushed $size bytes to $remotePath.")
+    }
+}
+
+/**
+ * `android_pull_file` — bring a file off the device.
+ *
+ * The local destination is **not** a parameter. A tool that writes to a path its caller chose
+ * lets anything holding the MCP token drop a file anywhere on the developer's filesystem, and
+ * no debugging workflow needs that; pulls land in one known directory and the tool reports
+ * where.
+ */
+class PullFileTool(
+    private val destinationDirectory: () -> Path = ::defaultPullDirectory,
+) : AdbTool {
+
+    override val name = "android_pull_file"
+
+    override val description =
+        "Copy a file off the device — a screen recording, an exported database, a log — into " +
+            "the IDE's own pull directory, and report where it landed. The source must be " +
+            "under /sdcard, /storage or /data/local/tmp. Small text files are also returned " +
+            "inline so you can read them without a second call."
+
+    override val safety = ToolSafety.SAFE_ACTION
+
+    override val inputSchema: JsonObject = Schema.obj {
+        string(
+            "remotePath",
+            "Absolute path on the device, under /sdcard, /storage or /data/local/tmp.",
+            required = true,
+        )
+        deviceSerial()
+    }
+
+    override fun execute(arguments: JsonObject, context: ToolContext): ToolResult {
+        val device = context.requireIDevice(arguments.optionalString("deviceSerial"))
+        val remotePath = DevicePaths.validate(arguments.requiredString("remotePath"))
+
+        val local = pull(device, remotePath)
+        val size = Files.size(local)
+
+        return ToolResult.text(
+            buildString {
+                append("Pulled ").append(size).append(" bytes from ").append(remotePath)
+                append(" to ").append(local).append('.')
+                inlineTextOf(local, size)?.let { append("\n\nContents:\n").append(it) }
+            },
+        )
+    }
+
+    /** @throws IllegalStateException when the device produced nothing, which ddmlib reports as success. */
+    private fun pull(device: IDevice, remotePath: String): Path {
+        val directory = destinationDirectory()
+        Files.createDirectories(directory)
+
+        // Pull to a temporary neighbour and move into place, so a failed transfer cannot leave
+        // a half-written file behind under the name of a previous good one.
+        val destination = directory.resolve(localNameFor(remotePath))
+        // Resolved, not created: createTempFile would make the file itself, and then the
+        // "did the device actually send anything" check below could never fail.
+        val staging = directory.resolve("pull-" + java.util.UUID.randomUUID() + ".part")
+        try {
+            device.pullFile(remotePath, staging.toString())
+            check(Files.exists(staging)) { "The device returned no file for '$remotePath'." }
+            Files.move(staging, destination, StandardCopyOption.REPLACE_EXISTING)
+        } finally {
+            Files.deleteIfExists(staging)
+        }
+        return destination
+    }
+
+    /** Keeps the remote basename when it is safe, so a pulled file is recognisable. */
+    private fun localNameFor(remotePath: String): String {
+        val base = remotePath.trimEnd('/').substringAfterLast('/')
+        val safe = base.filter { it.isLetterOrDigit() || it in "._-" }
+        return safe.ifBlank { "pulled-file" }
+    }
+
+    /**
+     * The file's text, when it is small and actually text.
+     *
+     * Strict decoding rather than a byte sniff: a `.db` whose first bytes happen to be ASCII
+     * would otherwise come back as mojibake that an agent would try to reason about.
+     */
+    private fun inlineTextOf(local: Path, size: Long): String? {
+        if (size > MAX_INLINE_BYTES) return null
+        val decoder = StandardCharsets.UTF_8.newDecoder()
+            .onMalformedInput(CodingErrorAction.REPORT)
+            .onUnmappableCharacter(CodingErrorAction.REPORT)
+        val bytes = Files.readAllBytes(local)
+        if (bytes.any { it == 0.toByte() }) return null
+        return try {
+            decoder.decode(java.nio.ByteBuffer.wrap(bytes)).toString()
+        } catch (_: CharacterCodingException) {
+            null
+        }
+    }
+
+    private companion object {
+        const val MAX_INLINE_BYTES = 64L * 1024
+    }
+}

--- a/src/main/kotlin/spock/adb/mcp/tools/InspectionTools.kt
+++ b/src/main/kotlin/spock/adb/mcp/tools/InspectionTools.kt
@@ -1,5 +1,6 @@
 package spock.adb.mcp.tools
 
+import com.android.ddmlib.IDevice
 import com.google.gson.JsonObject
 import spock.adb.ShellQuote
 import spock.adb.command.GetActivityCommand
@@ -96,6 +97,63 @@ class GetCurrentFragmentsTool : AdbTool {
     }
 }
 
+/**
+ * Reading logcat, shared by `android_get_logcat` and `android_get_debug_context`.
+ *
+ * Filtering by PID rather than by text lives here so both callers inherit it: matching a
+ * package name against message content both misses lines the app wrote under another tag and
+ * returns unrelated lines that merely mention it.
+ */
+internal object LogcatReader {
+
+    const val DEFAULT_MAX_LINES = 300
+    const val MAX_LINES = 5_000
+
+    /** @param packageName null reads the whole log; otherwise only that package's processes. */
+    fun read(device: IDevice, packageName: String?, minLevel: String, maxLines: Int): Read {
+        val pids = packageName
+            ?.let { McpShell.run(device, "pidof ${ShellQuote.quote(it)}").trim() }
+            ?.split(Regex("\\s+"))
+            ?.filter { it.isNotBlank() }
+            .orEmpty()
+
+        val command = buildString {
+            append("logcat -d -v threadtime -t ").append(maxLines)
+            pids.forEach { append(" --pid=").append(it) }
+            append(" *:").append(minLevel)
+        }
+        return Read(
+            output = McpShell.run(device, command),
+            filteredByPackage = packageName != null,
+            pidCount = pids.size,
+        )
+    }
+
+    data class Read(val output: String, val filteredByPackage: Boolean, val pidCount: Int) {
+
+        /** Why nothing came back, which is not always an error worth alarming the agent with. */
+        val emptyExplanation: String
+            get() = when {
+                filteredByPackage && pidCount == 0 ->
+                    "No matching log lines. The app may not be running — no process was found for it."
+                else -> "Logcat returned nothing."
+            }
+
+        fun textOrExplanation(): String = output.ifBlank { emptyExplanation }
+    }
+
+    /** Absent `packageName` means the open project's app; an explicit empty string means all. */
+    fun JsonObject.logcatPackage(context: ToolContext): String? {
+        if (has("packageName") && optionalString("packageName") == null) return null
+        return optionalString("packageName") ?: context.projectApplicationId()
+    }
+
+    fun JsonObject.logcatLevel(): String = optionalString("minLevel")?.uppercase() ?: "V"
+
+    fun JsonObject.logcatMaxLines(default: Int = DEFAULT_MAX_LINES): Int =
+        optionalInt("maxLines", default).coerceIn(1, MAX_LINES)
+}
+
 /** `android_get_logcat` — recent log, filtered. */
 class GetLogcatTool : AdbTool {
     override val name = "android_get_logcat"
@@ -116,42 +174,15 @@ class GetLogcatTool : AdbTool {
 
     override fun execute(arguments: JsonObject, context: ToolContext): ToolResult {
         val device = context.requireIDevice(arguments.optionalString("deviceSerial"))
-        val maxLines = arguments.optionalInt("maxLines", DEFAULT_MAX_LINES).coerceIn(1, MAX_LINES)
-        val level = arguments.optionalString("minLevel")?.uppercase() ?: "V"
-
-        // Filter by PID rather than by text: matching the package name against message
-        // content both misses lines and returns unrelated ones.
-        val pids = arguments.resolveLogcatPackage(context)
-            ?.let { pkg -> McpShell.run(device, "pidof ${ShellQuote.quote(pkg)}").trim() }
-            ?.split(Regex("\\s+"))
-            ?.filter { it.isNotBlank() }
-            .orEmpty()
-
-        val command = buildString {
-            append("logcat -d -v threadtime -t ").append(maxLines)
-            pids.forEach { append(" --pid=").append(it) }
-            append(" *:").append(level)
-        }
-
-        val output = McpShell.run(device, command)
-        return when {
-            output.isBlank() && pids.isEmpty() -> ToolResult.text("Logcat returned nothing.")
-            output.isBlank() -> ToolResult.text(
-                "No matching log lines. The app may not be running — no process was found for it.",
+        val read = with(LogcatReader) {
+            LogcatReader.read(
+                device = device,
+                packageName = arguments.logcatPackage(context),
+                minLevel = arguments.logcatLevel(),
+                maxLines = arguments.logcatMaxLines(),
             )
-            else -> ToolResult.text(output)
         }
-    }
-
-    private fun JsonObject.resolveLogcatPackage(context: ToolContext): String? {
-        // An explicit empty string is a deliberate "whole log" request.
-        if (has("packageName") && optionalString("packageName") == null) return null
-        return optionalString("packageName") ?: context.projectApplicationId()
-    }
-
-    private companion object {
-        const val DEFAULT_MAX_LINES = 300
-        const val MAX_LINES = 5_000
+        return ToolResult.text(read.textOrExplanation())
     }
 }
 

--- a/src/main/kotlin/spock/adb/mcp/tools/InspectionTools.kt
+++ b/src/main/kotlin/spock/adb/mcp/tools/InspectionTools.kt
@@ -18,8 +18,7 @@ class GetCurrentActivityTool : AdbTool {
 
     override fun execute(arguments: JsonObject, context: ToolContext): ToolResult {
         val device = context.requireDevice(arguments.optionalString("deviceSerial"))
-        val project = context.project
-            ?: return ToolResult.error("No project is open, which this tool needs to run.")
+        val project = context.requireProject()
 
         val activity = GetActivityCommand().execute(Any(), project, device.device)
             ?: return ToolResult.error(
@@ -40,8 +39,7 @@ class GetActivityStackTool : AdbTool {
 
     override fun execute(arguments: JsonObject, context: ToolContext): ToolResult {
         val device = context.requireDevice(arguments.optionalString("deviceSerial"))
-        val project = context.project
-            ?: return ToolResult.error("No project is open, which this tool needs to run.")
+        val project = context.requireProject()
 
         val stack = GetBackStackCommand().execute(Any(), project, device.device)
         if (stack.isEmpty()) return ToolResult.text("The activity stack is empty.")
@@ -73,8 +71,7 @@ class GetCurrentFragmentsTool : AdbTool {
 
     override fun execute(arguments: JsonObject, context: ToolContext): ToolResult {
         val device = context.requireDevice(arguments.optionalString("deviceSerial"))
-        val project = context.project
-            ?: return ToolResult.error("No project is open, which this tool needs to run.")
+        val project = context.requireProject()
 
         val fragments = GetFragmentsCommand().execute(
             context.resolvePackage(arguments),

--- a/src/main/kotlin/spock/adb/mcp/tools/Schema.kt
+++ b/src/main/kotlin/spock/adb/mcp/tools/Schema.kt
@@ -30,6 +30,31 @@ object Schema {
         fun boolean(name: String, description: String, required: Boolean = false) =
             property(name, "boolean", description, required)
 
+        /**
+     * An array of strings, optionally constrained to a fixed set.
+     *
+     * Declared here rather than hand-written per tool so the "which sections do you want"
+     * shape used by android_get_debug_context stays consistent with the rest of the schema.
+     */
+        fun stringArray(
+            name: String,
+            description: String,
+            values: List<String>? = null,
+            required: Boolean = false,
+        ) {
+            val items = JsonObject().apply {
+                addProperty("type", "string")
+                values?.let { allowed -> add("enum", JsonArray().also { node -> allowed.forEach(node::add) }) }
+            }
+            val node = JsonObject().apply {
+                addProperty("type", "array")
+                addProperty("description", description)
+                add("items", items)
+            }
+            properties.add(name, node)
+            if (required) this.required.add(name)
+        }
+
         fun enumeration(name: String, description: String, values: List<String>, required: Boolean = false) {
             val node = JsonObject().apply {
                 addProperty("type", "string")
@@ -78,3 +103,15 @@ fun JsonObject.optionalInt(name: String, default: Int): Int =
 
 fun JsonObject.optionalBoolean(name: String, default: Boolean): Boolean =
     get(name)?.takeIf { !it.isJsonNull }?.asBoolean ?: default
+
+/**
+ * A string array argument, tolerating the single bare string clients sometimes send where an
+ * array is declared. Returns null when the caller said nothing, so a tool can tell "omitted"
+ * from "explicitly empty".
+ */
+fun JsonObject.optionalStringList(name: String): List<String>? {
+    val element = get(name)?.takeIf { !it.isJsonNull } ?: return null
+    if (element.isJsonPrimitive) return listOf(element.asString)
+    if (!element.isJsonArray) return null
+    return element.asJsonArray.mapNotNull { it.takeIf { item -> !item.isJsonNull }?.asString }
+}

--- a/src/main/kotlin/spock/adb/mcp/tools/ScreenRecordTools.kt
+++ b/src/main/kotlin/spock/adb/mcp/tools/ScreenRecordTools.kt
@@ -43,8 +43,16 @@ internal object ScreenRecorder {
 
     /** @throws IllegalStateException when a recording is already running on this device. */
     fun start(device: IDevice, serial: String, timeLimitSeconds: Int): Session {
-        // A session whose time limit already elapsed is over, not in the way.
-        sessions[serial]?.takeIf { it.finished }?.let { sessions.remove(serial, it) }
+        // A session whose time limit already elapsed is over, not in the way — but its
+        // recording is still sitting on the device, and now that the session is gone nothing
+        // will ever pull it. Dropping the session without the file leaves one abandoned mp4
+        // per expired recording, which is the accumulation the rm -f after a pull exists to
+        // prevent.
+        sessions[serial]?.takeIf { it.finished }?.let { expired ->
+            if (sessions.remove(serial, expired)) {
+                runCatching { McpShell.run(device, "rm -f " + ShellQuote.quote(expired.remotePath)) }
+            }
+        }
 
         val session = Session(
             serial = serial,

--- a/src/main/kotlin/spock/adb/mcp/tools/ScreenRecordTools.kt
+++ b/src/main/kotlin/spock/adb/mcp/tools/ScreenRecordTools.kt
@@ -1,0 +1,177 @@
+package spock.adb.mcp.tools
+
+import com.android.ddmlib.IDevice
+import com.google.gson.JsonObject
+import spock.adb.ShellQuote
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Screen recording, one session per device.
+ *
+ * Recording goes through `executeShellCommand("screenrecord …")` rather than
+ * `IDevice.startScreenRecorder`, which Android Studio does not implement — it throws "This
+ * method is not used in Android Studio", the same way `getScreenshot` did before the
+ * screenshot tool was rewritten. `StubbedIDeviceApiTest` fails the build if anyone reaches
+ * for it again.
+ *
+ * `screenrecord` blocks until it stops, so the call runs on its own thread rather than a
+ * pooled one: occupying a shared pool thread for three minutes is not what that pool is for.
+ */
+internal object ScreenRecorder {
+
+    /** The platform's own hard cap. `screenrecord` stops itself here whatever we ask for. */
+    const val MAX_SECONDS = 180
+    const val DEFAULT_SECONDS = 180
+
+    private const val SHELL_SLACK_SECONDS = 30L
+    private const val FINALISE_TIMEOUT_MS = 15_000L
+    private const val MILLIS_PER_SECOND = 1_000L
+
+    private val sessions = ConcurrentHashMap<String, Session>()
+
+    class Session(val serial: String, val remotePath: String, val timeLimitSeconds: Int) {
+        val startedAt: Long = System.currentTimeMillis()
+
+        @Volatile
+        var thread: Thread? = null
+
+        @Volatile
+        var finished: Boolean = false
+
+        val elapsedSeconds: Long get() = (System.currentTimeMillis() - startedAt) / MILLIS_PER_SECOND
+    }
+
+    /** @throws IllegalStateException when a recording is already running on this device. */
+    fun start(device: IDevice, serial: String, timeLimitSeconds: Int): Session {
+        // A session whose time limit already elapsed is over, not in the way.
+        sessions[serial]?.takeIf { it.finished }?.let { sessions.remove(serial, it) }
+
+        val session = Session(
+            serial = serial,
+            remotePath = "/sdcard/spock-adb-recording-${System.currentTimeMillis()}.mp4",
+            timeLimitSeconds = timeLimitSeconds.coerceIn(1, MAX_SECONDS),
+        )
+        val existing = sessions.putIfAbsent(serial, session)
+        check(existing == null) {
+            "A recording has been running on $serial for ${existing?.elapsedSeconds}s " +
+                "(${existing?.remotePath}). Call android_stop_screen_recording first."
+        }
+
+        val command = "screenrecord --time-limit ${session.timeLimitSeconds} " +
+            ShellQuote.quote(session.remotePath)
+        session.thread = Thread({
+            try {
+                McpShell.run(
+                    device = device,
+                    command = command,
+                    timeoutSeconds = session.timeLimitSeconds + SHELL_SLACK_SECONDS,
+                )
+            } finally {
+                session.finished = true
+            }
+        }, "spock-adb-screenrecord-$serial").apply {
+            isDaemon = true
+            start()
+        }
+        return session
+    }
+
+    /** @throws IllegalStateException when nothing is recording on this device. */
+    fun stop(device: IDevice, serial: String): Session {
+        val session = sessions.remove(serial)
+            ?: error("No recording is running on $serial. Call android_start_screen_recording first.")
+
+        // SIGINT, not SIGKILL: screenrecord writes the MP4 container's index on the way out,
+        // and a killed recording leaves a file no player will open.
+        runCatching { McpShell.run(device, "pkill -INT screenrecord || killall -INT screenrecord") }
+        session.thread?.join(FINALISE_TIMEOUT_MS)
+        return session
+    }
+
+    fun active(serial: String): Session? = sessions[serial]?.takeIf { !it.finished }
+
+    /** Test seam: sessions outlive a single tool instance, so they must be resettable. */
+    fun reset() = sessions.clear()
+}
+
+/** `android_start_screen_recording` — begin capturing the screen. */
+class StartScreenRecordTool : AdbTool {
+
+    override val name = "android_start_screen_recording"
+
+    override val description =
+        "Start recording the device screen to a file on the device. Stop it with " +
+            "android_stop_screen_recording, which retrieves the video. Recording captures " +
+            "whatever is on screen, including notifications and any personal content, so ask " +
+            "before recording anything you were not asked to record. The platform stops the " +
+            "recording after three minutes whatever limit you set."
+
+    override val safety = ToolSafety.SAFE_ACTION
+
+    override val inputSchema: JsonObject = Schema.obj {
+        integer(
+            "timeLimitSeconds",
+            "Stop automatically after this many seconds. Defaults to 180, which is also the " +
+                "platform's hard maximum.",
+        )
+        deviceSerial()
+    }
+
+    override fun execute(arguments: JsonObject, context: ToolContext): ToolResult {
+        val device = context.requireDevice(arguments.optionalString("deviceSerial"))
+        val limit = arguments.optionalInt("timeLimitSeconds", ScreenRecorder.DEFAULT_SECONDS)
+
+        val session = ScreenRecorder.start(device.device, device.serialNumber, limit)
+        return ToolResult.text(
+            "Recording ${device.info.describe()} to ${session.remotePath}, stopping after " +
+                "${session.timeLimitSeconds}s. Call android_stop_screen_recording to end it " +
+                "and retrieve the file.",
+        )
+    }
+}
+
+/** `android_stop_screen_recording` — end the capture and bring the video back. */
+class StopScreenRecordTool(
+    private val pullFileTool: PullFileTool = PullFileTool(),
+) : AdbTool {
+
+    override val name = "android_stop_screen_recording"
+
+    override val description =
+        "Stop the recording started with android_start_screen_recording, copy the video off " +
+            "the device into the IDE's pull directory, and report where it landed. The file " +
+            "is removed from the device afterwards."
+
+    override val safety = ToolSafety.SAFE_ACTION
+
+    override val inputSchema: JsonObject = Schema.obj { deviceSerial() }
+
+    override fun execute(arguments: JsonObject, context: ToolContext): ToolResult {
+        val device = context.requireDevice(arguments.optionalString("deviceSerial"))
+        val session = ScreenRecorder.stop(device.device, device.serialNumber)
+
+        val pulled = pullFileTool.execute(
+            JsonObject().apply {
+                addProperty("remotePath", session.remotePath)
+                arguments.optionalString("deviceSerial")?.let { addProperty("deviceSerial", it) }
+            },
+            context,
+        )
+
+        // Leaving recordings on the device fills /sdcard a few hundred megabytes at a time,
+        // but only delete once the pull actually succeeded.
+        if (!pulled.isError) {
+            runCatching {
+                McpShell.run(device.device, "rm -f ${ShellQuote.quote(session.remotePath)}")
+            }
+        }
+
+        val detail = pulled.content.filterIsInstance<ToolContent.Text>().joinToString("\n") { it.text }
+        return ToolResult(
+            content = listOf(
+                ToolContent.Text("Recorded ${session.elapsedSeconds}s on ${device.info.describe()}.\n$detail"),
+            ),
+            isError = pulled.isError,
+        )
+    }
+}

--- a/src/main/kotlin/spock/adb/mcp/tools/SelectProjectTool.kt
+++ b/src/main/kotlin/spock/adb/mcp/tools/SelectProjectTool.kt
@@ -26,7 +26,8 @@ class SelectProjectTool : AdbTool {
     override val inputSchema: JsonObject = Schema.obj {
         string(
             "projectName",
-            "Name of the open project, as listed in the ambiguity error.",
+            "The open project to target. Pass one of the entries from the ambiguity error " +
+                "exactly as written; its name or its full path on their own are accepted too.",
             required = true,
         )
     }

--- a/src/main/kotlin/spock/adb/mcp/tools/SelectProjectTool.kt
+++ b/src/main/kotlin/spock/adb/mcp/tools/SelectProjectTool.kt
@@ -1,0 +1,46 @@
+package spock.adb.mcp.tools
+
+import com.google.gson.JsonObject
+
+/**
+ * `android_select_project` — says which open project later calls are about.
+ *
+ * An MCP client connects to the IDE, not to a project. With one project open there is
+ * nothing to choose and this tool is never needed. With several, the application ID, the
+ * sources an Activity resolves against and the default logcat filter all differ, so the
+ * plugin refuses to guess and asks which — exactly as `android_select_device` does when
+ * several devices are attached.
+ */
+class SelectProjectTool : AdbTool {
+
+    override val name = "android_select_project"
+
+    override val description =
+        "Select which open project later calls are about, for an IDE with more than one " +
+            "project open. Only needed when a tool reports that the project is ambiguous — " +
+            "that error lists the names to choose from. With a single project open, every " +
+            "tool already targets it and this call is unnecessary."
+
+    override val safety = ToolSafety.SAFE_ACTION
+
+    override val inputSchema: JsonObject = Schema.obj {
+        string(
+            "projectName",
+            "Name of the open project, as listed in the ambiguity error.",
+            required = true,
+        )
+    }
+
+    override fun execute(arguments: JsonObject, context: ToolContext): ToolResult {
+        val selected = context.selectProject(arguments.requiredString("projectName"))
+
+        // Report the application ID too: it is the thing the selection actually changes, so
+        // the agent can see immediately whether it picked the project it meant.
+        val applicationId = context.projectApplicationId()
+        return ToolResult.text(
+            "Selected project '$selected'. Later calls target it.\n" +
+                "application id: " +
+                (applicationId ?: "could not be resolved yet — let Gradle sync finish."),
+        )
+    }
+}

--- a/src/main/kotlin/spock/adb/mcp/tools/ToolContext.kt
+++ b/src/main/kotlin/spock/adb/mcp/tools/ToolContext.kt
@@ -13,7 +13,13 @@ import spock.adb.device.ConnectedDevice
  */
 interface ToolContext {
 
-    /** The project whose Android module supplies the application ID, if one is open. */
+    /**
+     * The project whose Android module supplies the application ID, if one can be chosen.
+     *
+     * Null both when nothing is open and when several projects are open and none has been
+     * selected. Prefer [requireProject] where the difference matters: a null cannot tell the
+     * agent which of the two problems it has, and they have different fixes.
+     */
     val project: Project?
 
     /** All devices ADB currently reports, with metadata already resolved. */
@@ -31,6 +37,25 @@ interface ToolContext {
 
     /** Persists the agent's device choice for subsequent calls. */
     fun selectDevice(serial: String): ConnectedDevice
+
+    /**
+     * The project this call is about, or an explanation of why one could not be chosen.
+     *
+     * @throws IllegalStateException with a message the agent can act on — open a project, or
+     *   call `android_select_project` and name one of the projects the message lists.
+     */
+    fun requireProject(): Project = project ?: error(
+        "No project is open, which this tool needs to run. Open the Android project in the " +
+            "IDE and let Gradle sync finish.",
+    )
+
+    /**
+     * Pins the project later calls resolve against, the way [selectDevice] pins the device.
+     *
+     * @return the name of the project that was selected.
+     * @throws IllegalStateException when no open project matches [name].
+     */
+    fun selectProject(name: String): String
 
     /**
      * Asks the developer to approve a [ToolSafety.DESTRUCTIVE] call.

--- a/src/main/kotlin/spock/adb/mcp/tools/ToolRegistry.kt
+++ b/src/main/kotlin/spock/adb/mcp/tools/ToolRegistry.kt
@@ -32,6 +32,8 @@ object ToolRegistry {
         GetProcessesTool(),
         GetBatteryInfoTool(),
         GetNetworkInfoTool(),
+        // The triage bundle: one round-trip instead of four, all describing the same moment.
+        DebugContextTool(),
         // UI inspection — semantics-first, so it covers Views, Compose and hybrid screens
         TakeScreenshotTool(),
         GetUiTreeTool(),

--- a/src/main/kotlin/spock/adb/mcp/tools/ToolRegistry.kt
+++ b/src/main/kotlin/spock/adb/mcp/tools/ToolRegistry.kt
@@ -14,6 +14,8 @@ object ToolRegistry {
         ListDevicesTool(),
         GetDeviceInfoTool(),
         SelectDeviceTool(),
+        // Which open project a call is about, for an IDE with more than one open
+        SelectProjectTool(),
         // Applications
         ListPackagesTool(),
         GetPackageInfoTool(),

--- a/src/main/kotlin/spock/adb/mcp/tools/ToolRegistry.kt
+++ b/src/main/kotlin/spock/adb/mcp/tools/ToolRegistry.kt
@@ -54,6 +54,11 @@ object ToolRegistry {
         TapTool(),
         SwipeTool(),
         PressKeyTool(),
+        // Moving files and video off the device, within a deliberately narrow path allow-list
+        PushFileTool(),
+        PullFileTool(),
+        StartScreenRecordTool(),
+        StopScreenRecordTool(),
         // Escape hatch
         RunAdbCommandTool(),
     )

--- a/src/test/kotlin/spock/adb/StubbedIDeviceApiTest.kt
+++ b/src/test/kotlin/spock/adb/StubbedIDeviceApiTest.kt
@@ -80,7 +80,7 @@ class StubbedIDeviceApiTest {
 
     private fun disassemble(classes: List<File>): String {
         if (classes.isEmpty()) return ""
-        val javap = File(System.getProperty("java.home"), "bin/javap")
+        val javap = File(System.getProperty("java.home"), "bin/$JAVAP")
         val process = ProcessBuilder(listOf(javap.absolutePath, "-p", "-c") + classes.map { it.absolutePath })
             .redirectErrorStream(true)
             .start()
@@ -100,6 +100,9 @@ class StubbedIDeviceApiTest {
 
     private companion object {
         const val CLASS_DIR = "build/classes/kotlin/main"
+
+        /** `bin/javap` does not exist on Windows, and this guard has to run wherever CI does. */
+        val JAVAP = if (System.getProperty("os.name").startsWith("Windows")) "javap.exe" else "javap"
 
         /** javap renders these as `invokeinterface ... // InterfaceMethod com/android/ddmlib/IDevice.name:(...)`. */
         val IDEVICE_CALL = Regex("""(?:InterfaceMethod|Method) com/android/ddmlib/IDevice\.([a-zA-Z]+)""")

--- a/src/test/kotlin/spock/adb/StubbedIDeviceApiTest.kt
+++ b/src/test/kotlin/spock/adb/StubbedIDeviceApiTest.kt
@@ -8,9 +8,14 @@ import java.io.File
  * Guards against calling `IDevice` methods that Android Studio does not implement.
  *
  * Android Studio does not supply ddmlib's own `DeviceImpl`. It supplies
- * `com.android.adblib.ddmlibcompatibility.debugging.AdblibIDeviceWrapper`, which leaves
- * nineteen `IDevice` methods unimplemented: each one throws
+ * `com.android.adblib.ddmlibcompatibility.debugging.AdblibIDeviceWrapper`, which leaves a
+ * number of `IDevice` methods unimplemented: each one throws
  * `"This method is not used in Android Studio"`.
+ *
+ * [UNIMPLEMENTED_IN_ANDROID_STUDIO] is the authority on which ones, and no count is repeated
+ * in prose — a number here would go stale the first time that set changed, and a stale one
+ * reads as if the set were complete. It is not claimed to be: it holds the stubs found so far,
+ * and finding another one means adding it rather than working around this test.
  *
  * Nothing catches this at compile time — the methods are on the interface and are perfectly
  * real in stock ddmlib — and no unit test catches it either, because a test that builds its

--- a/src/test/kotlin/spock/adb/StubbedIDeviceApiTest.kt
+++ b/src/test/kotlin/spock/adb/StubbedIDeviceApiTest.kt
@@ -1,0 +1,131 @@
+package spock.adb
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * Guards against calling `IDevice` methods that Android Studio does not implement.
+ *
+ * Android Studio does not supply ddmlib's own `DeviceImpl`. It supplies
+ * `com.android.adblib.ddmlibcompatibility.debugging.AdblibIDeviceWrapper`, which leaves
+ * nineteen `IDevice` methods unimplemented: each one throws
+ * `"This method is not used in Android Studio"`.
+ *
+ * Nothing catches this at compile time — the methods are on the interface and are perfectly
+ * real in stock ddmlib — and no unit test catches it either, because a test that builds its
+ * own `AndroidDebugBridge` gets ddmlib's real implementation, where they all work. The
+ * failure appears only in the IDE, which is the one place the plugin ever runs.
+ *
+ * `android_take_screenshot` shipped broken for exactly this reason: it called
+ * `IDevice.getScreenshot()` and returned that sentence to every caller instead of an image.
+ *
+ * So this reads the compiled bytecode rather than the source. Bytecode is exact: it sees
+ * through Kotlin's property syntax, where `device.screenshot` is a call to `getScreenshot()`
+ * that no text search for `getScreenshot(` would ever find.
+ *
+ * The fix, in every case, is to go through `executeShellCommand` — which Android Studio does
+ * implement — the way [spock.adb.mcp.tools.McpShell] does.
+ */
+class StubbedIDeviceApiTest {
+
+    @Test
+    fun `no code calls an IDevice method Android Studio leaves unimplemented`() {
+        val classes = compiledPluginClasses()
+        assertTrue(classes.isNotEmpty(), "found no compiled classes to scan in $CLASS_DIR")
+
+        val offenders = mutableMapOf<String, MutableSet<String>>()
+        classes.chunked(BATCH_SIZE).forEach { batch ->
+            disassemble(batch).lineSequence().forEach { line ->
+                val method = IDEVICE_CALL.find(line)?.groupValues?.get(1) ?: return@forEach
+                if (method in UNIMPLEMENTED_IN_ANDROID_STUDIO) {
+                    offenders.getOrPut(method) { mutableSetOf() } += line.substringAfter("//").trim()
+                }
+            }
+        }
+
+        assertTrue(offenders.isEmpty()) {
+            buildString {
+                appendLine("Called IDevice methods that Android Studio does not implement.")
+                appendLine("Each one throws \"This method is not used in Android Studio\" at runtime,")
+                appendLine("so the feature is broken in the IDE even though it compiles and unit-tests fine.")
+                appendLine("Use executeShellCommand instead — see McpShell.run and McpShell.runBinary.")
+                appendLine()
+                offenders.toSortedMap().forEach { (method, sites) ->
+                    appendLine("  IDevice.$method")
+                    sites.sorted().forEach { appendLine("      $it") }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `the scan actually sees IDevice calls`() {
+        // Without this, a broken class path or a changed javap format would turn the guard
+        // above into a test that passes because it inspected nothing.
+        val disassembled = disassemble(compiledPluginClasses().take(BATCH_SIZE))
+        assertTrue(
+            disassembled.contains("com/android/ddmlib/IDevice.executeShellCommand"),
+            "the scan found no IDevice.executeShellCommand call, so it is not reading the plugin's bytecode",
+        )
+    }
+
+    private fun compiledPluginClasses(): List<File> =
+        projectRoot().resolve(CLASS_DIR).walkTopDown().filter { it.extension == "class" }.toList()
+
+    private fun disassemble(classes: List<File>): String {
+        if (classes.isEmpty()) return ""
+        val javap = File(System.getProperty("java.home"), "bin/javap")
+        val process = ProcessBuilder(listOf(javap.absolutePath, "-p", "-c") + classes.map { it.absolutePath })
+            .redirectErrorStream(true)
+            .start()
+        val output = process.inputStream.bufferedReader().readText()
+        process.waitFor()
+        return output
+    }
+
+    private fun projectRoot(): File {
+        var candidate: File? = File(System.getProperty("user.dir")).absoluteFile
+        while (candidate != null) {
+            if (candidate.resolve("settings.gradle.kts").exists()) return candidate
+            candidate = candidate.parentFile
+        }
+        error("could not locate the project root from ${System.getProperty("user.dir")}")
+    }
+
+    private companion object {
+        const val CLASS_DIR = "build/classes/kotlin/main"
+
+        /** javap renders these as `invokeinterface ... // InterfaceMethod com/android/ddmlib/IDevice.name:(...)`. */
+        val IDEVICE_CALL = Regex("""(?:InterfaceMethod|Method) com/android/ddmlib/IDevice\.([a-zA-Z]+)""")
+
+        /** Long command lines fail; javap is happy to be called repeatedly. */
+        const val BATCH_SIZE = 150
+
+        /**
+         * Every method AdblibIDeviceWrapper routes to its `unsupportedMethod()` helper, read
+         * out of `plugins/android/lib/sdk-tools.jar` in Android Studio 2025.1.
+         *
+         * Overloads collapse to one name here: if one overload is unimplemented the other is
+         * too, and none of them is safe to reach for.
+         */
+        val UNIMPLEMENTED_IN_ANDROID_STUDIO = setOf(
+            "getBatteryLevel",
+            "getFileListingService",
+            "getLanguage",
+            "getMountPoint",
+            "getPropertyCacheOrSync",
+            "getPropertySync",
+            "getRegion",
+            "getScreenshot",
+            "getSyncService",
+            "hasClients",
+            "installRemotePackage",
+            "rawExec",
+            "reboot",
+            "runEventLogService",
+            "runLogService",
+            "startScreenRecorder",
+        )
+    }
+}

--- a/src/test/kotlin/spock/adb/assistant/AgentLoopTest.kt
+++ b/src/test/kotlin/spock/adb/assistant/AgentLoopTest.kt
@@ -1,0 +1,183 @@
+package spock.adb.assistant
+
+import com.google.gson.JsonObject
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicBoolean
+
+/** A client that replays a script, so the loop is tested and the provider is not. */
+private class ScriptedClient(private val script: MutableList<() -> LlmResponse>) : LlmClient {
+    val sentConversations = mutableListOf<List<LlmMessage>>()
+    override fun send(
+        system: String,
+        messages: List<LlmMessage>,
+        tools: List<ToolSpec>,
+        onTextDelta: (String) -> Unit,
+        isCancelled: () -> Boolean,
+    ): LlmResponse {
+        sentConversations += messages
+        val next = script.removeAt(0)()
+        onTextDelta(next.text)
+        return next
+    }
+}
+
+private class RecordingTools(
+    private val answer: (LlmToolCall) -> LlmToolResult = { LlmToolResult(it.id, "ok", isError = false) },
+) : AgentTools {
+    val invoked = mutableListOf<String>()
+    override fun specs() = listOf(ToolSpec("android_list_devices", "List devices.", JsonObject()))
+    override fun invoke(call: LlmToolCall): LlmToolResult {
+        invoked += call.name
+        return answer(call)
+    }
+}
+
+private fun call(id: String, name: String = "android_list_devices") = LlmToolCall(id, name, JsonObject())
+
+class AgentLoopTest {
+
+    private val conversation = mutableListOf<LlmMessage>()
+    private val streamed = StringBuilder()
+
+    private fun run(
+        client: LlmClient,
+        tools: AgentTools = RecordingTools(),
+        cap: Int = AgentLoop.MAX_ITERATIONS,
+        cancelled: () -> Boolean = { false },
+    ) = AgentLoop(client, tools, cap).run("sys", "why did it crash?", conversation, { streamed.append(it) }, cancelled)
+
+    @Test
+    fun `an answer with no tool calls ends the turn`() {
+        val outcome = run(ScriptedClient(mutableListOf({ LlmResponse("Because of an NPE.") })))
+
+        assertEquals(AgentOutcome.Answered("Because of an NPE."), outcome)
+        assertEquals("Because of an NPE.", streamed.toString())
+    }
+
+    @Test
+    fun `a tool call is run and its result fed back before the model answers`() {
+        val tools = RecordingTools()
+        val outcome = run(
+            ScriptedClient(
+                mutableListOf(
+                    { LlmResponse("Checking.", toolCalls = listOf(call("t1"))) },
+                    { LlmResponse("One device.") },
+                ),
+            ),
+            tools,
+        )
+
+        assertEquals(AgentOutcome.Answered("One device."), outcome)
+        assertEquals(listOf("android_list_devices"), tools.invoked)
+        // user, assistant(+call), user(result), assistant
+        assertEquals(4, conversation.size)
+        assertEquals("t1", conversation[2].toolResults.single().id)
+    }
+
+    @Test
+    fun `parallel calls come back in one message, in the order asked for`() {
+        val tools = RecordingTools()
+        run(
+            ScriptedClient(
+                mutableListOf(
+                    { LlmResponse("", toolCalls = listOf(call("a", "first"), call("b", "second"))) },
+                    { LlmResponse("done") },
+                ),
+            ),
+            tools,
+        )
+
+        val results = conversation[2].toolResults
+        assertEquals(listOf("a", "b"), results.map { it.id })
+        assertEquals(listOf("first", "second"), tools.invoked)
+    }
+
+    @Test
+    fun `a denied confirmation is fed back to the model rather than ending the turn`() {
+        // The developer said no. The model must be told so it can do something else — this is
+        // the case that separates a safety gate from a crash.
+        val denied = RecordingTools { LlmToolResult(it.id, "The developer declined this call.", isError = true) }
+        val outcome = run(
+            ScriptedClient(
+                mutableListOf(
+                    { LlmResponse("Clearing.", toolCalls = listOf(call("t1", "android_clear_app_data"))) },
+                    { LlmResponse("Understood — I will not clear it.") },
+                ),
+            ),
+            denied,
+        )
+
+        assertEquals(AgentOutcome.Answered("Understood — I will not clear it."), outcome)
+        val result = conversation[2].toolResults.single()
+        assertTrue(result.isError)
+        assertTrue(result.content.contains("declined"))
+    }
+
+    @Test
+    fun `the iteration cap stops a model that keeps calling tools`() {
+        val endless = ScriptedClient(MutableList(10) { { LlmResponse("again", toolCalls = listOf(call("t"))) } })
+
+        val outcome = run(endless, cap = 3)
+
+        assertEquals(AgentOutcome.ReachedIterationCap("again", 3), outcome)
+    }
+
+    @Test
+    fun `cancelling before the tools run means they do not run`() {
+        val cancel = AtomicBoolean(false)
+        val tools = RecordingTools()
+        // Stop is pressed while the model is still asking for the tool.
+        val asksThenStopped = ScriptedClient(
+            mutableListOf({
+                cancel.set(true)
+                LlmResponse("Clearing.", toolCalls = listOf(call("t1")))
+            }),
+        )
+
+        val outcome = run(asksThenStopped, tools, cancelled = { cancel.get() })
+
+        assertTrue(outcome is AgentOutcome.Cancelled, outcome.toString())
+        assertTrue(tools.invoked.isEmpty(), "a cancelled turn must not still clear app data")
+    }
+
+    @Test
+    fun `a refusal ends the turn instead of burning iterations`() {
+        val outcome = run(
+            ScriptedClient(mutableListOf({ LlmResponse("", stopReason = "refusal") })),
+        )
+        assertTrue(outcome is AgentOutcome.Refused, outcome.toString())
+    }
+
+    @Test
+    fun `a provider failure is reported in the provider's own words`() {
+        val failing = object : LlmClient {
+            override fun send(
+                system: String,
+                messages: List<LlmMessage>,
+                tools: List<ToolSpec>,
+                onTextDelta: (String) -> Unit,
+                isCancelled: () -> Boolean,
+            ): LlmResponse = throw LlmException("credit balance is too low")
+        }
+
+        val outcome = run(failing)
+
+        assertEquals(AgentOutcome.Failed("credit balance is too low"), outcome)
+    }
+
+    @Test
+    fun `the conversation grows across a turn so later requests carry the history`() {
+        val client = ScriptedClient(
+            mutableListOf(
+                { LlmResponse("", toolCalls = listOf(call("t1"))) },
+                { LlmResponse("done") },
+            ),
+        )
+        run(client)
+
+        assertEquals(1, client.sentConversations[0].size)
+        assertEquals(3, client.sentConversations[1].size)
+    }
+}

--- a/src/test/kotlin/spock/adb/assistant/AnthropicStreamTest.kt
+++ b/src/test/kotlin/spock/adb/assistant/AnthropicStreamTest.kt
@@ -1,0 +1,145 @@
+package spock.adb.assistant
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * The frame handling, driven from a canned stream.
+ *
+ * These are the cases that only appear on the wire: arguments split across frames, two calls
+ * interleaved by index, and a stream that stops half way. None of them need a network or a key.
+ */
+class AnthropicStreamTest {
+
+    private val streamed = StringBuilder()
+
+    private fun parse(vararg lines: String, cancel: AtomicBoolean = AtomicBoolean(false)) =
+        AnthropicStream.parse(lines.iterator(), { streamed.append(it) }, { cancel.get() })
+
+    private fun data(json: String) = "data: $json"
+
+    private fun textDelta(text: String) = data(
+        """{"type":"content_block_delta","index":0,""" +
+            """"delta":{"type":"text_delta","text":"$text"}}""",
+    )
+
+    private fun toolStart(index: Int, id: String, name: String) = data(
+        """{"type":"content_block_start","index":$index,""" +
+            """"content_block":{"type":"tool_use","id":"$id","name":"$name","input":{}}}""",
+    )
+
+    private fun argumentFragment(index: Int, fragment: String) = data(
+        """{"type":"content_block_delta","index":$index,""" +
+            """"delta":{"type":"input_json_delta","partial_json":"$fragment"}}""",
+    )
+
+    private fun stop(reason: String) =
+        data("""{"type":"message_delta","delta":{"stop_reason":"$reason"}}""")
+
+    @Test
+    fun `text deltas are streamed as they arrive and accumulated`() {
+        val response = parse(
+            "event: message_start",
+            data("""{"type":"message_start","message":{"id":"msg_1"}}"""),
+            textDelta("Hel"),
+            textDelta("lo"),
+            stop("end_turn"),
+            data("""{"type":"message_stop"}"""),
+        )
+
+        assertEquals("Hello", response.text)
+        assertEquals("Hello", streamed.toString(), "text should reach the transcript as it arrives")
+        assertEquals("end_turn", response.stopReason)
+        assertTrue(response.toolCalls.isEmpty())
+    }
+
+    @Test
+    fun `a tool call is assembled from fragments that are not valid json alone`() {
+        val response = parse(
+            toolStart(0, "toolu_1", "android_get_logcat"),
+            argumentFragment(0, """{\"maxLi"""),
+            argumentFragment(0, """nes\":20}"""),
+            stop("tool_use"),
+        )
+
+        val call = response.toolCalls.single()
+        assertEquals("toolu_1", call.id)
+        assertEquals("android_get_logcat", call.name)
+        assertEquals(20, call.arguments.get("maxLines").asInt)
+        assertEquals("tool_use", response.stopReason)
+    }
+
+    @Test
+    fun `parallel tool calls are kept apart by their block index`() {
+        // Fragments arrive interleaved and out of order; only the index says which is which.
+        val response = parse(
+            toolStart(0, "a", "first"),
+            toolStart(1, "b", "second"),
+            argumentFragment(1, """{\"x\":2}"""),
+            argumentFragment(0, """{\"x\":1}"""),
+        )
+
+        assertEquals(listOf("first", "second"), response.toolCalls.map { it.name })
+        assertEquals(1, response.toolCalls[0].arguments.get("x").asInt)
+        assertEquals(2, response.toolCalls[1].arguments.get("x").asInt)
+    }
+
+    @Test
+    fun `a tool call with no arguments still runs`() {
+        val response = parse(toolStart(0, "a", "android_list_devices"))
+
+        assertEquals(1, response.toolCalls.size)
+        assertEquals(0, response.toolCalls.single().arguments.size())
+    }
+
+    @Test
+    fun `a half-streamed tool call is dropped rather than run with broken arguments`() {
+        val response = parse(
+            toolStart(0, "a", "android_clear_app_data"),
+            argumentFragment(0, """{\"packageNam"""),
+        )
+
+        assertTrue(response.toolCalls.isEmpty(), "half a tool call must never be executed")
+    }
+
+    @Test
+    fun `cancellation stops reading and returns what arrived`() {
+        val cancel = AtomicBoolean(false)
+        val lines = listOf(textDelta("before"), textDelta("after"))
+
+        val response = AnthropicStream.parse(
+            lines.iterator(),
+            {
+                streamed.append(it)
+                cancel.set(true)
+            },
+            { cancel.get() },
+        )
+
+        assertEquals("before", response.text)
+    }
+
+    @Test
+    fun `a mid-stream error is raised rather than returned as an empty answer`() {
+        val failure = assertThrows<LlmException> {
+            parse(data("""{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}"""))
+        }
+
+        assertTrue(failure.message!!.contains("Overloaded"), failure.message)
+    }
+
+    @Test
+    fun `a refusal is reported as one, not as an empty response`() {
+        assertTrue(parse(stop("refusal")).wasRefused)
+    }
+
+    @Test
+    fun `non-data lines and keepalives are ignored`() {
+        val response = parse("event: ping", "", ": keepalive", data("[DONE]"), textDelta("ok"))
+
+        assertEquals("ok", response.text)
+    }
+}

--- a/src/test/kotlin/spock/adb/assistant/OpenAiStreamTest.kt
+++ b/src/test/kotlin/spock/adb/assistant/OpenAiStreamTest.kt
@@ -1,0 +1,68 @@
+package spock.adb.assistant
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class OpenAiStreamTest {
+
+    private fun parse(vararg lines: String) =
+        OpenAiStream.parse(lines.iterator(), {}, { false })
+
+    private fun data(json: String) = "data: $json"
+
+    private fun toolCallStart(id: String, name: String) = data(
+        """{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"$id",""" +
+            """"function":{"name":"$name","arguments":""}}]}}]}""",
+    )
+
+    private fun argumentFragment(fragment: String) = data(
+        """{"choices":[{"delta":{"tool_calls":[{"index":0,""" +
+            """"function":{"arguments":"$fragment"}}]}}]}""",
+    )
+
+    private fun finish(reason: String) =
+        data("""{"choices":[{"delta":{},"finish_reason":"$reason"}]}""")
+
+    @Test
+    fun `content deltas accumulate`() {
+        val response = parse(
+            data("""{"choices":[{"delta":{"content":"Hel"}}]}"""),
+            data("""{"choices":[{"delta":{"content":"lo"}}]}"""),
+            finish("stop"),
+            data("[DONE]"),
+        )
+        assertEquals("Hello", response.text)
+        assertEquals("stop", response.stopReason)
+    }
+
+    @Test
+    fun `tool call arguments are stitched from fragments keyed by index`() {
+        val response = parse(
+            toolCallStart("c1", "android_get_logcat"),
+            argumentFragment("""{\"maxLi"""),
+            argumentFragment("""nes\":20}"""),
+            finish("tool_calls"),
+        )
+        val call = response.toolCalls.single()
+        assertEquals("c1", call.id)
+        assertEquals("android_get_logcat", call.name)
+        assertEquals(20, call.arguments.get("maxLines").asInt)
+        // Mapped into the neutral vocabulary the loop reads.
+        assertEquals("tool_use", response.stopReason)
+    }
+
+    @Test
+    fun `a content filter finish maps onto the same refusal the loop already handles`() {
+        assertTrue(parse(finish("content_filter")).wasRefused)
+    }
+
+    @Test
+    fun `a half-streamed tool call is dropped`() {
+        val response = parse(
+            toolCallStart("c1", "x"),
+            argumentFragment("""{\"a"""),
+        )
+        assertTrue(response.toolCalls.isEmpty())
+    }
+}

--- a/src/test/kotlin/spock/adb/assistant/ToolSpecMappingTest.kt
+++ b/src/test/kotlin/spock/adb/assistant/ToolSpecMappingTest.kt
@@ -1,0 +1,47 @@
+package spock.adb.assistant
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import spock.adb.mcp.tools.ToolRegistry
+
+/**
+ * The assistant and the MCP transports must describe the same tools.
+ *
+ * The point of `toToolSpec` is that a tool is defined once. A test that only checked the
+ * mapping compiled would not catch the failure that matters: the registry growing a tool the
+ * assistant never hears about.
+ */
+class ToolSpecMappingTest {
+
+    @Test
+    fun `every registered tool is offered to the model, and none is invented`() {
+        val specs = ToolRegistry.all().toToolSpecs()
+
+        assertEquals(ToolRegistry.all().map { it.name }, specs.map { it.name })
+    }
+
+    @Test
+    fun `each spec carries what a model needs to call it`() {
+        ToolRegistry.all().toToolSpecs().forEach { spec ->
+            assertTrue(spec.name.isNotBlank(), "a tool with no name cannot be called")
+            assertTrue(
+                spec.description.isNotBlank(),
+                "${spec.name} has no description, so a model can only guess when to use it",
+            )
+            assertEquals(
+                "object",
+                spec.inputSchema.get("type")?.asString,
+                "${spec.name}'s schema must be an object, which is what both providers accept",
+            )
+        }
+    }
+
+    @Test
+    fun `the schema handed to the model is the registry's own, not a copy of it`() {
+        // Same instance, so a schema can never be edited in one place and stale in the other.
+        val tool = ToolRegistry.all().first()
+
+        assertTrue(tool.inputSchema === tool.toToolSpec().inputSchema)
+    }
+}

--- a/src/test/kotlin/spock/adb/mcp/DebugContextToolTest.kt
+++ b/src/test/kotlin/spock/adb/mcp/DebugContextToolTest.kt
@@ -37,7 +37,7 @@ class DebugContextToolTest {
      * canned reply would let a bug that sends the wrong command to the wrong section pass.
      */
     private fun routedDevice(
-        dumpReply: String = "UI hierchary dumped to: /sdcard/spock-adb-ui-dump.xml",
+        dumpReply: String = "UI hierarchy dumped to: /sdcard/spock-adb-ui-dump.xml",
         logcatReply: String = "01-01 00:00:00.000  1234  1234 E MyApp: boom",
     ): ConnectedDevice {
         val device = mockk<IDevice>(relaxed = true)

--- a/src/test/kotlin/spock/adb/mcp/DebugContextToolTest.kt
+++ b/src/test/kotlin/spock/adb/mcp/DebugContextToolTest.kt
@@ -1,0 +1,182 @@
+package spock.adb.mcp
+
+import com.android.ddmlib.IDevice
+import com.android.ddmlib.IShellOutputReceiver
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import spock.adb.device.ConnectedDevice
+import spock.adb.mcp.tools.DebugContextTool
+import spock.adb.mcp.tools.ToolContent
+import java.util.Base64
+import java.util.concurrent.TimeUnit
+
+/**
+ * The triage bundle is the tool an AI assistant reaches for first, so what matters is that it
+ * stays honest under partial failure and stays bounded under a large screen. Both are tested
+ * here against a routed fake shell rather than a device.
+ */
+class DebugContextToolTest {
+
+    private val uiDump = javaClass.getResource("/uidumps/compose-material3.xml")!!.readText()
+
+    private val pngBytes = byteArrayOf(
+        0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+        0x00, 0x01, 0x02, 0x03,
+    )
+
+    private val issued = mutableListOf<String>()
+
+    /**
+     * A device whose shell answers each command differently, the way a real one does. A single
+     * canned reply would let a bug that sends the wrong command to the wrong section pass.
+     */
+    private fun routedDevice(
+        dumpReply: String = "UI hierchary dumped to: /sdcard/spock-adb-ui-dump.xml",
+        logcatReply: String = "01-01 00:00:00.000  1234  1234 E MyApp: boom",
+    ): ConnectedDevice {
+        val device = mockk<IDevice>(relaxed = true)
+        val command = slot<String>()
+        val receiver = slot<IShellOutputReceiver>()
+        every {
+            device.executeShellCommand(capture(command), capture(receiver), any(), any<TimeUnit>())
+        } answers {
+            val issuedCommand = command.captured
+            issued += issuedCommand
+            val reply = when {
+                issuedCommand.startsWith("uiautomator dump") -> dumpReply
+                issuedCommand.startsWith("cat ") -> uiDump
+                issuedCommand.startsWith("pidof") -> "1234"
+                issuedCommand.startsWith("logcat") -> logcatReply
+                issuedCommand.startsWith("screencap") ->
+                    Base64.getEncoder().encodeToString(pngBytes)
+                else -> ""
+            }
+            val bytes = reply.toByteArray()
+            receiver.captured.addOutput(bytes, 0, bytes.size)
+            receiver.captured.flush()
+        }
+        return FakeToolContext.device("emulator-5554").copy(device = device)
+    }
+
+    private fun run(arguments: JsonObject = JsonObject(), device: ConnectedDevice = routedDevice()) =
+        DebugContextTool().execute(arguments, FakeToolContext(available = listOf(device)))
+
+    private fun textOf(result: spock.adb.mcp.tools.ToolResult) =
+        result.content.filterIsInstance<ToolContent.Text>().single().text
+
+    private fun include(vararg sections: String) = JsonObject().apply {
+        add("include", JsonArray().also { array -> sections.forEach(array::add) })
+    }
+
+    @Test
+    fun `by default it captures activity, ui and logcat but not the screenshot`() {
+        val result = run()
+        val text = textOf(result)
+
+        assertFalse(result.isError)
+        assertTrue(text.contains("## Current activity"), text)
+        assertTrue(text.contains("## UI semantics tree"), text)
+        assertTrue(text.contains("## Recent logcat"), text)
+        assertFalse(text.contains("## Screenshot"), "screenshot must be opt-in: $text")
+        assertTrue(
+            result.content.none { it is ToolContent.Image },
+            "no image should be attached unless asked for",
+        )
+    }
+
+    @Test
+    fun `include selects only the sections asked for`() {
+        val text = textOf(run(include("logcat")))
+
+        assertTrue(text.contains("## Recent logcat"), text)
+        assertFalse(text.contains("## UI semantics tree"), text)
+        assertFalse(text.contains("## Current activity"), text)
+    }
+
+    @Test
+    fun `the screenshot section attaches a real image alongside the text`() {
+        val result = run(include("screenshot"))
+
+        val image = result.content.filterIsInstance<ToolContent.Image>().single()
+        assertTrue(
+            Base64.getDecoder().decode(image.base64Data).contentEquals(pngBytes),
+            "the attached image must be the bytes the device returned",
+        )
+        assertTrue(textOf(result).contains("Attached as an image"), textOf(result))
+    }
+
+    @Test
+    fun `the UI section always states the framework, so Compose test tags are never assumed`() {
+        // A Compose screen without testTagsAsResourceId is the single most common reason an
+        // agent's selectors silently match nothing. It must be told, every time.
+        val text = textOf(run(include("ui")))
+
+        assertTrue(text.contains("UI framework:"), text)
+    }
+
+    @Test
+    fun `the UI tree is bounded by maxUiDepth and says how much it hid`() {
+        val arguments = include("ui").apply { addProperty("maxUiDepth", 1) }
+
+        val text = textOf(run(arguments))
+
+        assertTrue(text.contains("hidden by maxUiDepth=1"), text)
+        assertTrue(text.contains("more node(s) below"), "hidden nodes must be counted, not dropped: $text")
+    }
+
+    @Test
+    fun `logcat lines are capped however many the caller asks for`() {
+        run(include("logcat").apply { addProperty("maxLogcatLines", 999_999) })
+
+        val logcat = issued.single { it.startsWith("logcat") }
+        assertTrue(logcat.contains("-t 2000"), "should clamp to the documented cap: $logcat")
+    }
+
+    @Test
+    fun `logcat is filtered by pid rather than by matching text`() {
+        run(include("logcat"))
+
+        val logcat = issued.single { it.startsWith("logcat") }
+        assertTrue(logcat.contains("--pid=1234"), logcat)
+    }
+
+    @Test
+    fun `a section that fails does not cost the caller the sections that worked`() {
+        // The whole point of the bundle: a screen that refuses to dump must not also hide the
+        // crash sitting in logcat next to it.
+        val device = routedDevice(dumpReply = "ERROR: could not get idle state.")
+
+        val text = textOf(run(include("ui", "logcat"), device))
+
+        assertTrue(text.contains("Could not capture this section"), text)
+        assertTrue(text.contains("MyApp: boom"), "logcat must survive a failed UI dump: $text")
+    }
+
+    @Test
+    fun `an unknown section name is ignored rather than fatal`() {
+        // A newer client asking for a section this build does not have should still get the
+        // rest, not an error.
+        val text = textOf(run(include("logcat", "telemetry")))
+
+        assertTrue(text.contains("## Recent logcat"), text)
+    }
+
+    @Test
+    fun `asking for nothing recognisable is an error that lists what is available`() {
+        val result = run(include("telemetry"))
+
+        assertTrue(result.isError)
+        assertTrue(textOf(result).contains("screenshot"), textOf(result))
+    }
+
+    @Test
+    fun `the report names the device it describes`() {
+        assertTrue(textOf(run()).contains("emulator-5554"), textOf(run()))
+    }
+}

--- a/src/test/kotlin/spock/adb/mcp/FakeToolContext.kt
+++ b/src/test/kotlin/spock/adb/mcp/FakeToolContext.kt
@@ -16,12 +16,17 @@ class FakeToolContext(
     override val project: Project? = null,
     private val available: List<ConnectedDevice> = listOf(device("emulator-5554")),
     private val applicationId: String? = "com.example.app",
+    /** Names of the projects the IDE has open, for android_select_project. */
+    private val openProjects: List<String> = listOf("app"),
     /** Answer given to every destructive confirmation. */
     var confirmationAnswer: Boolean = false,
 ) : ToolContext {
 
     val confirmations = mutableListOf<String>()
     private var selected: String? = null
+
+    var selectedProject: String? = null
+        private set
 
     override fun devices(): List<ConnectedDevice> = available
 
@@ -46,6 +51,13 @@ class FakeToolContext(
     ): Boolean {
         confirmations += toolName
         return confirmationAnswer
+    }
+
+    override fun selectProject(name: String): String {
+        val match = openProjects.firstOrNull { it.equals(name, ignoreCase = true) }
+            ?: error("No open project is called '$name'. Open: ${openProjects.joinToString()}.")
+        selectedProject = match
+        return match
     }
 
     override fun projectApplicationId(): String? = applicationId

--- a/src/test/kotlin/spock/adb/mcp/FileToolsTest.kt
+++ b/src/test/kotlin/spock/adb/mcp/FileToolsTest.kt
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.io.TempDir
 import spock.adb.device.ConnectedDevice
+import spock.adb.mcp.tools.MAX_TRANSFER_BYTES
 import spock.adb.mcp.tools.PullFileTool
 import spock.adb.mcp.tools.PushFileTool
 import java.nio.file.Files
@@ -34,6 +35,8 @@ class FileToolsTest {
     private val context get() = FakeToolContext(available = listOf(connected))
 
     private fun pullTool() = PullFileTool { pullDirectory }
+
+    private fun pushTool() = PushFileTool { pullDirectory }
 
     private fun args(vararg pairs: Pair<String, String>) = JsonObject().apply {
         pairs.forEach { (key, value) -> addProperty(key, value) }
@@ -123,22 +126,23 @@ class FileToolsTest {
 
     @Test
     fun `pushing sends the local file and reports its size`() {
-        val local = workDirectory.resolve("fixture.json")
+        val local = pullDirectory.resolve("fixture.json")
         Files.writeString(local, """{"seeded":true}""")
 
-        val result = PushFileTool().execute(
+        val result = pushTool().execute(
             args("localPath" to local.toString(), "remotePath" to "/sdcard/fixture.json"),
             context,
         )
 
         assertFalse(result.isError)
-        verify { device.pushFile(local.toAbsolutePath().toString(), "/sdcard/fixture.json") }
+        // The resolved path, since that is the one the allow-list actually checked.
+        verify { device.pushFile(local.toRealPath().toString(), "/sdcard/fixture.json") }
         assertTrue(result.text().contains("15 bytes"), result.text())
     }
 
     @Test
     fun `pushing a file that is not there says so rather than failing obscurely`() {
-        val result = PushFileTool().execute(
+        val result = pushTool().execute(
             args("localPath" to workDirectory.resolve("absent").toString(), "remotePath" to "/sdcard/x"),
             context,
         )
@@ -148,15 +152,85 @@ class FileToolsTest {
     }
 
     @Test
-    fun `pushing outside the allowed device paths is refused`() {
-        val local = workDirectory.resolve("payload")
-        Files.writeString(local, "x")
+    fun `pushing a file from outside the allowed directories is refused`() {
+        // The exfiltration case, from the other end: push and pull compose. Without this, an
+        // agent pushes ~/.ssh/id_rsa to /sdcard, pulls it back, and reads it inline — two
+        // SAFE_ACTION calls, neither of which asks the developer anything.
+        val secret = Files.createFile(workDirectory.resolve("id_rsa"))
+
+        val failure = assertThrows<IllegalArgumentException> {
+            pushTool().execute(
+                args("localPath" to secret.toString(), "remotePath" to "/sdcard/x"),
+                context,
+            )
+        }
+
+        assertTrue(
+            failure.message!!.contains("android_run_adb_command"),
+            "should point at the gated escape hatch: ${failure.message}",
+        )
+    }
+
+    @Test
+    fun `pushing a file from the pull directory is allowed, so pull-edit-push works`() {
+        val fixture = Files.write(pullDirectory.resolve("fixture.json"), "{}".toByteArray())
+
+        val result = pushTool().execute(
+            args("localPath" to fixture.toString(), "remotePath" to "/sdcard/fixture.json"),
+            context,
+        )
+
+        assertFalse(result.isError, result.toString())
+        verify { device.pushFile(fixture.toRealPath().toString(), "/sdcard/fixture.json") }
+    }
+
+    @Test
+    fun `a symlink out of an allowed directory does not smuggle a file past the check`() {
+        // Why the check resolves real paths instead of comparing prefixes textually.
+        val secret = Files.write(workDirectory.resolve("id_rsa"), "KEY".toByteArray())
+        val link = pullDirectory.resolve("innocent.txt")
+        runCatching { Files.createSymbolicLink(link, secret) }
+            .onFailure { return } // filesystem without symlink support; nothing to assert
 
         assertThrows<IllegalArgumentException> {
-            PushFileTool().execute(
+            pushTool().execute(
+                args("localPath" to link.toString(), "remotePath" to "/sdcard/x"),
+                context,
+            )
+        }
+    }
+
+    @Test
+    fun `a pull larger than the transfer cap is refused and leaves nothing behind`() {
+        // docs/MCP.md and the changelog both promise 50 MB in both directions; only the push
+        // side used to check, so a pull wrote whatever the device had into the IDE config dir.
+        deviceHolds(ByteArray((MAX_TRANSFER_BYTES + 1).toInt()))
+
+        assertThrows<IllegalArgumentException> {
+            pullTool().execute(args("remotePath" to "/sdcard/huge.mp4"), context)
+        }
+
+        assertTrue(
+            Files.list(pullDirectory).use { it.count() } == 0L,
+            "an over-cap transfer must not be kept, nor leave its staging file",
+        )
+    }
+
+    @Test
+    fun `pushing outside the allowed device paths is refused`() {
+        // Sourced from an allowed directory on purpose, so it is the device path that refuses
+        // this and not the local allow-list — otherwise the test would still pass after the
+        // device-side check was removed.
+        val local = pullDirectory.resolve("payload")
+        Files.writeString(local, "x")
+
+        val failure = assertThrows<IllegalArgumentException> {
+            pushTool().execute(
                 args("localPath" to local.toString(), "remotePath" to "/system/bin/payload"),
                 context,
             )
         }
+
+        assertTrue(failure.message!!.contains("/sdcard/"), failure.message)
     }
 }

--- a/src/test/kotlin/spock/adb/mcp/FileToolsTest.kt
+++ b/src/test/kotlin/spock/adb/mcp/FileToolsTest.kt
@@ -1,0 +1,162 @@
+package spock.adb.mcp
+
+import com.android.ddmlib.IDevice
+import com.google.gson.JsonObject
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.io.TempDir
+import spock.adb.device.ConnectedDevice
+import spock.adb.mcp.tools.PullFileTool
+import spock.adb.mcp.tools.PushFileTool
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * File transfer is the one pair of tools that reaches off the device and onto the developer's
+ * machine, so the tests are mostly about what it refuses to do.
+ */
+class FileToolsTest {
+
+    @TempDir
+    lateinit var pullDirectory: Path
+
+    @TempDir
+    lateinit var workDirectory: Path
+
+    private val device = mockk<IDevice>(relaxed = true)
+    private val connected: ConnectedDevice = FakeToolContext.device("emulator-5554").copy(device = device)
+    private val context get() = FakeToolContext(available = listOf(connected))
+
+    private fun pullTool() = PullFileTool { pullDirectory }
+
+    private fun args(vararg pairs: Pair<String, String>) = JsonObject().apply {
+        pairs.forEach { (key, value) -> addProperty(key, value) }
+    }
+
+    /** Makes the device "contain" a file: pullFile writes the bytes where it is told to. */
+    private fun deviceHolds(bytes: ByteArray) {
+        every { device.pullFile(any(), any()) } answers {
+            Files.write(Path.of(secondArg<String>()), bytes)
+            Unit
+        }
+    }
+
+    @Test
+    fun `pulling from another app's private storage is refused, and says what is allowed`() {
+        // The exfiltration case. adb would allow this; this tool deliberately does not.
+        val failure = assertThrows<IllegalArgumentException> {
+            pullTool().execute(args("remotePath" to "/data/data/com.bank.app/databases/accounts.db"), context)
+        }
+
+        assertTrue(failure.message!!.contains("/sdcard/"), failure.message)
+        assertTrue(
+            failure.message!!.contains("android_run_adb_command"),
+            "should point at the gated escape hatch: ${failure.message}",
+        )
+    }
+
+    @Test
+    fun `a path that climbs out with dot-dot is refused`() {
+        assertThrows<IllegalArgumentException> {
+            pullTool().execute(args("remotePath" to "/sdcard/../data/data/com.bank.app/f"), context)
+        }
+    }
+
+    @Test
+    fun `a relative device path is refused`() {
+        assertThrows<IllegalArgumentException> {
+            pullTool().execute(args("remotePath" to "sdcard/thing.txt"), context)
+        }
+    }
+
+    @Test
+    fun `pulling lands the file in the IDE's pull directory, not anywhere the caller chose`() {
+        deviceHolds("hello".toByteArray())
+
+        val result = pullTool().execute(args("remotePath" to "/sdcard/notes.txt"), context)
+
+        assertFalse(result.isError)
+        val landed = pullDirectory.resolve("notes.txt")
+        assertTrue(Files.exists(landed), "expected the pulled file at $landed")
+        assertEquals("hello", Files.readString(landed))
+        assertTrue(result.text().contains(landed.toString()), result.text())
+    }
+
+    @Test
+    fun `a small text file comes back inline so no second call is needed`() {
+        deviceHolds("line one\nline two".toByteArray())
+
+        val result = pullTool().execute(args("remotePath" to "/sdcard/log.txt"), context)
+
+        assertTrue(result.text().contains("line two"), result.text())
+    }
+
+    @Test
+    fun `a binary file is not inlined as mojibake`() {
+        // A .db whose first bytes look like ASCII must not be decoded and reasoned about.
+        deviceHolds(byteArrayOf(0x53, 0x51, 0x4C, 0x69, 0x74, 0x65, 0x00, 0xFF.toByte()))
+
+        val result = pullTool().execute(args("remotePath" to "/sdcard/app.db"), context)
+
+        assertFalse(result.text().contains("Contents:"), result.text())
+    }
+
+    @Test
+    fun `a failed pull leaves no half-written file behind under the real name`() {
+        every { device.pullFile(any(), any()) } answers { } // writes nothing
+
+        val failure = runCatching { pullTool().execute(args("remotePath" to "/sdcard/gone.txt"), context) }
+
+        assertTrue(failure.isFailure, "a pull that produced no file must not report success")
+        assertFalse(Files.exists(pullDirectory.resolve("gone.txt")))
+        assertTrue(
+            Files.list(pullDirectory).use { it.toList() }.isEmpty(),
+            "the staging file must be cleaned up",
+        )
+    }
+
+    @Test
+    fun `pushing sends the local file and reports its size`() {
+        val local = workDirectory.resolve("fixture.json")
+        Files.writeString(local, """{"seeded":true}""")
+
+        val result = PushFileTool().execute(
+            args("localPath" to local.toString(), "remotePath" to "/sdcard/fixture.json"),
+            context,
+        )
+
+        assertFalse(result.isError)
+        verify { device.pushFile(local.toAbsolutePath().toString(), "/sdcard/fixture.json") }
+        assertTrue(result.text().contains("15 bytes"), result.text())
+    }
+
+    @Test
+    fun `pushing a file that is not there says so rather than failing obscurely`() {
+        val result = PushFileTool().execute(
+            args("localPath" to workDirectory.resolve("absent").toString(), "remotePath" to "/sdcard/x"),
+            context,
+        )
+
+        assertTrue(result.isError)
+        assertTrue(result.text().contains("is not a file"), result.text())
+    }
+
+    @Test
+    fun `pushing outside the allowed device paths is refused`() {
+        val local = workDirectory.resolve("payload")
+        Files.writeString(local, "x")
+
+        assertThrows<IllegalArgumentException> {
+            PushFileTool().execute(
+                args("localPath" to local.toString(), "remotePath" to "/system/bin/payload"),
+                context,
+            )
+        }
+    }
+}

--- a/src/test/kotlin/spock/adb/mcp/McpSmokeTest.kt
+++ b/src/test/kotlin/spock/adb/mcp/McpSmokeTest.kt
@@ -239,7 +239,7 @@ class McpSmokeTest {
             "android_get_current_activity" to "{}",
             "android_get_activity_stack" to "{}",
             "android_get_current_fragments" to "{}",
-            "android_get_logcat" to """{"lines":20}""",
+            "android_get_logcat" to """{"maxLines":20}""",
             "android_get_processes" to "{}",
             "android_get_battery_info" to "{}",
             "android_get_network_info" to "{}",

--- a/src/test/kotlin/spock/adb/mcp/McpSmokeTest.kt
+++ b/src/test/kotlin/spock/adb/mcp/McpSmokeTest.kt
@@ -1,0 +1,255 @@
+package spock.adb.mcp
+
+import com.google.gson.Gson
+import com.google.gson.JsonObject
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Test
+import spock.adb.mcp.tools.ToolRegistry
+import spock.adb.mcp.tools.ToolSafety
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.time.Duration
+
+/**
+ * Calls every read-only tool against a real device, through a real running server.
+ *
+ * This exists because the failure mode it looks for cannot be reached any other way.
+ * Android Studio supplies an `IDevice` whose implementation leaves nineteen methods
+ * unimplemented, and a tool that calls one of them returns an error to every caller while
+ * compiling cleanly and passing its unit tests — a test that builds its own
+ * `AndroidDebugBridge` gets stock ddmlib, where those methods work. `android_take_screenshot`
+ * shipped broken that way. [spock.adb.StubbedIDeviceApiTest] now blocks that specific class
+ * of bug statically; this covers the rest, where a tool is wired up wrongly, parses output
+ * that has changed shape, or fails only against a live device.
+ *
+ * Opt-in, because it needs both an IDE running the server and a device attached:
+ *
+ * ```
+ * SPOCK_MCP_URL=http://127.0.0.1:58649/mcp SPOCK_MCP_TOKEN=… ./gradlew test --tests '*McpSmokeTest'
+ * ```
+ *
+ * Both values come from `Tools → Spock ADB → Copy MCP Client Configuration (HTTP)`. Without
+ * them the live checks skip, so an ordinary `./gradlew test` is unaffected — but
+ * [every read-only tool is covered] still runs, so a new tool cannot be added without
+ * deciding how it is smoke-tested.
+ */
+class McpSmokeTest {
+
+    private val gson = Gson()
+    private val http: HttpClient = HttpClient.newBuilder()
+        .connectTimeout(Duration.ofSeconds(CONNECT_TIMEOUT_SECONDS))
+        .build()
+
+    @Test
+    fun `every read-only tool is covered`() {
+        // Runs with or without a device: it compares the registry against the tables below,
+        // so adding a read-only tool without classifying it fails here rather than silently
+        // going untested.
+        val readOnly = ToolRegistry.bySafety(ToolSafety.READ_ONLY).map { it.name }.toSet()
+        val covered = PROBES.keys + QUERIES.keys
+
+        val untested = readOnly - covered
+        assertTrue(untested.isEmpty()) {
+            "These read-only tools are not smoke-tested: ${untested.sorted()}. Add each to " +
+                "PROBES (must succeed) or QUERIES (may report no match)."
+        }
+
+        val stale = covered - readOnly
+        assertTrue(stale.isEmpty()) {
+            "These tools are smoke-tested but are no longer read-only: ${stale.sorted()}."
+        }
+    }
+
+    @Test
+    fun `the running server is this build`() {
+        val endpoint = liveEndpoint() ?: return
+
+        // The server runs inside an IDE that was launched at some point in the past. When
+        // this build defines a tool the server has never heard of, every probe for it fails
+        // with "Unknown tool", which reads like a broken tool rather than a stale IDE.
+        val missing = ToolRegistry.all().map { it.name }.toSet() - endpoint.servedTools
+        assertTrue(missing.isEmpty()) {
+            "The MCP server at ${endpoint.url} does not serve ${missing.sorted()}. It is " +
+                "running an older build — restart the IDE (./gradlew runIde) to pick up this one."
+        }
+    }
+
+    @Test
+    fun `every probe tool succeeds against a real device`() {
+        val endpoint = liveEndpoint() ?: return
+        assumeTrue(endpoint.devices.isNotEmpty(), "no device attached to ${endpoint.url}")
+
+        val failures = PROBES.servedBy(endpoint).mapNotNull { (tool, arguments) ->
+            val result = endpoint.call(tool, arguments)
+            when {
+                result.isError -> "$tool -> ${result.text}"
+                result.isEmptyResult -> "$tool -> returned no content"
+                else -> null
+            }
+        }
+
+        assertTrue(failures.isEmpty()) {
+            "These read-only tools failed against ${endpoint.devices.first()}:\n" +
+                failures.joinToString("\n") { "  $it" }
+        }
+    }
+
+    @Test
+    fun `query tools report no match rather than failing`() {
+        val endpoint = liveEndpoint() ?: return
+        assumeTrue(endpoint.devices.isNotEmpty(), "no device attached to ${endpoint.url}")
+
+        // Nothing on screen can match this, so each tool must give its own "not found"
+        // verdict. An infrastructure failure surfaces here as an unrecognisable message.
+        val failures = QUERIES.servedBy(endpoint).mapNotNull { (tool, arguments) ->
+            val result = endpoint.call(tool, arguments)
+            val text = result.text
+            when {
+                result.isEmptyResult -> "$tool -> returned no content"
+                !result.isError -> null
+                NO_MATCH_VERDICT.containsMatchIn(text) -> null
+                else -> "$tool -> failed instead of reporting no match: $text"
+            }
+        }
+
+        assertTrue(failures.isEmpty()) {
+            "These read-only tools broke on a selector that simply does not match:\n" +
+                failures.joinToString("\n") { "  $it" }
+        }
+    }
+
+    @Test
+    fun `no tool result carries an unimplemented-API failure`() {
+        val endpoint = liveEndpoint() ?: return
+        assumeTrue(endpoint.devices.isNotEmpty(), "no device attached to ${endpoint.url}")
+
+        // The sentence Android Studio's IDevice returns from every method it does not
+        // implement. It reached MCP clients verbatim for the whole life of the screenshot
+        // tool, so it is worth asserting on by name.
+        val offenders = (PROBES + QUERIES).servedBy(endpoint)
+            .filter { (tool, arguments) -> endpoint.call(tool, arguments).text.contains(UNIMPLEMENTED) }
+            .keys
+
+        assertTrue(offenders.isEmpty()) {
+            "These tools returned \"$UNIMPLEMENTED\": ${offenders.sorted()}. " +
+                "Route the call through executeShellCommand — see McpShell."
+        }
+    }
+
+    // ---- transport -------------------------------------------------------------------
+
+    private data class CallResult(val isError: Boolean, val text: String, val isEmptyResult: Boolean)
+
+    private inner class Endpoint(val url: String, val token: String) {
+        val devices: List<String> by lazy {
+            call("android_list_devices", "{}").text.lines().filter { it.isNotBlank() }
+        }
+
+        /** What the running server advertises, which is not always what this build defines. */
+        val servedTools: Set<String> by lazy {
+            val response = post("""{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}""")
+            gson.fromJson(response, JsonObject::class.java)
+                ?.getAsJsonObject("result")
+                ?.getAsJsonArray("tools")
+                ?.map { it.asJsonObject.get("name").asString }
+                ?.toSet()
+                .orEmpty()
+        }
+
+        fun call(tool: String, arguments: String): CallResult {
+            val body = """
+                {"jsonrpc":"2.0","id":1,"method":"tools/call",
+                 "params":{"name":"$tool","arguments":$arguments}}
+            """.trimIndent()
+            val response = post(body)
+            val result = gson.fromJson(response, JsonObject::class.java)?.getAsJsonObject("result")
+                ?: return CallResult(true, "no result in response: $response", isEmptyResult = true)
+
+            val content = result.getAsJsonArray("content") ?: return CallResult(true, "", true)
+            // Images carry no text; their presence is the evidence the call worked.
+            val text = content.joinToString("\n") { element ->
+                element.asJsonObject.get("text")?.asString
+                    ?: "<${element.asJsonObject.get("type")?.asString ?: "unknown"}>"
+            }
+            return CallResult(
+                isError = result.get("isError")?.asBoolean ?: false,
+                text = text,
+                isEmptyResult = content.isEmpty,
+            )
+        }
+
+        private fun post(body: String): String {
+            val request = HttpRequest.newBuilder(URI.create(url))
+                .header("Authorization", "Bearer $token")
+                .header("Content-Type", "application/json")
+                .header("Accept", "application/json, text/event-stream")
+                .timeout(Duration.ofSeconds(CALL_TIMEOUT_SECONDS))
+                .POST(HttpRequest.BodyPublishers.ofString(body))
+                .build()
+            return http.send(request, HttpResponse.BodyHandlers.ofString()).body()
+        }
+    }
+
+    /**
+     * Restricts a table to tools the running server actually serves.
+     *
+     * A stale IDE is reported once, by [the running server is this build]; it should not also
+     * surface as a failure against every tool it has not heard of.
+     */
+    private fun Map<String, String>.servedBy(endpoint: Endpoint): Map<String, String> =
+        filterKeys { it in endpoint.servedTools }.toSortedMap()
+
+    /** Null, having skipped the test, when no live server was configured. */
+    private fun liveEndpoint(): Endpoint? {
+        val url = System.getenv("SPOCK_MCP_URL")
+        val token = System.getenv("SPOCK_MCP_TOKEN")
+        assumeTrue(
+            !url.isNullOrBlank() && !token.isNullOrBlank(),
+            "set SPOCK_MCP_URL and SPOCK_MCP_TOKEN to smoke-test a running MCP server",
+        )
+        return Endpoint(url!!, token!!)
+    }
+
+    private companion object {
+        const val CONNECT_TIMEOUT_SECONDS = 5L
+        const val CALL_TIMEOUT_SECONDS = 60L
+        const val UNIMPLEMENTED = "This method is not used in Android Studio"
+
+        /** A selector no screen can match, so a query tool must answer "not found". */
+        const val ABSENT = "spock-smoke-test-no-such-element"
+
+        val NO_MATCH_VERDICT = Regex("FAIL|not found|nothing matched|no element", RegexOption.IGNORE_CASE)
+
+        /** Report device or app state. Any error is a real failure. */
+        val PROBES = mapOf(
+            "android_list_devices" to "{}",
+            "android_get_device_info" to "{}",
+            "android_list_packages" to """{"filter":"android"}""",
+            "android_get_package_info" to """{"packageName":"com.android.settings"}""",
+            "android_get_current_activity" to "{}",
+            "android_get_activity_stack" to "{}",
+            "android_get_current_fragments" to "{}",
+            "android_get_logcat" to """{"lines":20}""",
+            "android_get_processes" to "{}",
+            "android_get_battery_info" to "{}",
+            "android_get_network_info" to "{}",
+            "android_get_debug_context" to """{"include":["activity","ui","logcat"],"maxLogcatLines":20}""",
+            "android_take_screenshot" to "{}",
+            "android_get_ui_tree" to "{}",
+            "android_accessibility_audit" to "{}",
+            // Default sections only: the screenshot section is covered by its own tool above.
+            "android_get_debug_context" to "{}",
+        )
+
+        /** Search for something. Reporting "no match" is a pass; anything else is not. */
+        val QUERIES = mapOf(
+            "android_find_ui_element" to """{"text":"$ABSENT"}""",
+            "android_assert_visible" to """{"text":"$ABSENT"}""",
+            "android_assert_enabled" to """{"text":"$ABSENT"}""",
+            "android_assert_text" to """{"text":"$ABSENT"}""",
+        )
+    }
+}

--- a/src/test/kotlin/spock/adb/mcp/McpSmokeTest.kt
+++ b/src/test/kotlin/spock/adb/mcp/McpSmokeTest.kt
@@ -17,7 +17,7 @@ import java.time.Duration
  * Calls every read-only tool against a real device, through a real running server.
  *
  * This exists because the failure mode it looks for cannot be reached any other way.
- * Android Studio supplies an `IDevice` whose implementation leaves nineteen methods
+ * Android Studio supplies an `IDevice` whose implementation leaves a number of methods
  * unimplemented, and a tool that calls one of them returns an error to every caller while
  * compiling cleanly and passing its unit tests — a test that builds its own
  * `AndroidDebugBridge` gets stock ddmlib, where those methods work. `android_take_screenshot`

--- a/src/test/kotlin/spock/adb/mcp/McpSmokeTest.kt
+++ b/src/test/kotlin/spock/adb/mcp/McpSmokeTest.kt
@@ -49,7 +49,7 @@ class McpSmokeTest {
         // so adding a read-only tool without classifying it fails here rather than silently
         // going untested.
         val readOnly = ToolRegistry.bySafety(ToolSafety.READ_ONLY).map { it.name }.toSet()
-        val covered = PROBES.keys + QUERIES.keys
+        val covered = (PROBES + QUERIES).map { (tool, _) -> tool }.toSet()
 
         val untested = readOnly - covered
         assertTrue(untested.isEmpty()) {
@@ -131,7 +131,8 @@ class McpSmokeTest {
         // tool, so it is worth asserting on by name.
         val offenders = (PROBES + QUERIES).servedBy(endpoint)
             .filter { (tool, arguments) -> endpoint.call(tool, arguments).text.contains(UNIMPLEMENTED) }
-            .keys
+            .map { (tool, _) -> tool }
+            .distinct()
 
         assertTrue(offenders.isEmpty()) {
             "These tools returned \"$UNIMPLEMENTED\": ${offenders.sorted()}. " +
@@ -199,8 +200,8 @@ class McpSmokeTest {
      * A stale IDE is reported once, by [the running server is this build]; it should not also
      * surface as a failure against every tool it has not heard of.
      */
-    private fun Map<String, String>.servedBy(endpoint: Endpoint): Map<String, String> =
-        filterKeys { it in endpoint.servedTools }.toSortedMap()
+    private fun List<Pair<String, String>>.servedBy(endpoint: Endpoint): List<Pair<String, String>> =
+        filter { (tool, _) -> tool in endpoint.servedTools }.sortedBy { it.first }
 
     /** Null, having skipped the test, when no live server was configured. */
     private fun liveEndpoint(): Endpoint? {
@@ -223,8 +224,14 @@ class McpSmokeTest {
 
         val NO_MATCH_VERDICT = Regex("FAIL|not found|nothing matched|no element", RegexOption.IGNORE_CASE)
 
-        /** Report device or app state. Any error is a real failure. */
-        val PROBES = mapOf(
+        /**
+         * Report device or app state. Any error is a real failure.
+         *
+         * A list of pairs rather than a map: a tool worth probing two ways — as
+         * android_get_debug_context is, with and without an explicit section list — appears
+         * twice, and map keys are unique, so the first entry was silently discarded.
+         */
+        val PROBES = listOf(
             "android_list_devices" to "{}",
             "android_get_device_info" to "{}",
             "android_list_packages" to """{"filter":"android"}""",
@@ -245,7 +252,7 @@ class McpSmokeTest {
         )
 
         /** Search for something. Reporting "no match" is a pass; anything else is not. */
-        val QUERIES = mapOf(
+        val QUERIES = listOf(
             "android_find_ui_element" to """{"text":"$ABSENT"}""",
             "android_assert_visible" to """{"text":"$ABSENT"}""",
             "android_assert_enabled" to """{"text":"$ABSENT"}""",

--- a/src/test/kotlin/spock/adb/mcp/ProjectResolutionTest.kt
+++ b/src/test/kotlin/spock/adb/mcp/ProjectResolutionTest.kt
@@ -1,0 +1,111 @@
+package spock.adb.mcp
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * The rule that decides which open project an MCP call is about.
+ *
+ * This is the fix for a real defect: resolution used to be
+ * `openProjects.singleOrNull { !it.isDisposed }`, so opening a second project made every
+ * project-dependent tool — current activity, activity stack, fragments, the default logcat
+ * filter — fail with "No project is open", which was both wrong and unactionable.
+ */
+class ProjectResolutionTest {
+
+    private data class Proj(val name: String, val path: String?)
+
+    private fun resolve(
+        candidates: List<Proj>,
+        selectedKey: String? = null,
+    ): ProjectResolution.Outcome<Proj> = ProjectResolution.resolve(
+        candidates = candidates,
+        selectedKey = selectedKey,
+        keysOf = { listOfNotNull(it.name, it.path) },
+        nameOf = { it.name },
+    )
+
+    private val app = Proj("app", "/home/dev/app")
+    private val sdk = Proj("sdk", "/home/dev/sdk")
+
+    @Test
+    fun `nothing open resolves to none`() {
+        assertEquals(ProjectResolution.Outcome.None, resolve(emptyList()))
+    }
+
+    @Test
+    fun `one open project is used without being selected`() {
+        assertEquals(
+            ProjectResolution.Outcome.Resolved(app, ProjectResolution.Source.ONLY_OPEN),
+            resolve(listOf(app)),
+        )
+    }
+
+    @Test
+    fun `several open projects with a selection resolve to the selected one`() {
+        assertEquals(
+            ProjectResolution.Outcome.Resolved(sdk, ProjectResolution.Source.SELECTED),
+            resolve(listOf(app, sdk), selectedKey = "sdk"),
+        )
+    }
+
+    @Test
+    fun `a selection may name the project path as well as its name`() {
+        assertEquals(
+            ProjectResolution.Outcome.Resolved(sdk, ProjectResolution.Source.SELECTED),
+            resolve(listOf(app, sdk), selectedKey = "/home/dev/sdk"),
+        )
+    }
+
+    @Test
+    fun `a selection matches regardless of case`() {
+        assertEquals(
+            ProjectResolution.Outcome.Resolved(sdk, ProjectResolution.Source.SELECTED),
+            resolve(listOf(app, sdk), selectedKey = "SDK"),
+        )
+    }
+
+    @Test
+    fun `several open projects without a selection are ambiguous, and say which`() {
+        // Refusing to guess is the point. Picking the focused window would be wrong exactly
+        // when it matters most: an agent working while the developer looks at something else.
+        assertEquals(
+            ProjectResolution.Outcome.Ambiguous(listOf("app", "sdk")),
+            resolve(listOf(sdk, app)),
+        )
+    }
+
+    @Test
+    fun `a selection naming a project that has since closed does not win`() {
+        assertEquals(
+            ProjectResolution.Outcome.Ambiguous(listOf("app", "sdk")),
+            resolve(listOf(app, sdk), selectedKey = "closed-project"),
+        )
+    }
+
+    @Test
+    fun `a stale selection falls back to the only project left open`() {
+        // The choice should not outlive the project it named.
+        assertEquals(
+            ProjectResolution.Outcome.Resolved(app, ProjectResolution.Source.ONLY_OPEN),
+            resolve(listOf(app), selectedKey = "sdk"),
+        )
+    }
+
+    @Test
+    fun `a blank selection is treated as no selection`() {
+        assertEquals(
+            ProjectResolution.Outcome.Ambiguous(listOf("app", "sdk")),
+            resolve(listOf(app, sdk), selectedKey = "   "),
+        )
+    }
+
+    @Test
+    fun `a project with no path is still matched by name`() {
+        val pathless = Proj("scratch", null)
+        assertEquals(
+            ProjectResolution.Outcome.Resolved(pathless, ProjectResolution.Source.SELECTED),
+            resolve(listOf(app, pathless), selectedKey = "scratch"),
+        )
+    }
+}

--- a/src/test/kotlin/spock/adb/mcp/ProjectResolutionTest.kt
+++ b/src/test/kotlin/spock/adb/mcp/ProjectResolutionTest.kt
@@ -157,6 +157,55 @@ class ProjectResolutionTest {
     }
 
     @Test
+    fun `a selection may be the label the ambiguity error showed`() {
+        // The defect this covers: the ambiguity error lists "app (/home/dev/app)", and an agent
+        // that passed that back exactly was told no open project is called that — which reads
+        // as the project having closed rather than as the wrong string having been sent.
+        val fork = Proj("app", "/home/dev/app-fork")
+        val candidates = listOf(app, fork)
+        val label = ProjectResolution.labeller(candidates, { it.name }, { it.path })
+
+        val chosen = ProjectResolution.select(
+            candidates = candidates,
+            key = "app (/home/dev/app-fork)",
+            keysOf = { listOfNotNull(it.name, it.path) },
+            labelOf = label,
+        )
+
+        assertEquals(fork, chosen)
+    }
+
+    @Test
+    fun `a selection may still be the bare name or the bare path`() {
+        val candidates = listOf(app, sdk)
+        val label = ProjectResolution.labeller(candidates, { it.name }, { it.path })
+        fun select(key: String) = ProjectResolution.select(
+            candidates,
+            key,
+            { listOfNotNull(it.name, it.path) },
+            label,
+        )
+
+        assertEquals(sdk, select("sdk"))
+        assertEquals(sdk, select("/home/dev/sdk"))
+        assertEquals(app, select("APP"))
+    }
+
+    @Test
+    fun `a selection matching nothing is null rather than a guess`() {
+        val candidates = listOf(app, sdk)
+
+        val chosen = ProjectResolution.select(
+            candidates,
+            "closed-project",
+            { listOfNotNull(it.name, it.path) },
+            ProjectResolution.labeller(candidates, { it.name }, { it.path }),
+        )
+
+        assertEquals(null, chosen)
+    }
+
+    @Test
     fun `selecting by path wins over another project with the same name`() {
         // The defect this covers: the selection used to be stored as the project's *name*, so
         // it matched whichever the IDE listed first and the fork could never be targeted.

--- a/src/test/kotlin/spock/adb/mcp/ProjectResolutionTest.kt
+++ b/src/test/kotlin/spock/adb/mcp/ProjectResolutionTest.kt
@@ -22,7 +22,9 @@ class ProjectResolutionTest {
         candidates = candidates,
         selectedKey = selectedKey,
         keysOf = { listOfNotNull(it.name, it.path) },
-        nameOf = { it.name },
+        // The real caller passes a labeller; these cases are about resolution, not labelling,
+        // and the labelling has its own tests below.
+        labelOf = { it.name },
     )
 
     private val app = Proj("app", "/home/dev/app")
@@ -107,5 +109,61 @@ class ProjectResolutionTest {
             ProjectResolution.Outcome.Resolved(pathless, ProjectResolution.Source.SELECTED),
             resolve(listOf(app, pathless), selectedKey = "scratch"),
         )
+    }
+
+    @Test
+    fun `a duplicated name carries the path that tells the two apart`() {
+        val fork = Proj("app", "/home/dev/app-fork")
+        val label = ProjectResolution.labeller(listOf(app, fork), { it.name }, { it.path })
+
+        assertEquals("app (/home/dev/app)", label(app))
+        assertEquals("app (/home/dev/app-fork)", label(fork))
+    }
+
+    @Test
+    fun `a unique name is not cluttered with its path`() {
+        val label = ProjectResolution.labeller(listOf(app, sdk), { it.name }, { it.path })
+
+        assertEquals("app", label(app))
+    }
+
+    @Test
+    fun `a duplicated name with no path still says something`() {
+        val pathless = Proj("app", null)
+        val label = ProjectResolution.labeller(listOf(app, pathless), { it.name }, { it.path })
+
+        assertEquals("app (no path)", label(pathless))
+    }
+
+    @Test
+    fun `an ambiguity between same-named projects names choices the caller can make`() {
+        val fork = Proj("app", "/home/dev/app-fork")
+        val candidates = listOf(app, fork)
+
+        val outcome = ProjectResolution.resolve(
+            candidates = candidates,
+            selectedKey = null,
+            keysOf = { listOfNotNull(it.name, it.path) },
+            labelOf = ProjectResolution.labeller(candidates, { it.name }, { it.path }),
+        )
+
+        // "app, app" would ask the caller to choose between two identical strings.
+        assertEquals(
+            ProjectResolution.Outcome.Ambiguous(
+                listOf("app (/home/dev/app)", "app (/home/dev/app-fork)"),
+            ),
+            outcome,
+        )
+    }
+
+    @Test
+    fun `selecting by path wins over another project with the same name`() {
+        // The defect this covers: the selection used to be stored as the project's *name*, so
+        // it matched whichever the IDE listed first and the fork could never be targeted.
+        val fork = Proj("app", "/home/dev/app-fork")
+
+        val outcome = resolve(listOf(app, fork), selectedKey = "/home/dev/app-fork")
+
+        assertEquals(ProjectResolution.Outcome.Resolved(fork, ProjectResolution.Source.SELECTED), outcome)
     }
 }

--- a/src/test/kotlin/spock/adb/mcp/ReadmeToolCountTest.kt
+++ b/src/test/kotlin/spock/adb/mcp/ReadmeToolCountTest.kt
@@ -1,0 +1,66 @@
+package spock.adb.mcp
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import spock.adb.mcp.tools.ToolRegistry
+import java.io.File
+
+/**
+ * Keeps the tool count in the README true.
+ *
+ * It has already been wrong twice. One of the two places it appears sits inside the
+ * `<!-- Plugin description -->` block, which the Gradle build extracts into the JetBrains
+ * Marketplace listing — so a stale number is not an internal documentation nit, it is on the
+ * public plugin page until somebody happens to notice.
+ *
+ * Read off disk in the same spirit as [spock.adb.actions.ActionRegistrationTest]: what breaks
+ * users here is declarative, and checking it needs no running IDE.
+ */
+class ReadmeToolCountTest {
+
+    private val readme = File("README.md").readText()
+
+    @Test
+    fun `every stated tool count matches the registry`() {
+        val stated = COUNT.findAll(readme).map { it.groupValues[1].toInt() }.toList()
+
+        // A reworded README must fail here rather than quietly disable the check: a scan that
+        // finds nothing and passes is not a guard, it is a guard-shaped hole.
+        assertTrue(stated.isNotEmpty()) {
+            "No tool count found in README.md — the wording changed. Update the pattern " +
+                "`${COUNT.pattern}` so this stays a real check."
+        }
+
+        val registered = ToolRegistry.all().size
+        stated.forEach { count ->
+            assertEquals(
+                registered,
+                count,
+                "README.md says $count tools; ToolRegistry has $registered",
+            )
+        }
+    }
+
+    @Test
+    fun `the Marketplace description is one of the places that states it`() {
+        // buildPlugin lifts this block into the Marketplace description, so it is the copy
+        // read by people who have not installed the plugin yet — the one worth pinning.
+        val description = readme
+            .substringAfter(DESCRIPTION_START, "")
+            .substringBefore(DESCRIPTION_END, "")
+
+        assertTrue(description.isNotBlank(), "the plugin description markers are missing")
+        assertTrue(
+            COUNT.containsMatchIn(description),
+            "the Marketplace description no longer states a tool count, so the count that " +
+                "reaches the plugin page is no longer checked",
+        )
+    }
+
+    private companion object {
+        val COUNT = Regex("""(\d+) strongly typed tools""")
+        const val DESCRIPTION_START = "<!-- Plugin description -->"
+        const val DESCRIPTION_END = "<!-- Plugin description end -->"
+    }
+}

--- a/src/test/kotlin/spock/adb/mcp/ScreenRecordToolsTest.kt
+++ b/src/test/kotlin/spock/adb/mcp/ScreenRecordToolsTest.kt
@@ -80,6 +80,21 @@ class ScreenRecordToolsTest {
     private fun start(arguments: JsonObject = JsonObject()) =
         StartScreenRecordTool().execute(arguments, context)
 
+    /**
+     * Starts once the previous recording has released the device.
+     *
+     * A recording that ended on its own does not announce it — the thread notices when the
+     * shell call returns — so this retries rather than sleeping for a guessed interval.
+     */
+    private fun startWhenFree(): spock.adb.mcp.tools.ToolResult {
+        val deadline = System.currentTimeMillis() + AWAIT_SECONDS * 1_000
+        while (System.currentTimeMillis() < deadline) {
+            runCatching { return start() }
+            Thread.sleep(POLL_MS)
+        }
+        error("the expired recording never released the device; saw ${issued.toList()}")
+    }
+
     private fun awaitCommand(prefix: String) {
         val deadline = System.currentTimeMillis() + AWAIT_SECONDS * 1_000
         while (System.currentTimeMillis() < deadline) {
@@ -172,5 +187,24 @@ class ScreenRecordToolsTest {
     private companion object {
         const val AWAIT_SECONDS = 5L
         const val POLL_MS = 10L
+    }
+
+    @Test
+    fun `a recording that hit its own time limit is cleaned off the device`() {
+        start()
+        awaitCommand("screenrecord")
+
+        // The time limit elapses: screenrecord returns on its own and no one ever calls stop,
+        // so nothing will pull this file. Starting again drops the dead session — and used to
+        // drop the recording with it, leaving one abandoned mp4 on /sdcard every time.
+        recordingEnded.countDown()
+
+        startWhenFree()
+
+        awaitCommand("rm -f")
+        assertTrue(
+            issued.toList().any { it.startsWith("rm -f") && it.contains(".mp4") },
+            "the expired recording should be removed from the device; saw ${issued.toList()}",
+        )
     }
 }

--- a/src/test/kotlin/spock/adb/mcp/ScreenRecordToolsTest.kt
+++ b/src/test/kotlin/spock/adb/mcp/ScreenRecordToolsTest.kt
@@ -1,0 +1,176 @@
+package spock.adb.mcp
+
+import com.android.ddmlib.IDevice
+import com.android.ddmlib.IShellOutputReceiver
+import com.google.gson.JsonObject
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.io.TempDir
+import spock.adb.device.ConnectedDevice
+import spock.adb.mcp.tools.PullFileTool
+import spock.adb.mcp.tools.ScreenRecorder
+import spock.adb.mcp.tools.StartScreenRecordTool
+import spock.adb.mcp.tools.StopScreenRecordTool
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.Collections
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+/**
+ * A recording session outlives the tool call that started it, so the state machine — not the
+ * shell command — is what these tests are about.
+ *
+ * The fake device blocks on `screenrecord` the way a real one does, and releases when the
+ * interrupt arrives. Without that, the recording would "finish" the instant it started and
+ * the double-start case could never be reproduced.
+ */
+class ScreenRecordToolsTest {
+
+    @TempDir
+    lateinit var pullDirectory: Path
+
+    private val issued: MutableList<String> = Collections.synchronizedList(mutableListOf())
+    private val recordingEnded = CountDownLatch(1)
+
+    private val device = mockk<IDevice>(relaxed = true)
+    private val connected: ConnectedDevice = FakeToolContext.device("emulator-5554").copy(device = device)
+    private val context get() = FakeToolContext(available = listOf(connected))
+
+    private fun stopTool() = StopScreenRecordTool(PullFileTool { pullDirectory })
+
+    @BeforeEach
+    fun setUp() {
+        ScreenRecorder.reset()
+
+        val command = slot<String>()
+        val receiver = slot<IShellOutputReceiver>()
+        every {
+            device.executeShellCommand(capture(command), capture(receiver), any(), any<TimeUnit>())
+        } answers {
+            val issuedCommand = command.captured
+            issued += issuedCommand
+            when {
+                // screenrecord blocks until it is interrupted or hits its time limit.
+                issuedCommand.startsWith("screenrecord") ->
+                    recordingEnded.await(AWAIT_SECONDS, TimeUnit.SECONDS)
+                issuedCommand.startsWith("pkill") -> recordingEnded.countDown()
+            }
+            receiver.captured.flush()
+        }
+        every { device.pullFile(any(), any()) } answers {
+            Files.write(Path.of(secondArg<String>()), byteArrayOf(0x00, 0x01, 0x02))
+            Unit
+        }
+    }
+
+    @AfterEach
+    fun tearDown() {
+        recordingEnded.countDown()
+        ScreenRecorder.reset()
+    }
+
+    private fun start(arguments: JsonObject = JsonObject()) =
+        StartScreenRecordTool().execute(arguments, context)
+
+    private fun awaitCommand(prefix: String) {
+        val deadline = System.currentTimeMillis() + AWAIT_SECONDS * 1_000
+        while (System.currentTimeMillis() < deadline) {
+            if (issued.toList().any { it.startsWith(prefix) }) return
+            Thread.sleep(POLL_MS)
+        }
+        error("no '$prefix' command was issued; saw ${issued.toList()}")
+    }
+
+    @Test
+    fun `starting records to the device and says how to retrieve it`() {
+        val result = start()
+        awaitCommand("screenrecord")
+
+        assertFalse(result.isError)
+        assertTrue(result.text().contains("android_stop_screen_recording"), result.text())
+        val command = issued.toList().first { it.startsWith("screenrecord") }
+        assertTrue(command.contains("--time-limit 180"), command)
+        assertTrue(command.contains("spock-adb-recording"), command)
+    }
+
+    @Test
+    fun `a time limit beyond the platform's three-minute cap is clamped`() {
+        start(JsonObject().apply { addProperty("timeLimitSeconds", 9_999) })
+        awaitCommand("screenrecord")
+
+        val command = issued.toList().first { it.startsWith("screenrecord") }
+        assertTrue(command.contains("--time-limit 180"), command)
+    }
+
+    @Test
+    fun `starting a second recording on the same device is refused`() {
+        start()
+        awaitCommand("screenrecord")
+
+        val failure = assertThrows<IllegalStateException> { start() }
+
+        assertTrue(failure.message!!.contains("has been running"), failure.message)
+        assertTrue(failure.message!!.contains("emulator-5554"), failure.message)
+        assertTrue(
+            failure.message!!.contains("android_stop_screen_recording"),
+            "should say how to recover: ${failure.message}",
+        )
+    }
+
+    @Test
+    fun `stopping without starting says so rather than pulling a file that is not there`() {
+        val failure = assertThrows<IllegalStateException> { stopTool().execute(JsonObject(), context) }
+
+        assertTrue(failure.message!!.contains("No recording is running"), failure.message)
+    }
+
+    @Test
+    fun `stopping interrupts rather than kills, so the video is playable`() {
+        start()
+        awaitCommand("screenrecord")
+
+        stopTool().execute(JsonObject(), context)
+
+        val kill = issued.toList().first { it.startsWith("pkill") }
+        // SIGKILL would leave an MP4 with no index that no player will open.
+        assertTrue(kill.contains("-INT"), kill)
+    }
+
+    @Test
+    fun `stopping retrieves the video and clears it off the device`() {
+        start()
+        awaitCommand("screenrecord")
+
+        val result = stopTool().execute(JsonObject(), context)
+
+        assertFalse(result.isError, result.text())
+        val pulled = Files.list(pullDirectory).use { it.toList() }
+        assertTrue(pulled.size == 1, "expected exactly one pulled file, got $pulled")
+        assertTrue(pulled.single().fileName.toString().endsWith(".mp4"), pulled.toString())
+        assertTrue(issued.toList().any { it.startsWith("rm -f") }, issued.toList().toString())
+    }
+
+    @Test
+    fun `after stopping, a new recording can start`() {
+        start()
+        awaitCommand("screenrecord")
+        stopTool().execute(JsonObject(), context)
+
+        val result = start()
+
+        assertFalse(result.isError, result.text())
+    }
+
+    private companion object {
+        const val AWAIT_SECONDS = 5L
+        const val POLL_MS = 10L
+    }
+}

--- a/src/test/kotlin/spock/adb/mcp/SelectProjectToolTest.kt
+++ b/src/test/kotlin/spock/adb/mcp/SelectProjectToolTest.kt
@@ -61,8 +61,9 @@ class SelectProjectToolTest {
     @Test
     fun `a tool needing a project fails with the reason, not a bare null`() {
         // McpProtocol turns a thrown IllegalStateException into a tool error result, so the
-        // agent reads the actionable message rather than "no project is open" for a case
-        // that is really "say which project".
+        // agent reads why the call failed instead of receiving a bare null. This is the case
+        // where nothing is open at all; the ambiguous one, where several are open and the
+        // answer is "say which project", is covered by ProjectResolutionTest.
         val protocol = McpProtocol(contextProvider = { FakeToolContext(project = null) })
         val response = protocol.handle(
             """{"jsonrpc":"2.0","id":1,"method":"tools/call",""" +

--- a/src/test/kotlin/spock/adb/mcp/SelectProjectToolTest.kt
+++ b/src/test/kotlin/spock/adb/mcp/SelectProjectToolTest.kt
@@ -1,0 +1,82 @@
+package spock.adb.mcp
+
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import spock.adb.mcp.tools.SelectProjectTool
+import spock.adb.mcp.tools.ToolRegistry
+import spock.adb.mcp.tools.ToolSafety
+
+/**
+ * `android_select_project` is how an agent resolves the ambiguity that two open projects
+ * create. Without it the ambiguity error would name a fix the agent cannot perform.
+ */
+class SelectProjectToolTest {
+
+    private val context = FakeToolContext(openProjects = listOf("app", "sdk"))
+
+    @Test
+    fun `selecting a project reports it and the application id it implies`() {
+        val result = SelectProjectTool().execute(
+            JsonObject().apply { addProperty("projectName", "sdk") },
+            context,
+        )
+
+        assertTrue(!result.isError)
+        assertEquals("sdk", context.selectedProject)
+        // The application ID is what the selection actually changes, so it is reported back.
+        assertTrue(result.text().contains("com.example.app"), result.text())
+    }
+
+    @Test
+    fun `an unknown project name lists the ones that are open`() {
+        val failure = runCatching {
+            SelectProjectTool().execute(
+                JsonObject().apply { addProperty("projectName", "nope") },
+                context,
+            )
+        }.exceptionOrNull()
+
+        assertNotNull(failure)
+        assertTrue(failure!!.message.orEmpty().contains("app, sdk"), failure.message.orEmpty())
+    }
+
+    @Test
+    fun `a missing project name is rejected rather than guessed at`() {
+        assertTrue(
+            runCatching { SelectProjectTool().execute(JsonObject(), context) }.isFailure,
+        )
+    }
+
+    @Test
+    fun `it is registered, and selecting a project is not a read-only operation`() {
+        val tool = ToolRegistry.find("android_select_project")
+        assertNotNull(tool)
+        assertEquals(ToolSafety.SAFE_ACTION, tool!!.safety)
+    }
+
+    @Test
+    fun `a tool needing a project fails with the reason, not a bare null`() {
+        // McpProtocol turns a thrown IllegalStateException into a tool error result, so the
+        // agent reads the actionable message rather than "no project is open" for a case
+        // that is really "say which project".
+        val protocol = McpProtocol(contextProvider = { FakeToolContext(project = null) })
+        val response = protocol.handle(
+            """{"jsonrpc":"2.0","id":1,"method":"tools/call",""" +
+                """"params":{"name":"android_get_current_activity","arguments":{}}}""",
+        )!!
+
+        val result = JsonParser.parseString(response).asJsonObject.getAsJsonObject("result")
+        assertTrue(result.get("isError").asBoolean)
+        assertTrue(
+            result.getAsJsonArray("content").first().asJsonObject.get("text").asString
+                .contains("No project is open"),
+        )
+    }
+
+    private fun spock.adb.mcp.tools.ToolResult.text(): String =
+        content.filterIsInstance<spock.adb.mcp.tools.ToolContent.Text>().joinToString("\n") { it.text }
+}

--- a/src/test/kotlin/spock/adb/mcp/SelectProjectToolTest.kt
+++ b/src/test/kotlin/spock/adb/mcp/SelectProjectToolTest.kt
@@ -77,7 +77,4 @@ class SelectProjectToolTest {
                 .contains("No project is open"),
         )
     }
-
-    private fun spock.adb.mcp.tools.ToolResult.text(): String =
-        content.filterIsInstance<spock.adb.mcp.tools.ToolContent.Text>().joinToString("\n") { it.text }
 }

--- a/src/test/kotlin/spock/adb/mcp/ToolResultText.kt
+++ b/src/test/kotlin/spock/adb/mcp/ToolResultText.kt
@@ -1,0 +1,8 @@
+package spock.adb.mcp
+
+import spock.adb.mcp.tools.ToolContent
+import spock.adb.mcp.tools.ToolResult
+
+/** The text of a tool result, which is what almost every assertion here is about. */
+fun ToolResult.text(): String =
+    content.filterIsInstance<ToolContent.Text>().joinToString("\n") { it.text }

--- a/src/test/kotlin/spock/adb/mcp/ToolSafetyTest.kt
+++ b/src/test/kotlin/spock/adb/mcp/ToolSafetyTest.kt
@@ -52,6 +52,7 @@ class ToolSafetyTest {
                 "android_get_processes",
                 "android_get_battery_info",
                 "android_get_network_info",
+                "android_get_debug_context",
                 "android_take_screenshot",
                 "android_get_ui_tree",
                 "android_find_ui_element",


### PR DESCRIPTION
Four commits toward the 5.0 release: two new tool groups, one triage bundle, and two defect
fixes in the MCP layer.

## What's here

**`23fa1a2` — `android_get_debug_context`**
One call returning activity, UI semantics, logcat and a screenshot describing the same moment,
instead of the four round trips an agent has to know to make.

**`b6ed821` — file transfer and screen recording**
`PushFileTool`, `PullFileTool`, `StartScreenRecordTool`, `StopScreenRecordTool`. Both go through
`executeShellCommand` rather than the obvious ddmlib APIs, which Android Studio ships as stubs —
the same failure that broke `android_take_screenshot`. Device paths are restricted to `/sdcard`,
`/storage` and `/data/local/tmp`, and the local destination of a pull is deliberately *not* a
parameter, so nothing holding the MCP token can choose where a file lands.

**`a541b9f` — two defects: project resolution, and start/stop on the EDT**

*Every project-dependent tool failed whenever two projects were open.* The tool context resolved
the project with `openProjects.singleOrNull { !it.isDisposed }`, so a second open project turned
`android_get_current_activity`, `android_get_activity_stack`, `android_get_current_fragments`
and the default logcat package filter into "No project is open" — wrong, and unactionable.

Resolution now follows the rule `requireDevice` already uses: the selected project, or the only
one open, and otherwise **refuse to guess** and name the candidates. Falling back to the focused
window was rejected deliberately — it is wrong exactly when it matters most, with an agent
working while the developer looks at something else. `ProjectResolution` is generic and free of
IntelliJ types so the rule is unit tested directly, and `android_select_project` exists so the
ambiguity error names a fix the agent can actually perform.

*Starting and stopping the MCP server ran on the EDT.* Starting binds two sockets and writes the
stdio endpoint descriptor; stopping waits for live stdio sessions to end. Stopping from the MCP
panel with a client attached froze the tool window until that wait expired. Both transitions now
run on a pooled thread, the panel shows the transition and disables its controls, and Restart
chains stop → start. The menu actions had the same defect. `start()` is also idempotent now —
called twice it used to replace the HTTP server and strand the previous bridge's threads.

**`e719fc9` — plan checklist update**

**`3515cac` — the two test guards the commits above refer to**
`StubbedIDeviceApiTest` scans compiled bytecode for calls to the nineteen `IDevice` methods
Android Studio leaves unimplemented — it reads bytecode rather than source because Kotlin's
property syntax hides the call (`device.screenshot` is `getScreenshot()`). `McpSmokeTest` calls
every read-only tool against a real device through a running server; its live checks are opt-in
via `SPOCK_MCP_URL` / `SPOCK_MCP_TOKEN`, but its coverage assertion always runs.

**`8a28765` / `b6cb6fb` — README tool count, and a guard against it drifting again**
The README said 36 against a registry of 42, in two places — one of them inside the
`<!-- Plugin description -->` block that `buildPlugin` extracts into the Marketplace listing, so
the stale number was on the public plugin page. `ReadmeToolCountTest` now fails the build when
the count is wrong *or* when the wording changes such that no count is found, so rewording
cannot silently disable the check. Both failure modes were verified by breaking the README.

**`a9c2963` — probe tables fixed, and the CHANGELOG filled in**
`McpSmokeTest.PROBES` was a map keyed by tool name, so probing one tool two ways silently
dropped the first entry; both tables are lists of pairs now. The `[Unreleased]` section gained
entries for the debug context, file transfer and screen recording tools, which CI reads to
populate the GitHub Release and Marketplace change notes.

## Verification

- `./gradlew test detekt` is green at **each** commit, checked in a separate worktree so a
  bisect does not land on a red intermediate.
- New coverage: `ProjectResolutionTest` (10 cases), `SelectProjectToolTest`, `FileToolsTest`,
  `ScreenRecordToolsTest`.
- No new platform APIs beyond ones already used elsewhere in the plugin, so `sinceBuild=231` is
  unaffected. `verifyPlugin` has not been run locally — CI covers it.

**`4412544` — `docs/MCP.md` brought back in line with the code**
Its "Not yet implemented" list named three features that ship (screen recording, file push/pull,
the activity panel); the safety table named `android_get_ui_hierarchy`, which has never existed,
and omitted `android_uninstall_app` from the destructive row. The table is now generated from
`ToolRegistry`, all six new tools are documented, and every one of the 42 registered tool names
appears in the file.

## Known gaps, called out rather than left to be found

- **No per-tool allow-list.** A developer cannot expose the read-only tools and nothing else;
  the per-call confirmation on destructive tools is the only boundary. Recorded in `docs/MCP.md`.
- **`prompts/list` returns an empty array.** The debugging workflows in `docs/MCP.md` are prose
  an agent cannot call.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
