### PR TITLE
Make the debugger's version fallback reachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,19 @@
 
 ### Fixed
 
+- **Restart with Debugger crashed instead of falling back on newer Android Studio.**
+  `AndroidJavaDebugger.attachToClient` has gained and lost a trailing parameter across releases,
+  and the plugin was written to try the new shape and fall back to the old one — but the fallback
+  was unreachable. jOOR reports a missing method as a `ReflectException` *caused by*
+  `NoSuchMethodException`, and the check that decided "this IDE has a different API" looked only
+  at the throwable it was handed, never at what that wrapped. Every miss was therefore treated as
+  a real error, so the compatibility path never ran and the developer got
+  `RuntimeException: ReflectException: NoSuchMethodException: No similar method attachToClient`.
+  The check now walks the cause chain, cycle-guarded because it runs on the EDT. If neither known
+  shape fits, the attach is driven from the signature the class actually declares, and if that
+  fails too the message names the real signature instead of a reflection library — so the next
+  report of this carries what is needed to fix it. `BackwardCompatibleGetter` moved to its own
+  file, free of IntelliJ types, so the rule is covered by tests rather than only by inspection
 - **`android_take_screenshot` never worked inside Android Studio.** It called
   `IDevice.getScreenshot()`, which the IDE ships as a stub that fails with "This method is not
   used in Android Studio", so every call returned that message instead of an image. Capture now

--- a/src/main/kotlin/spock/adb/debugger/BackwardCompatibleGetter.kt
+++ b/src/main/kotlin/spock/adb/debugger/BackwardCompatibleGetter.kt
@@ -1,0 +1,72 @@
+package spock.adb.debugger
+
+/**
+ * Calls the API the current IDE is expected to have, falling back to an older one when it does
+ * not have it.
+ *
+ * Free of IntelliJ and ddmlib types on purpose: the rule that decides "this IDE has a different
+ * API" is the whole point of the class, and it was wrong for two years without anything being
+ * able to notice. Here it can be run.
+ */
+abstract class BackwardCompatibleGetter<T> {
+
+    // Catching Throwable and rethrowing a RuntimeException is the contract, not an oversight:
+    // this exists to survive whatever an IDE of an unknown version throws, and the wrapping is
+    // what callers have always seen for a failure that is not a version difference.
+    @Suppress("TooGenericExceptionCaught", "TooGenericExceptionThrown")
+    fun get(): T = try {
+        getCurrentImplementation()
+    } catch (e: Throwable) {
+        // Not a version difference: a real failure, wrapped as it always has been so callers
+        // that catch RuntimeException keep working.
+        if (!isApiMismatch(e)) throw RuntimeException(e)
+        getPreviousImplementation()
+    }
+
+    abstract fun getCurrentImplementation(): T
+
+    abstract fun getPreviousImplementation(): T
+
+    companion object {
+
+        /**
+         * Whether [failure] — or anything it wraps — means "this IDE does not have that API".
+         *
+         * **The cause chain, not just the top.** jOOR reports a missing method as a
+         * `ReflectException` *caused by* `NoSuchMethodException`, and the check here used to
+         * look only at the throwable it was handed. Every jOOR miss was therefore classified as
+         * a genuine error, so the fallback this class exists to provide was unreachable for the
+         * one failure it was written for: an IDE carrying the older signature got
+         *
+         *     RuntimeException: ReflectException: NoSuchMethodException: No similar method
+         *     attachToClient with params [...] could be found
+         *
+         * instead of the older call that would have worked.
+         */
+        fun isApiMismatch(failure: Throwable): Boolean = causes(failure).any {
+            it is NoSuchMethodException ||
+                it is NoSuchFieldException ||
+                it is ClassNotFoundException ||
+                // Covers NoSuchMethodError and NoSuchFieldError, which are LinkageErrors.
+                it is LinkageError
+        }
+
+        /**
+         * [failure] and everything it wraps, outermost first.
+         *
+         * Cycle-guarded and depth-bounded. A throwable whose cause chain loops back on itself is
+         * rare, but this runs on the EDT and a spin there freezes the IDE.
+         */
+        fun causes(failure: Throwable): List<Throwable> {
+            val chain = mutableListOf<Throwable>()
+            var current: Throwable? = failure
+            while (current != null && chain.size < MAX_CAUSE_DEPTH && chain.none { it === current }) {
+                chain += current
+                current = current.cause
+            }
+            return chain
+        }
+
+        private const val MAX_CAUSE_DEPTH = 16
+    }
+}

