### PR TITLE
MCP: per-tool access control, and an activity trail that survives a restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@
   and never retried: retrying a rejected request spends money to be rejected again
 - The API key lives in `PasswordSafe` and nowhere else — never in the settings XML, the audit
   history or the log
+- **Per-tool access control.** `Settings → Tools → Spock ADB → Tool Access` lists every tool
+  grouped by safety level, with "Enable all" and "Read-only only". Confirmation alone could not
+  express this: it sees one call at a time, and `android_push_file` and `android_pull_file` are
+  individually reasonable but compose into reading any file on the machine. A disabled tool is
+  still listed and still described, and refuses when called naming itself and where the switch
+  is, so an agent is told it was turned off rather than hunting for a tool it can see
+  documented. The refusal is audited like any other call — an agent reaching for something it
+  was denied is the entry most worth reviewing. Both ways in consult the same setting
+- **The activity history now survives a restart.** Calls are appended as newline-delimited JSON
+  under the IDE config directory, capped by the existing "keep the most recent N requests"
+  setting and written off the calling thread in batches, so an agent never waits on a disk
+  write. A file truncated by a crash costs one record rather than the history, and a failure to
+  persist is logged rather than failing the tool call that was being recorded
 
 ### Fixed
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -192,7 +192,33 @@ Rules that hold regardless of what a client asks for:
 - The IDE window is brought forward when a confirmation is needed, because the request came
   from another application and you are probably not looking at it.
 - Destructive calls are written to `idea.log`, so "what did the agent do to my device"
-  survives a restart.
+  survives a restart. The full activity trail survives one too: it is kept as newline-delimited
+  JSON under the IDE config directory, capped by the same "keep the most recent N requests"
+  setting, and written off the calling thread so an agent never waits on a disk write.
+
+### Turning tools off
+
+`Settings → Tools → Spock ADB → Tool Access` lists every registered tool, grouped by safety
+level, with **Enable all** and **Read-only only** for the two decisions worth making in one
+click. The per-call confirmation on destructive tools is unchanged: this decides what may be
+*attempted*, that decides what actually runs.
+
+It exists because confirmation cannot see a *composition*. `android_push_file` and
+`android_pull_file` are individually reasonable and compose into reading any file on the
+machine; a dialog shown one call at a time has no way to notice that, and a list does not have
+to.
+
+Three properties are deliberate:
+
+- **A disabled tool is still listed and still described.** It refuses when called, naming
+  itself and where the switch is, so an agent is told "you turned this off" rather than hunting
+  for a tool it can see documented. The exception is the in-IDE assistant, which is handed a
+  fresh list every turn and so is simply not offered the tool.
+- **A refused call is audited like any other.** An agent reaching for something it was denied
+  is the entry most worth reviewing.
+- **The setting stores what is *off*.** A tool added by a later plugin update is therefore
+  available by default, rather than silently withheld from anyone who had ever opened the
+  screen.
 
 ### The arbitrary command tool
 
@@ -378,9 +404,6 @@ moment.
 
 Recorded honestly so the gaps are not mistaken for features:
 
-- **Per-tool allow-lists** so a developer can expose, say, the read-only tools and nothing
-  else. The per-call confirmation on destructive tools is the real boundary today, and there is
-  no way to remove a tool from the catalogue short of not starting the server.
 - **Prompts.** `prompts/list` answers with an empty array. The debugging workflows in this
   document are prose an agent cannot call.
 - **Cancellation over HTTP.** stdio honours `notifications/cancelled` by interrupting the

--- a/docs/PLAN-5.0.md
+++ b/docs/PLAN-5.0.md
@@ -186,14 +186,34 @@ conversation yet — that arrives with the UI it exists to serve.
 
 ## Phase 5 — Safety and control (P0)
 
-- [ ] `McpSettings.disabledTools: MutableSet<String>`; predicate consulted in
-      `McpProtocol.dispatch` **and** the assistant loop. The shared registry is never mutated.
-- [ ] A disabled tool returns a clear "disabled by user" error and is still recorded.
-- [ ] Settings UI: checkbox list grouped by safety level.
-- [ ] History persistence: append-only NDJSON under `<config>/spock-adb/`, capped by
+`ToolGate`, `McpHistoryStore`, `McpHistoryWriter`, `McpSettings.disabledTools`, and the
+Tool Access section of `SpockAdbConfigurable`.
+
+- [x] `McpSettings.disabledTools: MutableSet<String>`; predicate consulted in
+      `McpProtocol.toolsCall` **and** `RegistryAgentTools`. The shared registry is never mutated.
+- [x] A disabled tool returns a clear "disabled by user" error and is still recorded.
+- [x] Settings UI: checkbox list grouped by safety level.
+- [x] History persistence: append-only NDJSON under `<config>/spock-adb/`, capped by
       `historySize`, batched writes off the EDT, loaded on start.
-- [ ] Tests: disabled-tool error path, NDJSON round-trip and cap, and a regression asserting
-      no new tool can perform a destructive action unconfirmed (extend `ToolSafetyTest`).
+- [x] Tests: disabled-tool error path, NDJSON round-trip and cap, and a regression asserting
+      no new tool can perform a destructive action unconfirmed (`ToolSafetyTest` already
+      carries it — `no destructive tool can report success without a confirmation` runs over
+      every registered destructive tool, so a tool added later is covered without being named).
+
+Decisions worth keeping:
+
+- **Disabled is stored, not enabled.** An allow-list would silently withhold every tool added
+  by a later update from a developer who had once opened the screen, which reads as the update
+  being broken.
+- **A disabled tool stays in `tools/list` and refuses on call.** Hiding it would send an agent
+  hunting for a tool it can see documented, and would leave the audit trail silent about the
+  attempt. The assistant is the deliberate exception: it is handed a fresh list every turn, so
+  offering it a tool certain to refuse would spend a turn to learn what the list could say.
+- **A refusal is audited like any other result.** An agent reaching for something it was denied
+  is the entry most worth reviewing; it must not be the one kind of call that leaves no trace.
+- **Writes are asynchronous and drained in batches.** The thread recording a call is the one
+  answering it. `McpHistoryWriter.shutdown()` flushes, so the calls made as the IDE closes —
+  exactly the ones worth having — are not the ones lost.
 
 ## Phase 6 — UI/UX polish (P2)
 

--- a/src/main/kotlin/spock/adb/assistant/RegistryAgentTools.kt
+++ b/src/main/kotlin/spock/adb/assistant/RegistryAgentTools.kt
@@ -1,6 +1,7 @@
 package spock.adb.assistant
 
 import spock.adb.mcp.McpCall
+import spock.adb.mcp.ToolGate
 import spock.adb.mcp.tools.ToolContent
 import spock.adb.mcp.tools.ToolContext
 import spock.adb.mcp.tools.ToolRegistry
