### PR TITLE
Move the MCP Server tab second, behind Devices

### DIFF
--- a/src/main/kotlin/spock/AdbDrawerViewer.kt
+++ b/src/main/kotlin/spock/AdbDrawerViewer.kt
@@ -41,9 +41,15 @@ class AdbDrawerViewer : ToolWindowFactory {
         }
         viewer.initPlugin(adbController)
 
+        // Devices first because every other tab acts on the device chosen there, then MCP
+        // Server: it is the tab a developer opens to start the server and to see what an agent
+        // has been doing, and it was last, behind three tabs used far less often.
         val contentManager = toolWindow.contentManager
         contentManager.addContent(
             contentManager.factory.createContent(viewer, "Devices", false),
+        )
+        contentManager.addContent(
+            contentManager.factory.createContent(mcpPanel, "MCP Server", false),
         )
         contentManager.addContent(
             contentManager.factory.createContent(logcatPanel, "Logcat", false),
@@ -53,9 +59,6 @@ class AdbDrawerViewer : ToolWindowFactory {
         )
         contentManager.addContent(
             contentManager.factory.createContent(uiInspectorPanel, "UI Inspector", false),
-        )
-        contentManager.addContent(
-            contentManager.factory.createContent(mcpPanel, "MCP Server", false),
         )
     }
 }


### PR DESCRIPTION
Tool window tab order becomes **Devices, MCP Server, Logcat, Commands, UI Inspector**.

MCP Server was last, behind Logcat, Commands and UI Inspector. It is the tab a developer opens to start the server and to see what an agent has been doing to the device — a good deal more often than the three that sat in front of it.

Devices stays first: every other tab acts on the device chosen there, so it is the one tab with a claim to being opened before the others.

## Notes

One `addContent` call moved in `AdbDrawerViewer.kt`; no behaviour beyond the ordering changes, and each panel is still registered with the tool window's disposable exactly as before.

I kept the five plain `addContent` calls rather than folding them into a list-and-loop. The loop reads better, but it depends on Kotlin inferring a common `JComponent` supertype across the five panel types, and `./gradlew` cannot resolve the Android Studio artifact in this environment — so that version could not be compiled to confirm. Not worth the risk for a cosmetic gain.

`docs/MCP.md` names the **MCP Server** tab but not its position, so no documentation change is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018W7aaYZfisooQqhECaFoQ1

---
_Generated by [Claude Code](https://claude.ai/code/session_018W7aaYZfisooQqhECaFoQ1)_