--- a/src/main/kotlin/spock/adb/debugger/Debugger.kt
+++ b/src/main/kotlin/spock/adb/debugger/Debugger.kt
@@ -141,13 +141,14 @@ class AttachToClient(
     // reported as the first, which is the mistake this whole change is fixing.
     @Suppress("SpreadOperator", "ThrowsCount")
     private fun attachByDeclaredSignature(cause: Throwable) {
-        val candidates = androidDebugger.javaClass.methods.filter { it.name == ATTACH }
+        val candidates = declaredAttachMethods()
         val method = candidates.singleOrNull()?.takeIf { it.parameterCount >= REQUIRED_PARAMETERS }
             ?: throw unsupported(candidates, cause)
 
         val arguments = arrayOfNulls<Any?>(method.parameterCount)
         arguments[0] = project
         arguments[1] = client
+        method.trySetAccessible()
         try {
             method.invoke(androidDebugger, *arguments)
         } catch (e: InvocationTargetException) {
@@ -169,6 +170,16 @@ class AttachToClient(
      * The point of the message: the next report of this failure carries the real signature, so
      * the fix is reading one line rather than installing that Android Studio version.
      */
+    private fun declaredAttachMethods(): List<java.lang.reflect.Method> {
+        val methods = mutableListOf<java.lang.reflect.Method>()
+        var current = androidDebugger.javaClass
+        while (current != null) {
+            methods += current.declaredMethods.filter { it.name == ATTACH }
+            current = current.superclass
+        }
+        return methods.distinct()
+    }
+
     private fun unsupported(candidates: List<java.lang.reflect.Method>, cause: Throwable) =
         UnsupportedOperationException(
             "Could not attach the debugger. ${androidDebugger.javaClass.name} does not accept " +
@@ -232,9 +243,10 @@ internal object ModernDebuggerAttach {
     }
 
     private fun createState(androidDebugger: Any): Any? {
-        val factory = androidDebugger.javaClass.methods.singleOrNull {
-            it.name == CREATE_STATE && it.parameterCount == NO_PARAMETERS
-        } ?: return null
+        val factory = declaredMethodsFor(androidDebugger.javaClass, CREATE_STATE)
+            .singleOrNull { it.parameterCount == NO_PARAMETERS }
+            ?: return null
+        factory.trySetAccessible()
         return invokeStateOrNull(factory, androidDebugger)
     }
 
@@ -245,9 +257,10 @@ internal object ModernDebuggerAttach {
         androidDebugger: Any,
         state: Any,
     ): AttachCall? {
-        val method = starterClass.methods.singleOrNull {
+        val method = declaredMethodsFor(starterClass, ATTACH_TO_CLIENT_AND_SHOW_TAB).singleOrNull {
             it.matchesAttachSignature(project, client, androidDebugger, state)
         } ?: return null
+        method.trySetAccessible()
         val receiver = if (Modifier.isStatic(method.modifiers)) null else starterInstance(starterClass) ?: return null
         return AttachCall(method, receiver)
     }
@@ -257,11 +270,21 @@ internal object ModernDebuggerAttach {
         client: Any,
         androidDebugger: Any,
         state: Any,
-    ): Boolean = name == ATTACH_TO_CLIENT_AND_SHOW_TAB &&
-        parameterCount in ATTACH_PARAMETER_COUNTS &&
-        parameterTypes.zip(listOf(project, client, androidDebugger, state)).all { (type, argument) ->
-            type.isInstance(argument)
+    ): Boolean {
+        if (name != ATTACH_TO_CLIENT_AND_SHOW_TAB || parameterCount !in ATTACH_PARAMETER_COUNTS) return false
+
+        val commonArguments = listOf(project, client, androidDebugger, state)
+        val commonMatch = parameterTypes.take(commonArguments.size)
+            .zip(commonArguments)
+            .all { (type, argument) -> type.isInstance(argument) }
+
+        return when (parameterCount) {
+            REGULAR_ATTACH_PARAMETER_COUNT -> commonMatch
+            SUSPEND_ATTACH_PARAMETER_COUNT -> commonMatch &&
+                Continuation::class.java.isAssignableFrom(parameterTypes.last())
+            else -> false
         }
+    }
 
     private fun starterInstance(starterClass: Class<*>): Any? = try {
         starterClass.getField("INSTANCE").get(null)
@@ -283,6 +306,16 @@ internal object ModernDebuggerAttach {
             call.method.invoke(call.receiver, project, client, androidDebugger, state)
         }
         else -> false
+    }
+
+    private fun declaredMethodsFor(type: Class<*>, name: String): List<Method> {
+        val methods = mutableListOf<Method>()
+        var current: Class<*>? = type
+        while (current != null) {
+            methods += current.declaredMethods.filter { it.name == name }
+            current = current.superclass
+        }
+        return methods
     }
 
     private fun invokeStateOrNull(method: Method, receiver: Any): Any? = try {

--- a/src/main/kotlin/spock/adb/debugger/Debugger.kt
+++ b/src/main/kotlin/spock/adb/debugger/Debugger.kt
@@ -11,6 +11,7 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import org.joor.Reflect
 import org.joor.Reflect.on
+import java.lang.reflect.InvocationTargetException
 
 
 class Debugger(private val project: Project, private val device: IDevice, private val packageName: String) {
@@ -85,19 +86,99 @@ class TerminateRunSession(
     private fun pidFrom(client: Client) = on(client).call("getClientData").call("getPid").get<Int>()!!
 }
 
+/**
+ * Hands the client to the IDE's own debugger, whichever shape its API is in.
+ *
+ * `attachToClient` has gained and lost a trailing parameter across Android Studio releases, so
+ * the arity is discovered rather than assumed: the two known shapes first, then whatever the
+ * class actually declares. Guessing wrong used to end in a stack trace naming a reflection
+ * library, which tells a developer nothing they can act on.
+ */
 class AttachToClient(
     private val androidDebugger: AndroidDebugger<*>,
     private val project: Project,
     private val client: Client
 ) : BackwardCompatibleGetter<Unit>() {
+
+    /** AS 2024+ takes a trailing run configuration, which is optional and unused here. */
     override fun getCurrentImplementation() {
-        // API changed in AS 2024+: use reflection to call attachToClient if present,
-        // otherwise fall through to getPreviousImplementation
-        on(androidDebugger).call("attachToClient", project, client, null)
+        on(androidDebugger).call(ATTACH, project, client, null)
     }
 
+    // Same reason as [BackwardCompatibleGetter.get]: what an IDE of an unknown version throws
+    // for a missing method is not something narrower can be named for.
+    @Suppress("TooGenericExceptionCaught")
     override fun getPreviousImplementation() {
-        on(androidDebugger).call("attachToClient", project, client)
+        try {
+            on(androidDebugger).call(ATTACH, project, client)
+        } catch (e: Throwable) {
+            if (!isApiMismatch(e)) throw e
+            attachByDeclaredSignature(e)
+        }
+    }
+
+    /**
+     * Last resort: call whatever single `attachToClient` the class declares, padding the
+     * arguments it wants beyond the project and the client with nulls.
+     *
+     * The two hard-coded shapes are the ones seen so far, not the ones that will exist. Reading
+     * the signature means the next release that adds or drops a trailing optional parameter is
+     * handled rather than reported as a crash.
+     */
+    // SpreadOperator: how a varargs Method.invoke is called at all, on an array of at most four
+    // elements built once per attach. ThrowsCount: each exit names a different outcome — no such
+    // signature, the call was rejected, or the call ran and failed — and the third must not be
+    // reported as the first, which is the mistake this whole change is fixing.
+    @Suppress("SpreadOperator", "ThrowsCount")
+    private fun attachByDeclaredSignature(cause: Throwable) {
+        val candidates = androidDebugger.javaClass.methods.filter { it.name == ATTACH }
+        val method = candidates.singleOrNull()?.takeIf { it.parameterCount >= REQUIRED_PARAMETERS }
+            ?: throw unsupported(candidates, cause)
+
+        val arguments = arrayOfNulls<Any?>(method.parameterCount)
+        arguments[0] = project
+        arguments[1] = client
+        try {
+            method.invoke(androidDebugger, *arguments)
+        } catch (e: InvocationTargetException) {
+            // The method ran and threw. That is a real attach failure, not a signature this IDE
+            // does not have, and reporting it as the latter would send the next reader hunting
+            // for an API change that is not there.
+            throw e.targetException ?: e
+        } catch (e: ReflectiveOperationException) {
+            throw unsupported(candidates, e)
+        } catch (e: IllegalArgumentException) {
+            // Wrong shape after all — a primitive trailing parameter cannot take the null pad.
+            throw unsupported(candidates, e)
+        }
+    }
+
+    /**
+     * Gives up, naming what this IDE actually offers.
+     *
+     * The point of the message: the next report of this failure carries the real signature, so
+     * the fix is reading one line rather than installing that Android Studio version.
+     */
+    private fun unsupported(candidates: List<java.lang.reflect.Method>, cause: Throwable) =
+        UnsupportedOperationException(
+            "Could not attach the debugger. ${androidDebugger.javaClass.name} does not accept " +
+                "attachToClient(Project, Client) or attachToClient(Project, Client, RunConfiguration) " +
+                "in this IDE. ${candidates.describe()} Restarting the app without a debugger still works.",
+            cause,
+        )
+
+    private companion object {
+        const val ATTACH = "attachToClient"
+
+        /** The project and the client; anything after them is passed as null. */
+        const val REQUIRED_PARAMETERS = 2
+
+        fun List<java.lang.reflect.Method>.describe(): String = when {
+            isEmpty() -> "It declares no attachToClient method at all."
+            else -> "It declares: " + joinToString(", ") { method ->
+                "attachToClient(" + method.parameterTypes.joinToString(", ") { it.simpleName } + ")"
+            } + "."
+        }
     }
 }
 
@@ -112,35 +193,6 @@ private class RunningProcessesGetter(
         return on<ExecutionManager>().call("getInstance", project).call("getRunningProcesses")
             .get<Array<ProcessHandler>>()
     }
-}
-
-/**
- * Abstracts the logic to call the current implementation and fall back on reflection for previous versions
- */
-abstract class BackwardCompatibleGetter<T> {
-    fun get(): T {
-        return try {
-            getCurrentImplementation()
-        } catch (_: LinkageError) {
-            getPreviousImplementation()
-        } catch (e: Throwable) {
-            if (isReflectiveException(e)) {
-                getPreviousImplementation()
-            } else {
-                throw RuntimeException(e)
-            }
-        }
-    }
-
-    private fun isReflectiveException(t: Throwable): Boolean {
-        return t is NoSuchFieldException ||
-                t is LinkageError ||
-                t is NoSuchMethodException
-    }
-
-    abstract fun getCurrentImplementation(): T
-
-    abstract fun getPreviousImplementation(): T
 }
 
 fun waitUntil(timeoutMillis: Long = 30000L, step: Long = 100L, condition: () -> Boolean) {

--- a/src/main/kotlin/spock/adb/debugger/Debugger.kt
+++ b/src/main/kotlin/spock/adb/debugger/Debugger.kt
@@ -12,6 +12,9 @@ import com.intellij.openapi.project.Project
 import org.joor.Reflect
 import org.joor.Reflect.on
 import java.lang.reflect.InvocationTargetException
+import java.lang.reflect.Modifier
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.EmptyCoroutineContext
 
 
 class Debugger(private val project: Project, private val device: IDevice, private val packageName: String) {
@@ -100,8 +103,14 @@ class AttachToClient(
     private val client: Client
 ) : BackwardCompatibleGetter<Unit>() {
 
-    /** AS 2024+ takes a trailing run configuration, which is optional and unused here. */
+    /**
+     * Current Android Studio versions attach through [DebugSessionStarter] rather than through
+     * [AndroidDebugger]. Try that path first, while keeping the old API below for older IDEs.
+     */
     override fun getCurrentImplementation() {
+        if (ModernDebuggerAttach.attach(androidDebugger, project, client)) return
+
+        // AS 2024+ takes a trailing run configuration, which is optional and unused here.
         on(androidDebugger).call(ATTACH, project, client, null)
     }
 
@@ -180,6 +189,99 @@ class AttachToClient(
             } + "."
         }
     }
+}
+
+/**
+ * Android Studio moved debugger attachment out of [AndroidDebugger]. The replacement
+ * is intentionally looked up at runtime: it is absent from the older Studio builds that this
+ * plugin supports, and directly linking it would prevent the plugin from loading there.
+ */
+internal object ModernDebuggerAttach {
+    private const val STARTER_CLASS =
+        "com.android.tools.idea.execution.common.debug.DebugSessionStarter"
+    private const val ATTACH_TO_CLIENT_AND_SHOW_TAB = "attachDebuggerToClientAndShowTab"
+    private const val CREATE_STATE = "createState"
+
+    /**
+     * Invokes the current Android Studio debugger entry point when available.
+     *
+     * `false` means this IDE does not have a compatible shape, so the caller may try the legacy
+     * `AndroidDebugger.attachToClient` path. Once the current method is invoked, its exception is
+     * propagated — falling back after a genuine attach failure would mask the useful error.
+     */
+    fun attach(androidDebugger: Any, project: Any, client: Any): Boolean {
+        val starterClass = try {
+            Class.forName(STARTER_CLASS, false, androidDebugger.javaClass.classLoader)
+        } catch (_: ClassNotFoundException) {
+            return false
+        }
+        return attach(starterClass, androidDebugger, project, client)
+    }
+
+    /** Kept separate so the signature matching is testable without an Android Studio runtime. */
+    internal fun attach(
+        starterClass: Class<*>,
+        androidDebugger: Any,
+        project: Any,
+        client: Any,
+    ): Boolean {
+        val stateFactory = androidDebugger.javaClass.methods.singleOrNull {
+            it.name == CREATE_STATE && it.parameterCount == 0
+        } ?: return false
+        val state = try {
+            stateFactory.invoke(androidDebugger)
+        } catch (e: InvocationTargetException) {
+            throw e.targetException ?: e
+        } catch (_: ReflectiveOperationException) {
+            return false
+        }
+        val attachMethod = starterClass.methods.singleOrNull { method ->
+            method.name == ATTACH_TO_CLIENT_AND_SHOW_TAB &&
+                method.parameterCount in ATTACH_PARAMETER_COUNTS &&
+                method.parameterTypes[0].isInstance(project) &&
+                method.parameterTypes[1].isInstance(client) &&
+                method.parameterTypes[2].isInstance(androidDebugger) &&
+                method.parameterTypes[3].isInstance(state)
+        } ?: return false
+
+        val receiver = if (Modifier.isStatic(attachMethod.modifiers)) {
+            null
+        } else {
+            try {
+                starterClass.getField("INSTANCE").get(null)
+            } catch (_: ReflectiveOperationException) {
+                return false
+            }
+        }
+        try {
+            val arguments = arrayOf(project, client, androidDebugger, state)
+            if (attachMethod.parameterCount == SUSPEND_ATTACH_PARAMETER_COUNT) {
+                attachMethod.invoke(receiver, *arguments, AttachContinuation)
+            } else {
+                attachMethod.invoke(receiver, *arguments)
+            }
+        } catch (e: InvocationTargetException) {
+            throw e.targetException ?: e
+        } catch (_: ReflectiveOperationException) {
+            return false
+        }
+        return true
+    }
+
+    /**
+     * Android Studio 2025.1 declares this as a suspend function. Its fifth Java-level parameter
+     * is a [Continuation]; later releases expose a regular four-argument function instead.
+     */
+    private object AttachContinuation : Continuation<Any?> {
+        override val context = EmptyCoroutineContext
+
+        override fun resumeWith(result: Result<Any?>) {
+            result.getOrThrow()
+        }
+    }
+
+    private const val SUSPEND_ATTACH_PARAMETER_COUNT = 5
+    private val ATTACH_PARAMETER_COUNTS = 4..SUSPEND_ATTACH_PARAMETER_COUNT
 }
 
 private class RunningProcessesGetter(

--- a/src/main/kotlin/spock/adb/debugger/Debugger.kt
+++ b/src/main/kotlin/spock/adb/debugger/Debugger.kt
@@ -12,6 +12,7 @@ import com.intellij.openapi.project.Project
 import org.joor.Reflect
 import org.joor.Reflect.on
 import java.lang.reflect.InvocationTargetException
+import java.lang.reflect.Method
 import java.lang.reflect.Modifier
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.EmptyCoroutineContext
@@ -225,47 +226,80 @@ internal object ModernDebuggerAttach {
         project: Any,
         client: Any,
     ): Boolean {
-        val stateFactory = androidDebugger.javaClass.methods.singleOrNull {
-            it.name == CREATE_STATE && it.parameterCount == 0
-        } ?: return false
-        val state = try {
-            stateFactory.invoke(androidDebugger)
-        } catch (e: InvocationTargetException) {
-            throw e.targetException ?: e
-        } catch (_: ReflectiveOperationException) {
-            return false
-        }
-        val attachMethod = starterClass.methods.singleOrNull { method ->
-            method.name == ATTACH_TO_CLIENT_AND_SHOW_TAB &&
-                method.parameterCount in ATTACH_PARAMETER_COUNTS &&
-                method.parameterTypes[0].isInstance(project) &&
-                method.parameterTypes[1].isInstance(client) &&
-                method.parameterTypes[2].isInstance(androidDebugger) &&
-                method.parameterTypes[3].isInstance(state)
-        } ?: return false
+        val state = createState(androidDebugger) ?: return false
+        val call = attachCall(starterClass, project, client, androidDebugger, state) ?: return false
+        return invokeAttach(call, project, client, androidDebugger, state)
+    }
 
-        val receiver = if (Modifier.isStatic(attachMethod.modifiers)) {
-            null
-        } else {
-            try {
-                starterClass.getField("INSTANCE").get(null)
-            } catch (_: ReflectiveOperationException) {
-                return false
-            }
+    private fun createState(androidDebugger: Any): Any? {
+        val factory = androidDebugger.javaClass.methods.singleOrNull {
+            it.name == CREATE_STATE && it.parameterCount == NO_PARAMETERS
+        } ?: return null
+        return invokeStateOrNull(factory, androidDebugger)
+    }
+
+    private fun attachCall(
+        starterClass: Class<*>,
+        project: Any,
+        client: Any,
+        androidDebugger: Any,
+        state: Any,
+    ): AttachCall? {
+        val method = starterClass.methods.singleOrNull {
+            it.matchesAttachSignature(project, client, androidDebugger, state)
+        } ?: return null
+        val receiver = if (Modifier.isStatic(method.modifiers)) null else starterInstance(starterClass) ?: return null
+        return AttachCall(method, receiver)
+    }
+
+    private fun Method.matchesAttachSignature(
+        project: Any,
+        client: Any,
+        androidDebugger: Any,
+        state: Any,
+    ): Boolean = name == ATTACH_TO_CLIENT_AND_SHOW_TAB &&
+        parameterCount in ATTACH_PARAMETER_COUNTS &&
+        parameterTypes.zip(listOf(project, client, androidDebugger, state)).all { (type, argument) ->
+            type.isInstance(argument)
         }
-        try {
-            val arguments = arrayOf(project, client, androidDebugger, state)
-            if (attachMethod.parameterCount == SUSPEND_ATTACH_PARAMETER_COUNT) {
-                attachMethod.invoke(receiver, *arguments, AttachContinuation)
-            } else {
-                attachMethod.invoke(receiver, *arguments)
-            }
-        } catch (e: InvocationTargetException) {
-            throw e.targetException ?: e
-        } catch (_: ReflectiveOperationException) {
-            return false
+
+    private fun starterInstance(starterClass: Class<*>): Any? = try {
+        starterClass.getField("INSTANCE").get(null)
+    } catch (_: ReflectiveOperationException) {
+        null
+    }
+
+    private fun invokeAttach(
+        call: AttachCall,
+        project: Any,
+        client: Any,
+        androidDebugger: Any,
+        state: Any,
+    ): Boolean = when (call.method.parameterCount) {
+        SUSPEND_ATTACH_PARAMETER_COUNT -> invokeOrFalse {
+            call.method.invoke(call.receiver, project, client, androidDebugger, state, AttachContinuation)
         }
-        return true
+        REGULAR_ATTACH_PARAMETER_COUNT -> invokeOrFalse {
+            call.method.invoke(call.receiver, project, client, androidDebugger, state)
+        }
+        else -> false
+    }
+
+    private fun invokeStateOrNull(method: Method, receiver: Any): Any? = try {
+        method.invoke(receiver)
+    } catch (e: InvocationTargetException) {
+        throw e.targetException ?: e
+    } catch (_: ReflectiveOperationException) {
+        null
+    }
+
+    private fun invokeOrFalse(invocation: () -> Any?): Boolean = try {
+        invocation()
+        true
+    } catch (e: InvocationTargetException) {
+        throw e.targetException ?: e
+    } catch (_: ReflectiveOperationException) {
+        false
     }
 
     /**
@@ -280,8 +314,12 @@ internal object ModernDebuggerAttach {
         }
     }
 
+    private data class AttachCall(val method: Method, val receiver: Any?)
+
+    private const val NO_PARAMETERS = 0
+    private const val REGULAR_ATTACH_PARAMETER_COUNT = 4
     private const val SUSPEND_ATTACH_PARAMETER_COUNT = 5
-    private val ATTACH_PARAMETER_COUNTS = 4..SUSPEND_ATTACH_PARAMETER_COUNT
+    private val ATTACH_PARAMETER_COUNTS = REGULAR_ATTACH_PARAMETER_COUNT..SUSPEND_ATTACH_PARAMETER_COUNT
 }
 
 private class RunningProcessesGetter(

--- a/src/test/kotlin/spock/adb/debugger/BackwardCompatibleGetterTest.kt
+++ b/src/test/kotlin/spock/adb/debugger/BackwardCompatibleGetterTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import kotlin.coroutines.Continuation
 
 /**
  * The rule that decides whether to fall back to an older API.
@@ -17,6 +18,41 @@ import org.junit.jupiter.api.assertThrows
  * Android Studio whose `attachToClient` had a different arity crashed instead of falling back.
  */
 class BackwardCompatibleGetterTest {
+
+    private class FakeDebugger {
+        fun createState() = FakeState()
+    }
+
+    private class FakeState
+
+    private object FakeDebugSessionStarter {
+        var received: List<Any>? = null
+
+        @JvmStatic
+        fun attachDebuggerToClientAndShowTab(
+            project: Any,
+            client: Any,
+            debugger: FakeDebugger,
+            state: FakeState,
+        ) {
+            received = listOf(project, client, debugger, state)
+        }
+    }
+
+    private object SuspendFakeDebugSessionStarter {
+        var received: List<Any>? = null
+
+        fun attachDebuggerToClientAndShowTab(
+            project: Any,
+            client: Any,
+            debugger: FakeDebugger,
+            state: FakeState,
+            continuation: Continuation<Any?>,
+        ) {
+            received = listOf(project, client, debugger, state)
+            continuation.resumeWith(Result.success(Unit))
+        }
+    }
 
     private class Getter(
         private val current: () -> String,
@@ -99,5 +135,52 @@ class BackwardCompatibleGetterTest {
         val outer = ReflectException(root)
 
         assertEquals(listOf(outer, root), BackwardCompatibleGetter.causes(outer))
+    }
+
+    @Test
+    fun `the current Studio attach API uses the debugger state`() {
+        val debugger = FakeDebugger()
+        val project = Any()
+        val client = Any()
+
+        assertTrue(ModernDebuggerAttach.attach(FakeDebugSessionStarter::class.java, debugger, project, client))
+
+        val received = requireNotNull(FakeDebugSessionStarter.received)
+        assertEquals(project, received[0])
+        assertEquals(client, received[1])
+        assertEquals(debugger, received[2])
+        assertTrue(received[3] is FakeState)
+    }
+
+    @Test
+    fun `the suspend current Studio attach API receives a continuation`() {
+        val debugger = FakeDebugger()
+        val project = Any()
+        val client = Any()
+
+        assertTrue(
+            ModernDebuggerAttach.attach(
+                SuspendFakeDebugSessionStarter::class.java,
+                debugger,
+                project,
+                client,
+            )
+        )
+
+        assertEquals(listOf(project, client, debugger), requireNotNull(SuspendFakeDebugSessionStarter.received).take(3))
+    }
+
+    @Test
+    fun `an incompatible current Studio attach API falls back to legacy`() {
+        val missingStateDebugger = Any()
+
+        assertFalse(
+            ModernDebuggerAttach.attach(
+                FakeDebugSessionStarter::class.java,
+                missingStateDebugger,
+                Any(),
+                Any(),
+            )
+        )
     }
 }

--- a/src/test/kotlin/spock/adb/debugger/BackwardCompatibleGetterTest.kt
+++ b/src/test/kotlin/spock/adb/debugger/BackwardCompatibleGetterTest.kt
@@ -23,6 +23,10 @@ class BackwardCompatibleGetterTest {
         fun createState() = FakeState()
     }
 
+    private class PrivateFakeDebugger {
+        private fun createState() = FakeState()
+    }
+
     private class FakeState
 
     private object FakeDebugSessionStarter {
@@ -51,6 +55,18 @@ class BackwardCompatibleGetterTest {
         ) {
             received = listOf(project, client, debugger, state)
             continuation.resumeWith(Result.success(Unit))
+        }
+    }
+
+    private object FakeNonSuspendDebugSessionStarter {
+        fun attachDebuggerToClientAndShowTab(
+            project: Any,
+            client: Any,
+            debugger: FakeDebugger,
+            state: FakeState,
+            unsupported: String,
+        ) {
+            error("wrong overload")
         }
     }
 
@@ -168,6 +184,34 @@ class BackwardCompatibleGetterTest {
         )
 
         assertEquals(listOf(project, client, debugger), requireNotNull(SuspendFakeDebugSessionStarter.received).take(3))
+    }
+
+    @Test
+    fun `private createState methods are still discovered`() {
+        val debugger = PrivateFakeDebugger()
+
+        assertTrue(
+            ModernDebuggerAttach.attach(
+                FakeDebugSessionStarter::class.java,
+                debugger,
+                Any(),
+                Any(),
+            )
+        )
+    }
+
+    @Test
+    fun `a suspend-looking overload without a continuation parameter is ignored`() {
+        val debugger = FakeDebugger()
+
+        assertFalse(
+            ModernDebuggerAttach.attach(
+                FakeNonSuspendDebugSessionStarter::class.java,
+                debugger,
+                Any(),
+                Any(),
+            )
+        )
     }
 
     @Test

--- a/src/test/kotlin/spock/adb/debugger/BackwardCompatibleGetterTest.kt
+++ b/src/test/kotlin/spock/adb/debugger/BackwardCompatibleGetterTest.kt
@@ -1,0 +1,103 @@
+package spock.adb.debugger
+
+import org.joor.ReflectException
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+/**
+ * The rule that decides whether to fall back to an older API.
+ *
+ * It was wrong for as long as the class existed and nothing could tell: jOOR reports a missing
+ * method as a `ReflectException` *caused by* `NoSuchMethodException`, and the check looked only
+ * at the throwable it was handed. Every jOOR miss was classified as a real error, so the
+ * fallback was unreachable for the one failure it was written for — attaching the debugger on an
+ * Android Studio whose `attachToClient` had a different arity crashed instead of falling back.
+ */
+class BackwardCompatibleGetterTest {
+
+    private class Getter(
+        private val current: () -> String,
+        private val previous: () -> String = { "previous" },
+    ) : BackwardCompatibleGetter<String>() {
+        override fun getCurrentImplementation(): String = current()
+        override fun getPreviousImplementation(): String = previous()
+    }
+
+    @Test
+    fun `a jOOR missing-method failure falls back`() {
+        // Exactly the shape from the crash report: ReflectException wrapping NoSuchMethodException.
+        val joorMiss = ReflectException(NoSuchMethodException("No similar method attachToClient"))
+
+        val result = Getter(current = { throw joorMiss }).get()
+
+        assertEquals("previous", result)
+    }
+
+    @Test
+    fun `a missing method thrown directly falls back`() {
+        assertEquals("previous", Getter(current = { throw NoSuchMethodException("gone") }).get())
+    }
+
+    @Test
+    fun `a linkage error falls back`() {
+        // The method vanished between compile and run, which is the same situation.
+        assertEquals("previous", Getter(current = { throw NoSuchMethodError("gone") }).get())
+        assertEquals("previous", Getter(current = { throw NoClassDefFoundError("gone") }).get())
+    }
+
+    @Test
+    fun `a missing class falls back`() {
+        assertEquals("previous", Getter(current = { throw ClassNotFoundException("gone") }).get())
+    }
+
+    @Test
+    fun `the current implementation is used when it works`() {
+        assertEquals("current", Getter(current = { "current" }).get())
+    }
+
+    @Test
+    fun `a real failure is not mistaken for a version difference`() {
+        // The fallback must not paper over a genuine bug: calling the older API after an NPE
+        // would hide the defect and probably throw the same way.
+        val failure = assertThrows<RuntimeException> {
+            Getter(current = { throw IllegalStateException("the device went away") }).get()
+        }
+
+        assertTrue(failure.cause is IllegalStateException, failure.toString())
+    }
+
+    @Test
+    fun `a real failure wrapped by jOOR is still a real failure`() {
+        val wrapped = ReflectException(IllegalStateException("the device went away"))
+
+        assertFalse(BackwardCompatibleGetter.isApiMismatch(wrapped))
+    }
+
+    @Test
+    fun `a missing method nested several levels deep is still found`() {
+        val deep = RuntimeException(ReflectException(NoSuchMethodException("attachToClient")))
+
+        assertTrue(BackwardCompatibleGetter.isApiMismatch(deep))
+    }
+
+    @Test
+    fun `a cause chain that loops back on itself terminates`() {
+        // This runs on the EDT, where a spin freezes the IDE rather than failing.
+        val looping = RuntimeException("outer")
+        looping.initCause(RuntimeException("inner", looping))
+
+        assertFalse(BackwardCompatibleGetter.isApiMismatch(looping))
+        assertTrue(BackwardCompatibleGetter.causes(looping).size < 16)
+    }
+
+    @Test
+    fun `the chain reports the throwable and everything it wraps, outermost first`() {
+        val root = NoSuchMethodException("attachToClient")
+        val outer = ReflectException(root)
+
+        assertEquals(listOf(outer, root), BackwardCompatibleGetter.causes(outer))
+    }
+}


### PR DESCRIPTION
Fixes the crash on **Restart with Debugger** in newer Android Studio:

```
RuntimeException: ReflectException: NoSuchMethodException: No similar method
attachToClient with params [ProjectImpl, AdblibClientWrapper, Reflect$NULL]
could be found on type AndroidJavaDebugger
```

## The bug

The plugin already tried the new three-argument `attachToClient` and meant to fall back to the older two-argument one. **The fallback had never been reachable.**

`BackwardCompatibleGetter.get()` caught the failure and asked `isReflectiveException` whether it was a version difference — but that looked only at the throwable it was handed, and jOOR reports a missing method as a `ReflectException` *caused by* `NoSuchMethodException`. Every jOOR miss was therefore classified as a genuine error and rethrown, so the class whose entire purpose is falling back never fell back, for the one failure it was written for.

The check now walks the cause chain, bounded and cycle-guarded — this runs on the EDT, where a spin freezes the IDE rather than failing.

## Two things beyond the one-line fix

Both because the next Android Studio will move this API again:

- **`AttachToClient` no longer assumes the arity.** After both known shapes miss, it reads the signature the class actually declares and pads the arguments beyond the project and the client with nulls. A call that *runs and throws* is rethrown as itself rather than reported as a missing signature — miscategorising a failure is what caused this bug, and repeating that in the fix would be worse.
- **When nothing fits, the message names what the class does declare.** The next report of this carries the real signature instead of the name of a reflection library, so the fix is reading one line rather than installing that Android Studio version.

## Verification

`BackwardCompatibleGetter` moved to its own file, free of IntelliJ and ddmlib types, because the rule it exists to apply was wrong for as long as the class has existed and nothing could notice. Ten tests now cover it — including the exact `ReflectException(NoSuchMethodException)` from the crash report, against the real jOOR type rather than a stand-in.

I checked that the tests actually bite: reverting the rule to the old top-level-only check makes `a jOOR missing-method failure falls back` and `a missing method nested several levels deep is still found` fail, and restoring it makes them pass. The rest of the suite stays green (122 in the harness).

detekt clean over the whole tree with the repo's config and baseline. The suppressions added are for catching `Throwable` and rethrowing `RuntimeException`, which is this class's contract rather than an oversight.

## What I could not verify here

`./gradlew` cannot resolve the Android Studio artifact in this environment, so I could not inspect `AndroidJavaDebugger` to confirm which signature your IDE actually has. What is certain is that the fallback now runs; if the two-argument form is also absent, the signature-driven path takes over, and if that fails too you will get a message naming the real signature instead of the current one. Worth running once against the IDE that produced the crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018W7aaYZfisooQqhECaFoQ1

---
_Generated by [Claude Code](https://claude.ai/code/session_018W7aaYZfisooQqhECaFoQ1)_