@@ -23,9 +24,20 @@ import spock.adb.mcp.tools.ToolResult
 class RegistryAgentTools(
     private val contextProvider: () -> ToolContext,
     private val audit: (McpCall) -> Unit = {},
+    /** The same switch the MCP transports consult — one setting, both ways in. */
+    private val isToolEnabled: (String) -> Boolean = { true },
 ) : AgentTools {
 
-    override fun specs(): List<ToolSpec> = ToolRegistry.all().toToolSpecs()
+    /**
+     * Only the tools that may actually run.
+     *
+     * Unlike the MCP transports, which list everything and refuse on call because a client may
+     * cache a tool list across a settings change, the model is given a fresh list every turn.
+     * Offering it a tool that is certain to refuse would spend a turn and a tool call to learn
+     * something the list could have said.
+     */
+    override fun specs(): List<ToolSpec> =
+        ToolRegistry.all().filter { isToolEnabled(it.name) }.toToolSpecs()
 
     // A tool boundary must not be able to end the conversation: whatever went wrong is a
     // result the model can read and act on, and an exception here would instead be a stack
@@ -40,12 +52,20 @@ class RegistryAgentTools(
             )
 
         val startedAt = System.currentTimeMillis()
-        val result = try {
-            tool.execute(call.arguments, contextProvider())
-        } catch (e: Exception) {
-            // Includes a declined confirmation, which reaches here as a thrown refusal. The
-            // model needs to be told "no" in words; silence would look like a tool that hung.
-            ToolResult.error(e.message ?: "${e.javaClass.simpleName} while running ${call.name}")
+        // The check is still needed despite the filtered list: a tool switched off part-way
+        // through a conversation is still in the history the model is reasoning from. It falls
+        // through to the audit below rather than returning early, so a blocked attempt shows in
+        // the Activity tab exactly as one over MCP does.
+        val result = if (!isToolEnabled(call.name)) {
+            ToolResult.error(ToolGate.refusal(call.name))
+        } else {
+            try {
+                tool.execute(call.arguments, contextProvider())
+            } catch (e: Exception) {
+                // Includes a declined confirmation, which reaches here as a thrown refusal. The
+                // model needs to be told "no" in words; silence would look like a tool that hung.
+                ToolResult.error(e.message ?: "${e.javaClass.simpleName} while running ${call.name}")
+            }
         }
 
         val text = result.content.joinToString("\n") { item ->

--- a/src/main/kotlin/spock/adb/mcp/McpHistoryStore.kt
+++ b/src/main/kotlin/spock/adb/mcp/McpHistoryStore.kt
@@ -1,0 +1,192 @@
+package spock.adb.mcp
+
+import com.google.gson.Gson
+import com.google.gson.JsonSyntaxException
+import spock.adb.mcp.tools.ToolSafety
+import java.io.IOException
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
+
+/**
+ * The activity history, on disk.
+ *
+ * In-memory history is lost on the restart that most often prompts the question it answers:
+ * "what did that agent do to my device?" Destructive calls already reach `idea.log` for this
+ * reason; this keeps the rest, in the same trust boundary and under the same cap.
+ *
+ * Newline-delimited JSON, appended a line at a time. An append cannot corrupt what is already
+ * written, a half-written trailing line costs one record rather than the file, and it needs no
+ * schema migration when a field is added — an unreadable line is skipped rather than fatal.
+ *
+ * Free of IntelliJ types so the round trip, the cap and the tolerance for a truncated file can
+ * be tested directly rather than only inside a running IDE.
+ */
+class McpHistoryStore(
+    private val file: Path,
+    capacity: Int,
+    /**
+     * Reported rather than swallowed. A history that has quietly stopped persisting looks
+     * exactly like one with nothing to say, which is the one moment it matters that the two
+     * are told apart, so the caller is given the failure to log.
+     */
+    private val onError: (String, IOException) -> Unit = { _, _ -> },
+) {
+
+    var capacity: Int = capacity.coerceAtLeast(1)
+        set(value) {
+            field = value.coerceAtLeast(1)
+        }
+
+    private val gson = Gson()
+
+    /**
+     * Appends one call.
+     *
+     * @return false when it could not be written. A history that cannot be persisted must not
+     *   take the tool call down with it — the call already happened.
+     */
+    fun append(calls: List<McpCall>): Boolean {
+        if (calls.isEmpty()) return true
+        return try {
+            file.parent?.let { Files.createDirectories(it) }
+            val lines = calls.joinToString("") { gson.toJson(Record.of(it)) + "\n" }
+            Files.write(
+                file,
+                lines.toByteArray(StandardCharsets.UTF_8),
+                StandardOpenOption.CREATE,
+                StandardOpenOption.WRITE,
+                StandardOpenOption.APPEND,
+            )
+            true
+        } catch (e: IOException) {
+            onError("could not append to the MCP history file", e)
+            false
+        }
+    }
+
+    /** Oldest first, capped to the newest [capacity]. Missing or unreadable file means empty. */
+    fun load(): List<McpCall> {
+        if (!Files.exists(file)) return emptyList()
+        val lines = try {
+            Files.readAllLines(file, StandardCharsets.UTF_8)
+        } catch (e: IOException) {
+            onError("could not read the MCP history file", e)
+            return emptyList()
+        }
+        return lines.mapNotNull(::parse).takeLast(capacity)
+    }
+
+    /**
+     * Rewrites the file to the newest [capacity] records.
+     *
+     * Appending forever is what makes appending cheap, so the trim is a separate, occasional
+     * step rather than something every write pays for. Written to a neighbour and moved into
+     * place, so an interrupted compaction cannot lose the history it was tidying.
+     */
+    fun compact(): Boolean {
+        val kept = load()
+        return try {
+            val staging = file.resolveSibling(file.fileName.toString() + ".compacting")
+            Files.write(
+                staging,
+                kept.joinToString("") { gson.toJson(Record.of(it)) + "\n" }
+                    .toByteArray(StandardCharsets.UTF_8),
+            )
+            Files.move(staging, file, java.nio.file.StandardCopyOption.REPLACE_EXISTING)
+            true
+        } catch (e: IOException) {
+            onError("could not compact the MCP history file", e)
+            false
+        }
+    }
+
+    /** True once the file holds meaningfully more than the cap, so trimming is worth doing. */
+    fun needsCompaction(): Boolean {
+        if (!Files.exists(file)) return false
+        val lines = runCatching { Files.readAllLines(file, StandardCharsets.UTF_8).size }.getOrDefault(0)
+        return lines > capacity * COMPACT_SLACK
+    }
+
+    fun clear(): Boolean = try {
+        Files.deleteIfExists(file)
+        true
+    } catch (e: IOException) {
+        onError("could not delete the MCP history file", e)
+        false
+    }
+
+    /**
+     * A line, or null when it cannot be read.
+     *
+     * Tolerant on purpose: a truncated last line after a crash, or a record written by a newer
+     * version, costs that one entry rather than the whole history.
+     */
+    private fun parse(line: String): McpCall? {
+        if (line.isBlank()) return null
+        val record = try {
+            gson.fromJson(line, Record::class.java)
+        } catch (ignored: JsonSyntaxException) {
+            // Named rather than reported: a line this cannot read is a case the format is
+            // designed for, not a fault, and a corrupt file would otherwise log once per line.
+            return null
+        } ?: return null
+        return record.toCall()
+    }
+
+    /**
+     * The on-disk shape, kept separate from [McpCall].
+     *
+     * [McpCall] is free to gain computed members and change constructor defaults; a stored
+     * record cannot, because files written by an older version have to keep loading.
+     */
+    private data class Record(
+        val toolName: String? = null,
+        val safety: String? = null,
+        val arguments: String? = null,
+        val result: String? = null,
+        val durationMs: Long = 0,
+        val isError: Boolean = false,
+        val client: String? = null,
+        val deviceSerial: String? = null,
+        val timestamp: Long = 0,
+    ) {
+        fun toCall(): McpCall? {
+            val name = toolName?.takeIf { it.isNotBlank() } ?: return null
+            val level = safety?.let { value ->
+                ToolSafety.entries.firstOrNull { it.name == value }
+            } ?: return null
+            return McpCall(
+                toolName = name,
+                safety = level,
+                arguments = arguments.orEmpty(),
+                result = result.orEmpty(),
+                durationMs = durationMs,
+                isError = isError,
+                client = client,
+                deviceSerial = deviceSerial,
+                timestamp = timestamp,
+            )
+        }
+
+        companion object {
+            fun of(call: McpCall) = Record(
+                toolName = call.toolName,
+                safety = call.safety.name,
+                arguments = call.arguments,
+                result = call.result,
+                durationMs = call.durationMs,
+                isError = call.isError,
+                client = call.client,
+                deviceSerial = call.deviceSerial,
+                timestamp = call.timestamp,
+            )
+        }
+    }
+
+    private companion object {
+        /** Let the file drift to twice the cap before rewriting it, so trims stay rare. */
+        const val COMPACT_SLACK = 2
+    }
+}

--- a/src/main/kotlin/spock/adb/mcp/McpHistoryWriter.kt
+++ b/src/main/kotlin/spock/adb/mcp/McpHistoryWriter.kt
@@ -1,0 +1,66 @@
+package spock.adb.mcp
+
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+/**
+ * [McpHistoryStore], written off the calling thread.
+ *
+ * The thread recording a call is the one answering it: an agent waiting on a result should not
+ * also be waiting on a disk write, still less on the occasional compaction that rewrites the
+ * whole file. Each task drains everything queued, so a burst of calls costs one append rather
+ * than one per call — which is the shape MCP traffic actually has.
+ *
+ * A failure to persist never propagates. The call has already happened; losing the record of it
+ * is worth a log line, not a failed tool call.
+ */
+class McpHistoryWriter(private val store: McpHistoryStore) {
+
+    private val pending = ConcurrentLinkedQueue<McpCall>()
+
+    /** One thread, so appends cannot interleave; daemon, so a pending write cannot hold the IDE open. */
+    private val worker = Executors.newSingleThreadExecutor { runnable ->
+        Thread(runnable, "spock-adb-mcp-history").apply { isDaemon = true }
+    }
+
+    fun record(call: McpCall) {
+        pending.add(call)
+        // Rejected once [shutdown] has run, which happens only as the IDE closes. The call is
+        // already in the in-memory history and, when destructive, in the IDE log.
+        runCatching { worker.execute(::drain) }
+    }
+
+    fun clear() {
+        pending.clear()
+        runCatching { worker.execute { store.clear() } }
+    }
+
+    /**
+     * Writes what is still queued, then stops accepting work.
+     *
+     * Without the flush, the calls made in the last moments before the IDE closes would be
+     * exactly the ones missing from the record of what an agent did. Bounded, because a stuck
+     * disk must not hold up shutdown.
+     */
+    fun shutdown() {
+        runCatching { worker.submit(::drain).get(FLUSH_TIMEOUT_SECONDS, TimeUnit.SECONDS) }
+        worker.shutdownNow()
+    }
+
+    private fun drain() {
+        val batch = mutableListOf<McpCall>()
+        while (true) {
+            batch += pending.poll() ?: break
+        }
+        // Nothing queued: an earlier task drained it. Returning before touching the store keeps
+        // an IDE that never records a call from creating the file at all.
+        if (batch.isEmpty()) return
+
+        if (store.append(batch) && store.needsCompaction()) store.compact()
+    }
+
+    private companion object {
+        const val FLUSH_TIMEOUT_SECONDS = 2L
+    }
+}

--- a/src/main/kotlin/spock/adb/mcp/McpProtocol.kt
+++ b/src/main/kotlin/spock/adb/mcp/McpProtocol.kt
@@ -20,6 +20,13 @@ import spock.adb.mcp.tools.ToolResult
 class McpProtocol(
     private val contextProvider: () -> ToolContext,
     private val auditLog: (McpCall) -> Unit = {},
+    /**
+     * Whether a tool the developer has switched off may run. Consulted here rather than by
+     * removing tools from the registry: a disabled tool stays listed, stays described, and
+     * refuses when called, so an agent is told why instead of hunting for a tool it can see
+     * documented — and the attempt still reaches the audit trail.
+     */
+    private val isToolEnabled: (String) -> Boolean = { true },
 ) {
 
     /**
@@ -131,7 +138,6 @@ class McpProtocol(
         )
     }
 
-    @Suppress("TooGenericExceptionCaught")
     private fun toolsCall(params: JsonObject?): JsonObject {
         val name = params?.get("name")?.asString
             ?: throw IllegalArgumentException("Missing tool name")
@@ -143,12 +149,13 @@ class McpProtocol(
             ).toJson()
 
         val startedAt = System.currentTimeMillis()
-        val result = try {
-            tool.execute(arguments, contextProvider())
-        } catch (e: Exception) {
-            // Surfaced as a tool error rather than a protocol error: the agent can read it,
-            // explain it to the user and try something else, which a JSON-RPC error hides.
-            ToolResult.error(e.message ?: "${e.javaClass.simpleName} while running $name")
+        // A refusal takes the same path as a result: it is audited, timed and returned like
+        // any other tool error, so a blocked attempt is visible in the activity trail rather
+        // than being the one kind of call that leaves no trace.
+        val result = if (isToolEnabled(name)) {
+            run(tool, name, arguments)
+        } else {
+            ToolResult.error(ToolGate.refusal(name))
         }
 
         auditLog(
@@ -164,6 +171,15 @@ class McpProtocol(
             ),
         )
         return result.toJson()
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun run(tool: AdbTool, name: String, arguments: JsonObject): ToolResult = try {
+        tool.execute(arguments, contextProvider())
+    } catch (e: Exception) {
+        // Surfaced as a tool error rather than a protocol error: the agent can read it,
+        // explain it to the user and try something else, which a JSON-RPC error hides.
+        ToolResult.error(e.message ?: "${e.javaClass.simpleName} while running $name")
     }
 
     private fun resourcesList(): JsonObject = JsonObject().apply {

--- a/src/main/kotlin/spock/adb/mcp/McpRequestHistory.kt
+++ b/src/main/kotlin/spock/adb/mcp/McpRequestHistory.kt
@@ -29,6 +29,23 @@ class McpRequestHistory(capacity: Int = DEFAULT_CAPACITY) {
     @Synchronized
     fun all(): List<McpCall> = calls.toList().asReversed()
 
+    /**
+     * Inserts [older] ahead of everything already here, oldest first.
+     *
+     * Used to bring the persisted history back at startup. It prepends rather than replaces
+     * because the load runs off the EDT and a call can be recorded while it is in flight —
+     * replacing would throw that call away, which is the one the developer is watching for. The
+     * caller loads once; loading twice would double the entries.
+     */
+    @Synchronized
+    fun prepend(older: List<McpCall>) {
+        val live = calls.toList()
+        calls.clear()
+        calls.addAll(older)
+        calls.addAll(live)
+        trim()
+    }
+
     @Synchronized
     fun clear() = calls.clear()
 

--- a/src/main/kotlin/spock/adb/mcp/McpServerService.kt
+++ b/src/main/kotlin/spock/adb/mcp/McpServerService.kt
@@ -16,6 +16,7 @@ import spock.adb.mcp.stdio.SpockAdbStdioLauncher
 import java.nio.file.Path
 import java.security.SecureRandom
 import java.util.Base64
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 
 /**
@@ -40,6 +41,27 @@ class McpServerService : PersistentStateComponent<McpSettings>, Disposable {
     private val selectedProject = AtomicReference<String?>(null)
     private val history = McpRequestHistory()
 
+    /**
+     * Read on a server thread for every tool call, written from the settings dialog. Held as
+     * an immutable set that is *replaced* rather than mutated, so a reader sees either the
+     * old membership or the new one and never a set being rebuilt underneath it.
+     */
+    private val disabledToolNames = AtomicReference<Set<String>>(emptySet())
+
+    /**
+     * Both built on first use: an IDE where the server is never enabled reads no file and
+     * starts no thread.
+     */
+    private val historyStore: McpHistoryStore by lazy {
+        McpHistoryStore(
+            file = endpointDirectory().resolve(HISTORY_FILE),
+            capacity = settings.historySize,
+            onError = { message, error -> log.warn("$message; the activity view is unaffected", error) },
+        )
+    }
+    private val historyWriter: McpHistoryWriter by lazy { McpHistoryWriter(historyStore) }
+    private val historyLoaded = AtomicBoolean(false)
+
     private var server: McpHttpServer? = null
     private var bridge: McpBridgeServer? = null
     private var protocol: McpProtocol? = null
@@ -59,6 +81,11 @@ class McpServerService : PersistentStateComponent<McpSettings>, Disposable {
     override fun loadState(state: McpSettings) {
         settings = state
         if (settings.token.isBlank()) settings.token = generateToken()
+        disabledToolNames.set(state.disabledTools.toSet())
+        // Off the calling thread: this runs during IDE startup and the file can hold thousands
+        // of records. Nothing waits on it — the activity view shows what has arrived so far,
+        // and a call recorded while it is in flight is kept rather than overwritten.
+        ApplicationManager.getApplication().executeOnPooledThread(::ensureHistoryLoaded)
     }
 
     @Synchronized
@@ -74,9 +101,10 @@ class McpServerService : PersistentStateComponent<McpSettings>, Disposable {
         val mcpProtocol = McpProtocol(
             contextProvider = { McpToolContext(selectedSerial, selectedProject) },
             auditLog = ::record,
+            isToolEnabled = ::isToolEnabled,
         )
         protocol = mcpProtocol
-        history.capacity = settings.historySize
+        ensureHistoryLoaded()
         val httpServer = McpHttpServer(mcpProtocol, settings.token)
         val boundPort = httpServer.start(settings.port)
         server = httpServer
@@ -168,7 +196,38 @@ class McpServerService : PersistentStateComponent<McpSettings>, Disposable {
         return settings.token
     }
 
-    /** Most recent tool calls, newest first, for the activity view. */
+    /**
+     * Whether [toolName] may run at all.
+     *
+     * Both ways in consult this — the MCP transports through [McpProtocol], the built-in
+     * assistant through `RegistryAgentTools` — so the switch means the same thing wherever
+     * the call came from.
+     */
+    fun isToolEnabled(toolName: String): Boolean = ToolGate.isEnabled(toolName, disabledToolNames.get())
+
+    /** The tools switched off, for the settings screen. */
+    val disabledTools: Set<String> get() = disabledToolNames.get()
+
+    /**
+     * Replaces the set of disabled tools.
+     *
+     * Takes effect on the next call, on a running server: the predicate is consulted per call
+     * rather than baked into the tool list, so turning a tool off does not need a restart and
+     * cannot be outrun by a client that cached `tools/list`.
+     */
+    fun setDisabledTools(names: Set<String>) {
+        // Sorted so the settings file does not churn on save, and so a diff of it is readable.
+        val stored = names.toSortedSet().toMutableSet()
+        settings.disabledTools = stored
+        disabledToolNames.set(stored.toSet())
+    }
+
+    /**
+     * Most recent tool calls, newest first, for the activity view.
+     *
+     * Reads memory only. The panel calls this on the EDT, and parsing the history file there
+     * would be a visible hitch every time the tool window opens.
+     */
     fun recentCalls(): List<McpCall> = history.all()
 
     fun queryHistory(filter: McpHistoryFilter): List<McpCall> = history.query(filter)
@@ -177,7 +236,10 @@ class McpServerService : PersistentStateComponent<McpSettings>, Disposable {
 
     fun knownClients(): List<String> = history.knownClients()
 
-    fun clearHistory() = history.clear()
+    fun clearHistory() {
+        history.clear()
+        historyWriter.clear()
+    }
 
     /**
      * What the connected client reported at `initialize`.
@@ -200,13 +262,32 @@ class McpServerService : PersistentStateComponent<McpSettings>, Disposable {
         set(value) {
             settings.historySize = value
             history.capacity = value
+            // The in-memory cap is authoritative; the file follows it so a lowered cap
+            // actually shrinks what is kept on disk rather than only what is displayed.
+            historyStore.capacity = history.capacity
         }
+
+    /**
+     * Brings the persisted history into memory, once.
+     *
+     * Never on the EDT: it opens and parses a file that is capped, but capped at thousands of
+     * records. Both callers are already off it — [start] runs on a pooled thread through
+     * [startAsync], and [loadState] schedules this on one.
+     */
+    private fun ensureHistoryLoaded() {
+        if (!historyLoaded.compareAndSet(false, true)) return
+        history.capacity = settings.historySize
+        historyStore.capacity = history.capacity
+        history.prepend(historyStore.load())
+    }
 
     private fun record(call: McpCall) {
         history.record(call)
+        historyWriter.record(call)
 
-        // Destructive calls are recorded in the IDE log too: the in-memory history is lost
-        // on restart, and "what did the agent do to my device" must survive that.
+        // Destructive calls reach the IDE log as well as the history file. The history is the
+        // developer's view and can be cleared from the panel; the log is the one an incident is
+        // reconstructed from, and the two should not be lost by the same action.
         if (call.safety == spock.adb.mcp.tools.ToolSafety.DESTRUCTIVE) {
             log.info("MCP destructive call: ${call.toolName} args=${call.arguments} error=${call.isError}")
         }
@@ -287,7 +368,10 @@ class McpServerService : PersistentStateComponent<McpSettings>, Disposable {
         PathManager.getJarPathForClass(SpockAdbStdioLauncher::class.java)
             ?: PathManager.getPluginsPath()
 
-    override fun dispose() = stop()
+    override fun dispose() {
+        stop()
+        historyWriter.shutdown()
+    }
 
     private fun generateToken(): String {
         val bytes = ByteArray(TOKEN_BYTES)
@@ -297,6 +381,9 @@ class McpServerService : PersistentStateComponent<McpSettings>, Disposable {
 
     companion object {
         private const val TOKEN_BYTES = 32
+
+        /** Beside the stdio endpoint descriptor, under the IDE config directory. */
+        const val HISTORY_FILE = "mcp-history.ndjson"
 
         fun getInstance(): McpServerService =
             ApplicationManager.getApplication().getService(McpServerService::class.java)
@@ -313,4 +400,12 @@ data class McpSettings(
     var token: String = "",
     /** How many tool calls to keep. Bounded so the log cannot grow without limit. */
     var historySize: Int = McpRequestHistory.DEFAULT_CAPACITY,
+    /**
+     * Tools the developer has switched off, by name.
+     *
+     * Stored as the exception rather than the allow-list so a tool added by a plugin update
+     * is available by default: an allow-list would silently withhold every new tool from a
+     * developer who had once opened this screen, which reads as the update being broken.
+     */
+    var disabledTools: MutableSet<String> = mutableSetOf(),
 )

--- a/src/main/kotlin/spock/adb/mcp/SpockAdbConfigurable.kt
+++ b/src/main/kotlin/spock/adb/mcp/SpockAdbConfigurable.kt
@@ -8,6 +8,9 @@ import com.intellij.openapi.options.ShowSettingsUtil
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBScrollPane
 import com.intellij.util.ui.JBUI
+import spock.adb.mcp.tools.AdbTool
+import spock.adb.mcp.tools.ToolRegistry
+import spock.adb.mcp.tools.ToolSafety
 import spock.adb.ui.WrapLayout
 import java.awt.BorderLayout
 import java.awt.FlowLayout
@@ -16,6 +19,7 @@ import java.awt.GridBagConstraints
 import java.awt.GridBagLayout
 import java.awt.Insets
 import javax.swing.JButton
+import javax.swing.JCheckBox
 import javax.swing.JComponent
 import javax.swing.JPanel
 import javax.swing.JSpinner
@@ -35,6 +39,9 @@ class SpockAdbConfigurable : Configurable {
     private var historySpinner: JSpinner? = null
     private var panel: JComponent? = null
 
+    /** One checkbox per registered tool, in registry order within its safety group. */
+    private val toolChecks = LinkedHashMap<String, JCheckBox>()
+
     override fun getDisplayName(): String = "Spock ADB"
 
     override fun createComponent(): JComponent {
@@ -47,6 +54,7 @@ class SpockAdbConfigurable : Configurable {
         }
 
         content.add(mcpSection(), constraints)
+        content.add(toolAccessSection(), constraints)
         content.add(shortcutSection(), constraints)
         content.add(
             JPanel().apply { },
@@ -92,6 +100,88 @@ class SpockAdbConfigurable : Configurable {
             },
         )
     }
+
+    /**
+     * Which tools an agent may call at all.
+     *
+     * Grouped by safety level rather than listed alphabetically because the useful decisions
+     * are made a group at a time — "read-only and nothing else" is the common one, and it is
+     * one click here. The per-call confirmation on destructive tools is unchanged: this
+     * decides what may be *attempted*, that decides what actually runs.
+     *
+     * Every tool is listed, including the disabled ones. A tool that vanished when switched
+     * off could not be switched back on.
+     */
+    private fun toolAccessSection(): JComponent {
+        toolChecks.clear()
+        val list = JPanel(GridBagLayout())
+        val constraints = GridBagConstraints().apply {
+            gridx = 0
+            anchor = GridBagConstraints.WEST
+            fill = GridBagConstraints.HORIZONTAL
+            weightx = 1.0
+        }
+
+        SAFETY_ORDER.forEach { safety ->
+            val group = ToolRegistry.all().filter { it.safety == safety }
+            if (group.isEmpty()) return@forEach
+            list.add(groupHeader(safety, group.size), constraints)
+            group.forEach { tool ->
+                val box = JCheckBox(tool.name).apply {
+                    isSelected = service.isToolEnabled(tool.name)
+                    toolTipText = tool.description
+                }
+                toolChecks[tool.name] = box
+                list.add(box, constraints)
+            }
+        }
+
+        return section(
+            "Tool Access",
+            JPanel(BorderLayout()).apply {
+                add(
+                    JBLabel(
+                        "<html>Tools that are switched off stay visible to the agent and refuse " +
+                            "when called, so it is told why rather than left guessing.</html>",
+                    ),
+                    BorderLayout.NORTH,
+                )
+                add(list, BorderLayout.CENTER)
+                add(bulkButtons(), BorderLayout.SOUTH)
+            },
+        )
+    }
+
+    private fun groupHeader(safety: ToolSafety, count: Int): JComponent = JBLabel(
+        "${safetyTitle(safety)} ($count)",
+    ).apply {
+        font = font.deriveFont(Font.BOLD)
+        border = JBUI.Borders.empty(GAP, 0, 2, 0)
+    }
+
+    private fun safetyTitle(safety: ToolSafety): String = when (safety) {
+        ToolSafety.READ_ONLY -> "Read-only"
+        ToolSafety.SAFE_ACTION -> "Changes state, undoable by hand"
+        ToolSafety.DESTRUCTIVE -> "Destructive — always asks before running"
+    }
+
+    private fun bulkButtons(): JComponent =
+        JPanel(WrapLayout(FlowLayout.LEFT, JBUI.scale(GAP), JBUI.scale(GAP))).apply {
+            add(JButton("Enable all").apply { addActionListener { selectWhere { true } } })
+            add(
+                JButton("Read-only only").apply {
+                    addActionListener { selectWhere { it.safety == ToolSafety.READ_ONLY } }
+                },
+            )
+        }
+
+    private fun selectWhere(predicate: (AdbTool) -> Boolean) {
+        ToolRegistry.all().forEach { tool -> toolChecks[tool.name]?.isSelected = predicate(tool) }
+    }
+
+    /** Names of the tools left unchecked. Empty when everything is enabled. */
+    private fun uncheckedTools(): Set<String> =
+        toolChecks.filterValues { !it.isSelected }.keys.toSet()
 
     private fun shortcutSection(): JComponent {
         val table = JPanel(GridBagLayout())
@@ -162,20 +252,26 @@ class SpockAdbConfigurable : Configurable {
         add(body, BorderLayout.CENTER)
     }
 
-    override fun isModified(): Boolean =
-        (historySpinner?.value as? Int)?.let { it != service.historySize } ?: false
+    override fun isModified(): Boolean {
+        val historyChanged = (historySpinner?.value as? Int)?.let { it != service.historySize } ?: false
+        val toolsChanged = toolChecks.isNotEmpty() && uncheckedTools() != service.disabledTools
+        return historyChanged || toolsChanged
+    }
 
     override fun apply() {
         (historySpinner?.value as? Int)?.let { service.historySize = it }
+        if (toolChecks.isNotEmpty()) service.setDisabledTools(uncheckedTools())
     }
 
     override fun reset() {
         historySpinner?.value = service.historySize
+        toolChecks.forEach { (name, box) -> box.isSelected = service.isToolEnabled(name) }
     }
 
     override fun disposeUIResources() {
         panel = null
         historySpinner = null
+        toolChecks.clear()
     }
 
     private companion object {
@@ -184,6 +280,9 @@ class SpockAdbConfigurable : Configurable {
         const val HISTORY_STEP = 50
         const val NOT_BOUND = "not bound"
         const val KEYMAP_ID = "preferences.keymap"
+
+        /** Least dangerous first, so the list reads as a widening of what an agent may do. */
+        val SAFETY_ORDER = listOf(ToolSafety.READ_ONLY, ToolSafety.SAFE_ACTION, ToolSafety.DESTRUCTIVE)
 
         /** Shown in the overview. Order matches how often they are actually used. */
         val SHORTCUT_ACTIONS = listOf(

--- a/src/main/kotlin/spock/adb/mcp/ToolGate.kt
+++ b/src/main/kotlin/spock/adb/mcp/ToolGate.kt
@@ -1,0 +1,34 @@
+package spock.adb.mcp
+
+/**
+ * Whether a tool may run at all, before anything about the call is considered.
+ *
+ * The per-call confirmation on destructive tools has been the only boundary until now, which
+ * leaves a developer no way to expose the read-only tools and nothing else. That gap is not
+ * theoretical: `android_push_file` and `android_pull_file` are individually reasonable and
+ * compose into reading any file on the machine. A confirmation dialog cannot see a
+ * composition; an allow-list does not have to.
+ *
+ * The registry is never mutated to express this. A disabled tool is still registered, still
+ * described in `tools/list`, and still refuses when called — hiding it would make an agent
+ * hunt for a tool it can see documented, and would leave the audit trail silent about the
+ * attempt.
+ */
+object ToolGate {
+
+    /**
+     * The refusal an agent sees. Names the tool and where the decision lives, so the model can
+     * tell "you turned this off" from "this failed", and say so to the developer rather than
+     * retrying.
+     */
+    fun refusal(toolName: String): String =
+        "The tool '$toolName' is disabled in Settings > Tools > Spock ADB. It was not run. " +
+            "Enable it there if you want it available, or use a different tool."
+
+    /**
+     * @param disabled tool names the developer switched off, matched exactly — these come from
+     *   the registry's own names, so a near-miss means the setting is stale rather than that a
+     *   tool should quietly run.
+     */
+    fun isEnabled(toolName: String, disabled: Set<String>): Boolean = toolName !in disabled
+}

--- a/src/test/kotlin/spock/adb/assistant/RegistryAgentToolsTest.kt
+++ b/src/test/kotlin/spock/adb/assistant/RegistryAgentToolsTest.kt
@@ -1,0 +1,77 @@
+package spock.adb.assistant
+
+import com.google.gson.JsonObject
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import spock.adb.mcp.FakeToolContext
+import spock.adb.mcp.McpCall
+import spock.adb.mcp.tools.ToolRegistry
+
+/**
+ * The assistant runs against the same registry and the same switch as the MCP transports, so
+ * what these cover is the one place the two deliberately differ: the assistant is handed a
+ * filtered tool list, where a transport lists everything and refuses on call.
+ */
+class RegistryAgentToolsTest {
+
+    private val context = FakeToolContext()
+    private val audited = mutableListOf<McpCall>()
+
+    private fun tools(enabled: (String) -> Boolean = { true }) = RegistryAgentTools(
+        contextProvider = { context },
+        audit = { audited += it },
+        isToolEnabled = enabled,
+    )
+
+    private fun listDevices(name: String = "android_list_devices") =
+        LlmToolCall(id = "call-1", name = name, arguments = JsonObject())
+
+    @Test
+    fun `the model is offered only the tools it may actually use`() {
+        // Offering one that is certain to refuse would spend a turn and a tool call to learn
+        // something the list could have said.
+        val specs = tools { it != "android_run_adb_command" }.specs().map { it.name }
+
+        assertEquals(ToolRegistry.all().size - 1, specs.size)
+        assertFalse(specs.contains("android_run_adb_command"))
+    }
+
+    @Test
+    fun `a tool switched off mid-conversation refuses rather than running`() {
+        // The filtered list is not enough on its own: the model is reasoning from a history
+        // that still contains the tool it was offered a turn ago.
+        val result = tools { false }.invoke(listDevices())
+
+        assertTrue(result.isError)
+        assertTrue(result.content.contains("disabled"), result.content)
+        assertFalse(result.content.contains("emulator-5554"), result.content)
+    }
+
+    @Test
+    fun `a blocked attempt reaches the same audit trail as a call that ran`() {
+        tools { false }.invoke(listDevices())
+
+        assertEquals(listOf("android_list_devices"), audited.map { it.toolName })
+        assertEquals(RegistryAgentTools.ASSISTANT_CLIENT, audited.single().client)
+        assertTrue(audited.single().isError)
+    }
+
+    @Test
+    fun `an enabled tool runs and is audited`() {
+        val result = tools().invoke(listDevices())
+
+        assertFalse(result.isError, result.content)
+        assertTrue(result.content.contains("emulator-5554"), result.content)
+        assertEquals(listOf("android_list_devices"), audited.map { it.toolName })
+    }
+
+    @Test
+    fun `a tool that does not exist is answered in words, not an exception`() {
+        val result = tools().invoke(listDevices(name = "android_no_such_tool"))
+
+        assertTrue(result.isError)
+        assertTrue(result.content.contains("no tool called"), result.content)
+    }
+}

--- a/src/test/kotlin/spock/adb/mcp/McpHistoryStoreTest.kt
+++ b/src/test/kotlin/spock/adb/mcp/McpHistoryStoreTest.kt
@@ -1,0 +1,139 @@
+package spock.adb.mcp
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import spock.adb.mcp.tools.ToolSafety
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
+
+/**
+ * The history file is what answers "what did that agent do to my device" after the restart
+ * that usually prompts the question, so the cases that matter are the ugly ones: a file
+ * truncated mid-write, a record written by a version that knows a field this one does not,
+ * and a directory the IDE cannot write to.
+ */
+class McpHistoryStoreTest {
+
+    @TempDir
+    lateinit var dir: Path
+
+    private val file: Path get() = dir.resolve("history.ndjson")
+
+    private fun store(capacity: Int = 100) = McpHistoryStore(file, capacity)
+
+    private fun call(
+        name: String = "android_list_devices",
+        safety: ToolSafety = ToolSafety.READ_ONLY,
+        error: Boolean = false,
+        at: Long = 1_000,
+    ) = McpCall(
+        toolName = name,
+        safety = safety,
+        arguments = """{"deviceSerial":"emulator-5554"}""",
+        result = "one device",
+        durationMs = 12,
+        isError = error,
+        client = "spock-assistant",
+        deviceSerial = "emulator-5554",
+        timestamp = at,
+    )
+
+    private fun appendRaw(line: String) =
+        Files.write(file, line.toByteArray(), StandardOpenOption.APPEND)
+
+    @Test
+    fun `a call survives the round trip with every field intact`() {
+        val original = call(name = "android_clear_app_data", safety = ToolSafety.DESTRUCTIVE, error = true)
+        store().append(listOf(original))
+
+        assertEquals(listOf(original), store().load())
+    }
+
+    @Test
+    fun `appending adds to what is already there rather than replacing it`() {
+        val store = store()
+        store.append(listOf(call(at = 1)))
+        store.append(listOf(call(at = 2)))
+
+        assertEquals(listOf(1L, 2L), store.load().map { it.timestamp })
+    }
+
+    @Test
+    fun `loading keeps the newest entries when the file holds more than the cap`() {
+        store().append((1L..10L).map { call(at = it) })
+
+        assertEquals(listOf(8L, 9L, 10L), store(capacity = 3).load().map { it.timestamp })
+    }
+
+    @Test
+    fun `a truncated last line costs one record, not the history`() {
+        val store = store()
+        store.append((1L..3L).map { call(at = it) })
+        // What a crash part-way through a write leaves behind.
+        appendRaw("""{"toolName":"android_l""")
+
+        assertEquals(listOf(1L, 2L, 3L), store.load().map { it.timestamp })
+    }
+
+    @Test
+    fun `a record from a newer version is skipped rather than fatal`() {
+        val store = store()
+        store.append(listOf(call(at = 1)))
+        appendRaw("""{"toolName":"x","safety":"SOMETHING_NEW","timestamp":2}""" + "\n")
+        store.append(listOf(call(at = 3)))
+
+        assertEquals(listOf(1L, 3L), store.load().map { it.timestamp })
+    }
+
+    @Test
+    fun `compaction rewrites the file down to the cap`() {
+        val store = store(capacity = 3)
+        store.append((1L..10L).map { call(at = it) })
+        assertTrue(store.needsCompaction())
+
+        assertTrue(store.compact())
+
+        assertEquals(3, Files.readAllLines(file).size)
+        assertEquals(listOf(8L, 9L, 10L), store.load().map { it.timestamp })
+        assertFalse(store.needsCompaction())
+    }
+
+    @Test
+    fun `compaction leaves no staging file behind`() {
+        val store = store(capacity = 2)
+        store.append((1L..6L).map { call(at = it) })
+        store.compact()
+
+        val left = Files.list(dir).use { paths -> paths.map { it.fileName.toString() }.sorted().toList() }
+        assertEquals(listOf("history.ndjson"), left)
+    }
+
+    @Test
+    fun `a missing file loads as empty rather than failing`() {
+        assertEquals(emptyList<McpCall>(), store().load())
+        assertFalse(store().needsCompaction())
+    }
+
+    @Test
+    fun `a history that cannot be written does not take the tool call down with it`() {
+        // The parent is a regular file, so creating the history under it can only fail.
+        val blocker = Files.write(dir.resolve("blocker"), byteArrayOf(1))
+        val store = McpHistoryStore(blocker.resolve("nested/history.ndjson"), 10)
+
+        assertFalse(store.append(listOf(call())))
+        assertEquals(emptyList<McpCall>(), store.load())
+    }
+
+    @Test
+    fun `clearing removes the file`() {
+        val store = store()
+        store.append(listOf(call()))
+
+        assertTrue(store.clear())
+        assertEquals(emptyList<McpCall>(), store.load())
+    }
+}

--- a/src/test/kotlin/spock/adb/mcp/McpHistoryWriterTest.kt
+++ b/src/test/kotlin/spock/adb/mcp/McpHistoryWriterTest.kt
@@ -1,0 +1,104 @@
+package spock.adb.mcp
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import spock.adb.mcp.tools.ToolSafety
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * The asynchronous half of the history.
+ *
+ * Every case ends at `shutdown()`, which is both the assertion point — it is the one moment the
+ * queue is guaranteed to be on disk — and what stops the test leaving a thread behind.
+ */
+class McpHistoryWriterTest {
+
+    @TempDir
+    lateinit var dir: Path
+
+    private val file: Path get() = dir.resolve("history.ndjson")
+
+    private fun call(at: Long) = McpCall(
+        toolName = "android_list_devices",
+        safety = ToolSafety.READ_ONLY,
+        arguments = "{}",
+        result = "one device",
+        durationMs = 1,
+        isError = false,
+        client = "Claude Code",
+        deviceSerial = "emulator-5554",
+        timestamp = at,
+    )
+
+    private fun writer(capacity: Int = 100): Pair<McpHistoryWriter, McpHistoryStore> {
+        val store = McpHistoryStore(file, capacity)
+        return McpHistoryWriter(store) to store
+    }
+
+    @Test
+    fun `recorded calls reach the file`() {
+        val (writer, store) = writer()
+
+        (1L..3L).forEach { writer.record(call(it)) }
+        writer.shutdown()
+
+        assertEquals(listOf(1L, 2L, 3L), store.load().map { it.timestamp })
+    }
+
+    @Test
+    fun `shutdown writes what is still queued`() {
+        // The calls made in the last moments before the IDE closes are exactly the ones worth
+        // having, so a shutdown that dropped the queue would fail at the only time it matters.
+        val (writer, store) = writer()
+
+        writer.record(call(1))
+        writer.shutdown()
+
+        assertEquals(1, store.load().size)
+    }
+
+    @Test
+    fun `an IDE that records nothing never creates the file`() {
+        val (writer, _) = writer()
+
+        writer.shutdown()
+
+        assertFalse(Files.exists(file), "the history file should not exist")
+    }
+
+    @Test
+    fun `the file is trimmed once it drifts past the cap`() {
+        val (writer, store) = writer(capacity = 3)
+
+        (1L..20L).forEach { writer.record(call(it)) }
+        writer.shutdown()
+
+        assertTrue(Files.readAllLines(file).size <= 3 * 2, Files.readAllLines(file).size.toString())
+        assertEquals(listOf(18L, 19L, 20L), store.load().map { it.timestamp })
+    }
+
+    @Test
+    fun `clearing removes the file and drops anything still queued`() {
+        val (writer, store) = writer()
+        writer.record(call(1))
+
+        writer.clear()
+        writer.shutdown()
+
+        assertEquals(emptyList<McpCall>(), store.load())
+    }
+
+    @Test
+    fun `recording after shutdown is ignored rather than thrown`() {
+        // Reached when a call lands as the IDE is closing. The tool call has already happened;
+        // failing it to report that its record could not be filed would be the wrong trade.
+        val (writer, _) = writer()
+        writer.shutdown()
+
+        writer.record(call(1))
+    }
+}

--- a/src/test/kotlin/spock/adb/mcp/McpProtocolTest.kt
+++ b/src/test/kotlin/spock/adb/mcp/McpProtocolTest.kt
@@ -124,4 +124,59 @@ class McpProtocolTest {
         assertEquals("abc", response.get("id").asString)
         assertNotNull(response.get("result"))
     }
+
+    @Test
+    fun `a disabled tool refuses, says why, and never reaches the device`() {
+        val disabled = McpProtocol(
+            contextProvider = { context },
+            auditLog = { calls += it },
+            isToolEnabled = { it != "android_list_devices" },
+        )
+
+        val result = JsonParser.parseString(
+            disabled.handle(
+                """{"jsonrpc":"2.0","id":9,"method":"tools/call",
+                   "params":{"name":"android_list_devices","arguments":{}}}""",
+            )!!,
+        ).asJsonObject.getAsJsonObject("result")
+
+        assertTrue(result.get("isError").asBoolean)
+        val text = result.getAsJsonArray("content").toString()
+        assertTrue(text.contains("disabled"), text)
+        assertTrue(text.contains("android_list_devices"), text)
+        // The device would have been named had the tool run at all.
+        assertFalse(text.contains("emulator-5554"), text)
+    }
+
+    @Test
+    fun `a blocked attempt is still audited`() {
+        // Otherwise the one kind of call worth reviewing — an agent reaching for something it
+        // was denied — would be the one kind that leaves no trace.
+        val disabled = McpProtocol(
+            contextProvider = { context },
+            auditLog = { calls += it },
+            isToolEnabled = { false },
+        )
+
+        disabled.handle(
+            """{"jsonrpc":"2.0","id":10,"method":"tools/call",
+               "params":{"name":"android_list_devices","arguments":{}}}""",
+        )
+
+        assertEquals(listOf("android_list_devices"), calls.map { it.toolName })
+        assertTrue(calls.single().isError)
+    }
+
+    @Test
+    fun `a disabled tool is still listed and still described`() {
+        // Hiding it would send an agent hunting for a tool it can see documented, and would
+        // make "you turned this off" indistinguishable from "this build does not have it".
+        val disabled = McpProtocol(contextProvider = { context }, isToolEnabled = { false })
+
+        val tools = JsonParser.parseString(
+            disabled.handle("""{"jsonrpc":"2.0","id":11,"method":"tools/list"}""")!!,
+        ).asJsonObject.getAsJsonObject("result").getAsJsonArray("tools")
+
+        assertEquals(ToolRegistry.all().size, tools.size())
+    }
 }

--- a/src/test/kotlin/spock/adb/mcp/McpRequestHistoryTest.kt
+++ b/src/test/kotlin/spock/adb/mcp/McpRequestHistoryTest.kt
@@ -46,6 +46,30 @@ class McpRequestHistoryTest {
     }
 
     @Test
+    fun `prepending puts the loaded history behind what is already there`() {
+        // The persisted history loads on a background thread, so a call can be recorded while
+        // the load is in flight. That call is the one the developer is watching for; replacing
+        // the contents instead of prepending would throw it away.
+        val history = McpRequestHistory()
+        history.record(call(tool = "live"))
+
+        history.prepend(listOf(call(tool = "older"), call(tool = "oldest")))
+
+        assertEquals(listOf("live", "oldest", "older"), history.all().map { it.toolName })
+    }
+
+    @Test
+    fun `prepending honours the current cap`() {
+        // A file written when the cap was higher must not restore more than is allowed now.
+        val history = McpRequestHistory(capacity = McpRequestHistory.MIN_CAPACITY)
+
+        history.prepend((1..60).map { call(tool = "t$it") })
+
+        assertEquals(McpRequestHistory.MIN_CAPACITY, history.size())
+        assertEquals("t60", history.all().first().toolName)
+    }
+
+    @Test
     fun `capacity is clamped to a sane range`() {
         val history = McpRequestHistory()
         history.capacity = 1

--- a/src/test/kotlin/spock/adb/mcp/ToolGateTest.kt
+++ b/src/test/kotlin/spock/adb/mcp/ToolGateTest.kt
@@ -1,0 +1,34 @@
+package spock.adb.mcp
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class ToolGateTest {
+
+    @Test
+    fun `a tool not on the disabled list runs`() {
+        assertTrue(ToolGate.isEnabled("android_list_devices", setOf("android_run_adb_command")))
+    }
+
+    @Test
+    fun `a disabled tool does not`() {
+        assertFalse(ToolGate.isEnabled("android_run_adb_command", setOf("android_run_adb_command")))
+    }
+
+    @Test
+    fun `nothing disabled means everything runs`() {
+        assertTrue(ToolGate.isEnabled("android_run_adb_command", emptySet()))
+    }
+
+    @Test
+    fun `the refusal names the tool, says it did not run, and says where the switch is`() {
+        // All three matter: the model has to tell "you turned this off" from "this failed",
+        // be sure nothing happened, and be able to tell the developer where to change it.
+        val message = ToolGate.refusal("android_push_file")
+
+        assertTrue(message.contains("android_push_file"), message)
+        assertTrue(message.contains("not run"), message)
+        assertTrue(message.contains("Settings"), message)
+    }
+}


### PR DESCRIPTION
Phase 5 of `docs/PLAN-5.0.md` — "Safety and control". Closes both gaps #71 called out in its own description rather than leaving them to be found.

## Per-tool access control

Per-call confirmation was the only boundary, and it **cannot see a composition**. `android_push_file` and `android_pull_file` are each perfectly reasonable and together read any file on the machine; a dialog shown one call at a time has no way to notice that, and a list does not have to.

`Settings → Tools → Spock ADB → Tool Access` lists every registered tool grouped by safety level, with **Enable all** and **Read-only only** for the two decisions worth one click. `ToolGate` is consulted per call in `McpProtocol.toolsCall` and in `RegistryAgentTools`, so both ways in mean the same thing, and the shared registry is never mutated to express it.

Three properties are deliberate:

- **A disabled tool stays in `tools/list` and refuses when called**, naming itself and where the switch is. Hiding it would send an agent hunting for a tool it can see documented, and would make "you turned this off" indistinguishable from "this build does not have it". The in-IDE assistant is the exception — it is handed a fresh list every turn, so offering it a tool certain to refuse would spend a turn and a tool call to learn what the list could have said. The call-site check stays for a tool switched off mid-conversation, which is still in the history the model reasons from.
- **A refusal is audited exactly like a result.** An agent reaching for something it was denied is the entry most worth reviewing; it must not be the one kind of call that leaves no trace. Both call sites were restructured for this — the first cut returned early in `RegistryAgentTools` and would have skipped the audit.
- **The setting stores what is *off*.** An allow-list would silently withhold every tool added by a later update from anyone who had once opened the screen, which reads as the update being broken.

## The activity history now survives a restart

Only destructive calls reached `idea.log`, and the restart is exactly what prompts "what did that agent do to my device".

`McpHistoryStore` appends newline-delimited JSON under the IDE config directory. An append cannot corrupt what is already written, a line truncated by a crash costs one record rather than the file, and a record written by a newer version is skipped rather than fatal. The on-disk shape is a separate `Record` type so `McpCall` stays free to change while old files keep loading. Compaction stages to a neighbour and moves into place, so an interrupted trim cannot lose the history it was tidying.

`McpHistoryWriter` drains the queue on one daemon thread: a burst of calls costs one append, the agent never waits on a disk write, and `shutdown()` flushes so the calls made as the IDE closes are not the ones lost. A failure to persist is logged, never propagated — the call already happened.

Loading **prepends** and runs **off the EDT**. Two defects caught by reading rather than by test: `recentCalls()` was going to parse the file on the EDT where the panel calls it, and a `restore()` that cleared would have discarded any call recorded while the load was in flight.

## Verification

`./gradlew test detekt verifyPlugin` cannot run in this environment — Gradle cannot resolve the Android Studio artifact — so this leans on two things that can:

- **The scratch harness.** `McpProtocol`, `RegistryAgentTools`, `McpHistoryStore`, `McpHistoryWriter`, `McpRequestHistory` and `ProjectResolution` are all free of IntelliJ types and were run there for real, under a stand-in for the platform's `ThreadLeakTracker`. Every case in this PR passes, including the async writer leaving no thread behind.
- **detekt** run over the changed files with the repository's own `detekt-config.yml`.

New coverage: `ToolGateTest`, `McpHistoryStoreTest` (round trip, append-not-replace, cap on load, truncated last line, unknown safety level, compaction, no staging file left behind, missing file, unwritable file, clear), `McpHistoryWriterTest`, `RegistryAgentToolsTest`, plus disabled-tool cases in `McpProtocolTest` and prepend cases in `McpRequestHistoryTest`.

The plan also asked for a regression that no new tool can perform a destructive action unconfirmed. `ToolSafetyTest` already carries it — `no destructive tool can report success without a confirmation` iterates every registered destructive tool, so one added later is covered without being named. Marked as such in the plan rather than duplicated.

`McpServerService` and `SpockAdbConfigurable` need the platform and so were reviewed by reading; CI is their first compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018W7aaYZfisooQqhECaFoQ1

---
_Generated by [Claude Code](https://claude.ai/code/session_018W7aaYZfisooQqhECaFoQ1)_